### PR TITLE
cand: v-runtime — 509defa41

### DIFF
--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -151,6 +151,7 @@ pass	WAVE reorder alternates <= and >= by index parity through a carried-element
 pass	a 1000-step UPSERT fold builds a 7-bucket histogram — persistent-map churn under real load
 pass	a 1100-element prepend-built runtime list reads every index through a multi-level RRB front-spine
 pass	a 16-field MIXED-type record projects across the layout and survives a mid-layout Record.without
+pass	a 200-element runtime Set of BYTES resolves every member through a multi-level CHAMP over the blessed byte order
 pass	a 200-element runtime Set resolves every member through a multi-level CHAMP trie and rejects non-members
 pass	a 2x2 MATRIX POWER by squaring recovers fibonacci and satisfies the determinant identity
 pass	a 2x2 matrix MULTIPLY composes row extraction, column extraction, and a zipped dot product

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -35,6 +35,7 @@ pass	@requires over a MAP argument walks the CHAMP at body entry
 pass	@requires stacked OVER @ensures: the precondition is still enforced when an @ensures wrapper sits between it and the def
 pass	ACKERMANN evaluates — a recursive call in the ARGUMENT of a recursive call (not primitive-recursive)
 pass	a 1100-element prepend-built runtime list reads every index through a multi-level RRB front-spine
+pass	a 200-element runtime Set of BYTES resolves every member through a multi-level CHAMP over the blessed byte order
 pass	a 200-element runtime Set resolves every member through a multi-level CHAMP trie and rejects non-members
 pass	a Map keyed by a (Bytes, Int64) tuple is looked up by content through the compound key descent
 pass	a Set of (Int64, Bytes) tuples orders by int then Bytes lexicographically and dedups by content

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -35,6 +35,7 @@ pass	@requires over a MAP argument walks the CHAMP at body entry
 pass	@requires stacked OVER @ensures: the precondition is still enforced when an @ensures wrapper sits between it and the def
 pass	ACKERMANN evaluates — a recursive call in the ARGUMENT of a recursive call (not primitive-recursive)
 pass	a 1100-element prepend-built runtime list reads every index through a multi-level RRB front-spine
+pass	a 200-element runtime Set of BYTES resolves every member through a multi-level CHAMP over the blessed byte order
 pass	a 200-element runtime Set resolves every member through a multi-level CHAMP trie and rejects non-members
 pass	a Map keyed by a (Bytes, Int64) tuple is looked up by content through the compound key descent
 pass	a Set of (Int64, Bytes) tuples orders by int then Bytes lexicographically and dedups by content

--- a/spec/semantics/05-compound-types.sexp
+++ b/spec/semantics/05-compound-types.sexp
@@ -1941,6 +1941,35 @@
             (export main)))
   (call   main (: 200 Int64)) (output (: 200 Int64)))
 
+(case "a 200-element runtime Set of BYTES resolves every member through a multi-level CHAMP over the blessed byte order"
+  (doc    "Combines the blessed Bytes total order with a SCALE CHAMP set — a gap the small-Bytes-set cases and
+           the Int64 large-set case each miss individually. `build` inserts, for i in 0..n, a distinct 2-byte
+           Bytes value `[i/256, i%256]` into a `Set Bytes`. At n=200 the CHAMP grows multi-level, and its
+           hashing/eq/canonical order run over the BYTES leaves (the blessed unsigned-lex order the champ
+           descent uses). `present` re-derives each `[i/256, i%256]` and checks membership (+1 each); `absent`
+           checks 50 genuinely-absent keys `[1, j]` (high byte 1 — never inserted, since inserts have high byte
+           0 for i<256) scoring a 1000 penalty if wrongly found. checksum = 200 (all present, none absent
+           found). A Bytes key lost/misrouted in the multi-level CHAMP, or an unsigned-order mismatch between
+           insert and probe, breaks it. The Bytes-element companion of the Int64 large-set + small-Bytes-set
+           cases. Empty-set seed is `(Set.of (list))` (no `Set.empty`).")
+  (input  (do
+            (def (bk (: i Int64)) (Bytes.of (list (UInt8.wrap (/ i 256)) (UInt8.wrap (% i 256)))))
+            (def (build (: i Int64) (: n Int64) (: s (Set Bytes)))
+              (if (< i n) (build (+ i 1) n (Set.insert s (bk i))) s))
+            (def (present (: i Int64) (: n Int64) (: s (Set Bytes)) (: acc Int64))
+              (if (< i n)
+                (present (+ i 1) n s (+ acc (if (Set.contains s (bk i)) 1 0)))
+                acc))
+            (def (absent (: j Int64) (: hi Int64) (: s (Set Bytes)) (: acc Int64))
+              (if (< j hi)
+                (absent (+ j 1) hi s (+ acc (if (Set.contains s (Bytes.of (list (UInt8.wrap 1) (UInt8.wrap (% j 256))))) 1000 0)))
+                acc))
+            (def (main (: n Int64))
+              (let ((s (build 0 n (Set.of (list)))))
+                (- (present 0 n s 0) (absent 0 50 s 0))))
+            (export main)))
+  (call   main (: 200 Int64)) (output (: 200 Int64)))
+
 (case "an overwrite-churn runtime map holds one entry with the last value winning"
   (doc    "`churn` inserts the SAME key 7 fifty times with values n..1 (the last insert is value 1). The
            map must hold exactly ONE entry (an overwrite replaces, never accumulates — a length that grew


### PR DESCRIPTION
Automated CI-gated candidate for v-runtime MR 000000021189-1441649-merge-request.json (ref 509defa41).