### PR TITLE
cand: v-effects — 43712225f

### DIFF
--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -62204,6 +62204,44 @@ mod stage1 {
     }
 
     #[test]
+    fn a_single_handler_dispatches_a_resuming_and_an_abortive_arm_by_op() {
+        // One handler for one effect `E` with TWO ops of DIFFERENT arm kinds — `get` resumes, `bail`
+        // abandons — so the fold must route each performed op to its own arm kind within a SINGLE handler
+        // context (distinct from the nested three-handler abort, where each kind is its own handler). Body
+        // `(+ (E.get) (E.bail 7))` seeded 0: `E.get` resumes 5, then `E.bail 7` — non-resuming — ABANDONS
+        // the pending `(+ 5 …)` and the arm value 7 becomes the whole handle's value (NOT 5+7).
+        let mixed_src = "(do (effect E (op get (-> Unit Int64)) (op bail (-> Int64 Int64))) \
+                   (def (main) (handle E 0 ((get (u) s (resume 5 s)) (bail (b) s b)) \
+                   (+ (E.get) (E.bail 7)))) (export main))";
+        assert_eq!(
+            run_returns::<i64>(
+                &compile_component(&crate::codec::encode(&parse(mixed_src))).expect(
+                    "a single mixed resuming+abortive handler dispatches each op to its arm kind"
+                ),
+                "main"
+            ),
+            7,
+            "the abortive bail must abandon the pending (+ 5 ..) even though get resumed in the same handler"
+        );
+        // Control: the same two-op handler but the body performs ONLY the resuming op — the abortive arm is
+        // present but never reached, so nothing abandons and the handle folds to the resumed value.
+        // `(+ (E.get) 100)` seeded 0: get resumes 5, `(+ 5 100)` = 105.
+        let only_resume_src = "(do (effect E (op get (-> Unit Int64)) (op bail (-> Int64 Int64))) \
+                   (def (main) (handle E 0 ((get (u) s (resume 5 s)) (bail (b) s b)) \
+                   (+ (E.get) 100))) (export main))";
+        assert_eq!(
+            run_returns::<i64>(
+                &compile_component(&crate::codec::encode(&parse(only_resume_src))).expect(
+                    "a mixed handler folds normally when its abortive op is never performed"
+                ),
+                "main"
+            ),
+            105,
+            "the mere presence of an abortive arm must not perturb the resuming path"
+        );
+    }
+
+    #[test]
     fn a_cross_function_perform_is_discharged_by_the_callers_handler() {
         // E1c-3 (the inline trigger): a perform in a CALLEE `gen` is discharged by the handler enclosing
         // `gen`'s CALL — `(handle … (gen))`. The fold inlines `gen` into the handled region (β-reduces

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -3027,6 +3027,8 @@ pass	a signed pattern segment reads a two's-complement integer as negative
 pass	a signed segment reads the sign-bit-only byte as the minimum, not its magnitude
 pass	a signed-byte entrypoint returns its runtime argument
 pass	a single Map.swap reports the OLD prior value WHILE the new map holds the NEW value (combined atomicity)
+pass	a single handler with both a resuming and an abortive arm dispatches each op to its own arm kind
+pass	a single mixed handler uses only its resuming arm when the abortive op is never performed
 pass	a single-form body admits a sequence by holding a do block
 pass	a single-scalar String.slice equals the String.at of the same index (the two scalar-addressing paths agree)
 pass	a single-task DES scheduler sleeps a task and fast-forwards the clock to its wake instant

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -3000,6 +3000,8 @@ pass	a signed pattern segment reads a two's-complement integer as negative
 pass	a signed segment reads the sign-bit-only byte as the minimum, not its magnitude
 pass	a signed-byte entrypoint returns its runtime argument
 pass	a single Map.swap reports the OLD prior value WHILE the new map holds the NEW value (combined atomicity)
+pass	a single handler with both a resuming and an abortive arm dispatches each op to its own arm kind
+pass	a single mixed handler uses only its resuming arm when the abortive op is never performed
 pass	a single-form body admits a sequence by holding a do block
 pass	a single-scalar String.slice equals the String.at of the same index (the two scalar-addressing paths agree)
 pass	a single-task DES scheduler sleeps a task and fast-forwards the clock to its wake instant

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -2948,6 +2948,8 @@ pass	a signed pattern segment reads a two's-complement integer as negative
 pass	a signed segment reads the sign-bit-only byte as the minimum, not its magnitude
 pass	a signed-byte entrypoint returns its runtime argument
 pass	a single Map.swap reports the OLD prior value WHILE the new map holds the NEW value (combined atomicity)
+pass	a single handler with both a resuming and an abortive arm dispatches each op to its own arm kind
+pass	a single mixed handler uses only its resuming arm when the abortive op is never performed
 pass	a single-form body admits a sequence by holding a do block
 pass	a single-scalar String.slice equals the String.at of the same index (the two scalar-addressing paths agree)
 pass	a single-task DES scheduler sleeps a task and fast-forwards the clock to its wake instant

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -1139,6 +1139,32 @@
                     (+ (A.a) (+ (B.b) (Bail.bail 99))))))) (export main)))
   (output (: 99 Int64)))
 
+(case "a single handler with both a resuming and an abortive arm dispatches each op to its own arm kind"
+  (doc    "One handler for ONE effect `E` declaring TWO operations whose arms are DIFFERENT KINDS — `get`
+           resumes, `bail` abandons — so the fold must dispatch each performed op to its own arm kind within
+           a single handler context (distinct from the nested three-separate-handler abort above, where each
+           kind is its own handler). Body `(+ (E.get) (E.bail 7))` seeded 0: `E.get` resumes with 5, then
+           `E.bail 7` — a NON-resuming arm — ABANDONS the pending `(+ 5 …)` and yields the arm value 7 as the
+           whole handle's value (NOT 5+7). Pins that a mixed-arm handler routes the resuming op through the
+           resume fold AND the abortive op through the non-local exit, in one handler.")
+  (input  (do
+            (effect E (op get (-> Unit Int64)) (op bail (-> Int64 Int64)))
+            (def (main)
+              (handle E 0 ((get (u) s (resume 5 s)) (bail (b) s b)) (+ (E.get) (E.bail 7)))) (export main)))
+  (output (: 7 Int64)))
+
+(case "a single mixed handler uses only its resuming arm when the abortive op is never performed"
+  (doc    "The control companion of the mixed-arm case above: the SAME two-op handler (`get` resuming,
+           `bail` abortive) but the body performs ONLY the resuming op — the abortive arm is present but
+           never reached, so nothing abandons. Body `(+ (E.get) 100)` seeded 0: `E.get` resumes with 5,
+           `(+ 5 100)` = 105. Pins that the mere PRESENCE of an abortive arm does not perturb the resuming
+           path — the handle folds to the ordinary resumed value when the abortive op is not performed.")
+  (input  (do
+            (effect E (op get (-> Unit Int64)) (op bail (-> Int64 Int64)))
+            (def (main)
+              (handle E 0 ((get (u) s (resume 5 s)) (bail (b) s b)) (+ (E.get) 100))) (export main)))
+  (output (: 105 Int64)))
+
 (case "when two abortive performs sit on one spine the FIRST (leftmost) abort wins"
   (doc    "Refines the abortive class for MULTIPLE performs. Operands evaluate LEFT-TO-RIGHT, and an
            abortive perform ABANDONS the rest of the computation, so on `(+ (Bail.bail 7) (Bail.bail 9))` the


### PR DESCRIPTION
Automated CI-gated candidate for v-effects MR 021157 (ref 43712225f).