### PR TITLE
cand: v-compiler-ml — 614017827

### DIFF
--- a/implementation/compiler-ml/src/emit-rec-db.cdz
+++ b/implementation/compiler-ml/src/emit-rec-db.cdz
@@ -174,6 +174,23 @@ def er-nonrecursive-not-in-defenv-declines-ccall() =
    else trap("arith emits under empty def-env"))
 
 @test
+def er-recursive-types-puts-main-last() =
+  // The funcidx/typeidx ORDERING invariant: recursive-types appends main's functype (nullary, functype-bytes(0))
+  // LAST — defs take typeidx 0..k-1, main = k — so export-section-idx(k) names main. A peer reordering the
+  // push (main first) would silently export the WRONG function; this pins main-is-last structurally. For a
+  // 1-def entry (fac, 1 param): types = [functype-bytes(1), functype-bytes(0)] — index 0 is the 1-param def
+  // (5 bytes: 60 01 7e 01 7e), the LAST is nullary main (4 bytes: 60 00 01 7e). Discriminate by Bytes.len.
+  (let entries = List.push(([] : List(Tuple(Int64, Tuple(List(Int64), Core)))), (900, (List.push([], 7), Core.CNum(1, true, 64)))) in
+   (let types = recursive-types(entries) in
+    (match List.at(types, List.len(types) - 1) with        // the LAST functype must be main's (nullary, 4 bytes)
+      | Option.Some(lastT) => (if (Bytes.len(lastT) == 4) then
+          (match List.at(types, 0) with                    // index 0 must be the 1-param def's (5 bytes), NOT main's
+            | Option.Some(firstT) => (if (Bytes.len(firstT) == 5) then unit else trap("typeidx 0 is the 1-param def functype (5 bytes), not main"))
+            | Option.None(_) => trap("recursive-types has a first entry"))
+        else trap("LAST functype is nullary main (functype-bytes(0), 4 bytes)"))
+      | Option.None(_) => trap("recursive-types is non-empty"))))
+
+@test
 def er-all-defs-emittable-gates-out-of-subset-body() =
   // The def-body emit gate: all-defs-emittable is TRUE iff EVERY entry's body is in the emit subset. A def
   // whose body is an out-of-subset form (CMatchSum — eval-only, not emit-subset) must make it FALSE so


### PR DESCRIPTION
Automated CI-gated candidate for v-compiler-ml MR 000000021366-4128099-merge-request.json (ref 6140178272cce234e1b1a84320c55b64a2e63592).