### PR TITLE
cand: v-diagnostics — d5973785e

### DIFF
--- a/implementation/seed/crates/rcdzc/src/eval.rs
+++ b/implementation/seed/crates/rcdzc/src/eval.rs
@@ -3493,6 +3493,41 @@ pub fn int_width_fault(db: &mut Db, id: StructId) -> Option<IntWidthFault> {
     }
 }
 
+/// If the type expression at `id` is a WIDTH constructor `(Int W)`/`(UInt W)`/`(Float W)` whose single
+/// width argument `W` is an UNBOUND NAME (resolves to `Poison(Unbound)`), return that argument's node.
+/// This is the width-position analogue of an unbound TYPE name: `(: a (Int hello))` is the newcomer reflex
+/// of putting a name where a width literal belongs, but unlike `(List hello)` (a type position, caught by
+/// the nested-type-var walk) the WIDTH position is not a type, so it slips past both that walk and
+/// `int_width_fault` — `read_width` reads an unbound name as `WidthRead::NotConst` (indistinguishable from
+/// a legitimately BOUND width variable like `(Int a)` in a generic), and the fault classifier returns
+/// `None`, so the annotation silently reduces to the sentinel `Int0` and `cdz check` exits 0. Here we
+/// separate the two: only a `Poison(Unbound)` arg is a fault; a `Resolved::Param`/`Ref` (a bound width
+/// var) is a VALID generic width and returns `None`. Keyed on the ctor prim; a compound `(Int 64)` literal
+/// width or a valid type never matches. Consumed by the annotation checks to surface a width-specific
+/// CDZ0101 instead of nothing.
+pub fn unbound_width_arg(db: &mut Db, id: StructId) -> Option<(StructId, &'static str)> {
+    let Resolved::Apply { head, args } = resolved_of(db, id) else {
+        return None;
+    };
+    // The ctor-appropriate sized-type EXAMPLE for the diagnostic — a `Float` width names `Float64`, not the
+    // misleading `Int64`.
+    let example = match meta_apply_of(db, head) {
+        Some(Prim::IntCtor) => "Int64",
+        Some(Prim::UIntCtor) => "UInt64",
+        Some(Prim::FloatCtor) => "Float64",
+        _ => return None,
+    };
+    if args.len() != 1 {
+        return None;
+    }
+    match resolved_of(db, args[0]) {
+        Resolved::Poison(reject) if reject.code == Some(crate::diag::Code::Unbound) => {
+            Some((args[0], example))
+        }
+        _ => None,
+    }
+}
+
 /// If the type expression at `id` is a `(Float W)` with a CONCRETE width OUTSIDE the admitted IEEE set
 /// `{32, 64}` — a `(Float 8)` / `(Float 16)` / `(Float 128)`, or a non-natural width `(Float -8)` /
 /// `(Float true)` — return `true`. The float analogue of `int_width_fault`, but the admitted set is a

--- a/implementation/seed/crates/rcdzc/src/infer.rs
+++ b/implementation/seed/crates/rcdzc/src/infer.rs
@@ -1016,6 +1016,43 @@ fn nested_ill_formed_float_width(db: &mut Db, ty_expr: StructId) -> Option<Struc
 pub(crate) const FLOAT_WIDTH_MESSAGE: &str =
     "a floating-point width must be one of the admitted IEEE widths (32 or 64)";
 
+/// The UNBOUND-WIDTH companion of [`nested_ill_formed_int_width`]/[`nested_ill_formed_float_width`]: the
+/// position of a width constructor `(Int W)`/`(UInt W)`/`(Float W)` whose width argument `W` is an UNBOUND
+/// NAME (`(: a (Int hello))`), at `ty_expr` OR nested in one of its type-argument positions (`(List (Int
+/// hello))`). `None` when no width position holds an unbound name. An unbound name in a WIDTH slot is not a
+/// type (so the nested-type-var walk skips it) and reads as a non-constant width (so `int_width_fault`
+/// waves it through as if it were a bound width variable), which let it slip past `cdz check` silently —
+/// this closes that gap. Same skip-first descent as the sibling width walkers (child 0 of a `(head arg…)`
+/// form is the ctor, never a nested type). A BOUND width variable (`(Int a)` with `a` a `Type`/width param)
+/// is valid and returns `None` — `eval::unbound_width_arg` distinguishes the two by the arg's resolution.
+fn nested_unbound_width(db: &mut Db, ty_expr: StructId) -> Option<(StructId, &'static str)> {
+    if let Some(found) = crate::eval::unbound_width_arg(db, ty_expr) {
+        return Some(found);
+    }
+    let crate::ast::Struct::List(children) = db.ast.get(ty_expr) else {
+        return None;
+    };
+    for &child in children.clone().iter().skip(1) {
+        if let Some(found) = nested_unbound_width(db, child) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// The CDZ0101 message for an UNBOUND NAME in a width position — `(: a (Int hello))` / `(Float hi)`. Names
+/// the specific mistake (a width is a compile-time integer literal, not a name) and the repair: write the
+/// literal, or the sized type directly. `example` is a ctor-appropriate sized type (`Int64`/`UInt64`/
+/// `Float64`), so a `Float` width names a float example rather than the misleading `Int64`. The
+/// width-position analogue of the lowercase-type-var guidance, but a width is not a type, so the fix is a
+/// literal like `64`, not "leave the parameter unannotated".
+pub(crate) fn unbound_width_message(name: &str, example: &str) -> String {
+    format!(
+        "unbound name `{name}` — a width must be a compile-time integer literal like `64`, not a name \
+         (write the width literal, or the sized type `{example}` directly)"
+    )
+}
+
 /// The CDZ0302 REPAIR for an ill-formed FLOAT width at `pos` — the actionable half of
 /// [`FLOAT_WIDTH_MESSAGE`] (`spec/capabilities/diagnostics.md` §A Diagnostic Carries A Route To A Fix),
 /// the float twin of [`ill_formed_int_width_fix`]. A CONCRETE natural width outside the admitted IEEE set
@@ -2419,6 +2456,17 @@ pub fn param_annotation_faults(db: &mut Db, param: StructId, out: &mut Vec<Rejec
             reject = reject.with_fix(fix);
         }
         out.push(reject);
+        return;
+    }
+    // An UNBOUND NAME in a width position — `(: a (Int hello))`, or nested `(: xs (List (Int hello)))`. A
+    // width is not a type (so the nested-type-var walk skips it) and reads as a non-constant width (so the
+    // ill-formed-width check waves it through as if it were a bound width variable), so it slipped past
+    // `cdz check` silently. Surface the width-specific CDZ0101 at the offending arg. A BOUND width variable
+    // (`(Int a)` with `a` a `Type` param) is valid and does not match.
+    if let Some((pos, example)) = nested_unbound_width(db, ty_expr) {
+        trace!(target: "rcdzc::infer", param = param.0, "fault: unbound name in a width position (CDZ0101)");
+        let name = db.ast.as_name(pos).unwrap_or("?").to_string();
+        out.push(Reject::coded(Code::Unbound, unbound_width_message(&name, example)).at(pos));
         return;
     }
     // A TYPE CONSTRUCTOR applied to the WRONG number of arguments — a prelude `(List Int64 Int64)` (fails
@@ -13434,6 +13482,17 @@ fn collect_node(db: &mut Db, id: StructId, out: &mut Vec<Reject>) {
                         reject = reject.with_fix(fix);
                     }
                     out.push(reject);
+                }
+                // An UNBOUND NAME in a width position — `(: v (Int hello))` — the value-annotation twin of
+                // the parameter-path check: a width is not a type, so the nested-type-var walk skips it, and
+                // it reads as a non-constant width, so it slipped past `cdz check`. A bound width variable is
+                // valid and does not match.
+                if let Some((pos, example)) = nested_unbound_width(db, ty_expr) {
+                    trace!(target: "rcdzc::infer", node = id.0, "fault: unbound name in a width position (CDZ0101)");
+                    let name = db.ast.as_name(pos).unwrap_or("?").to_string();
+                    out.push(
+                        Reject::coded(Code::Unbound, unbound_width_message(&name, example)).at(pos),
+                    );
                 }
                 // A bare integer LITERAL annotated with an integer type is a GROUNDING, not a
                 // unification: the literal has no intrinsic signedness/width to conflict, so the

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -57996,6 +57996,68 @@ mod stage1 {
         }
     }
 
+    #[test]
+    fn an_unbound_name_in_a_width_position_names_it_as_a_width_not_silently_accepted() {
+        // The WIDTH argument of `(Int W)`/`(UInt W)`/`(Float W)` must be a compile-time integer literal. An
+        // UNBOUND NAME there — `(: a (Int hello))` — is not a type (so the nested-type-var walk skips it) and
+        // reads as a non-constant width (so the ill-formed-width check waves it through as if it were a BOUND
+        // width variable), which let it slip past `cdz check` SILENTLY (the annotation reduced to sentinel
+        // `Int0`). Now it surfaces a width-specific CDZ0101 at the offending arg — the width analogue of an
+        // unbound type name. A BOUND width variable stays valid.
+        let diags = |src: &str| crate::diagnostics(&mut crate::db::Db::load(parse(src)));
+        for (name, ctor, example) in [
+            ("hello", "Int", "Int64"),
+            ("bad", "UInt", "UInt64"),
+            ("hi", "Float", "Float64"),
+        ] {
+            let src = format!("(module m (def (f (: a ({ctor} {name}))) a) (export f))");
+            let ds = diags(&src);
+            let d = ds
+                .iter()
+                .find(|d| d.code.as_deref() == Some("CDZ0101"))
+                .unwrap_or_else(|| {
+                    panic!("`({ctor} {name})` surfaces a CDZ0101 for the unbound width: {ds:?}")
+                });
+            assert!(
+                d.message.contains(&format!("unbound name `{name}`"))
+                    && d.message
+                        .contains("a width must be a compile-time integer literal")
+                    && d.message.contains(&format!("`{example}`")),
+                "the unbound width names it + the width guidance + the ctor-appropriate example: {}",
+                d.message
+            );
+        }
+        // NESTED: an unbound width buried in a compound annotation `(List (Int hello))` is caught too.
+        let nested = diags("(module m (def (f (: a (List (Int hello)))) a) (export f))");
+        assert!(
+            nested.iter().any(|d| d.code.as_deref() == Some("CDZ0101")
+                && d.message
+                    .contains("a width must be a compile-time integer literal")),
+            "a nested unbound width is caught: {nested:?}"
+        );
+        // CONTROLS — must NOT trip this reject:
+        // a concrete width `(Int 64)`, an odd width `(Int 7)`, and a BOUND width variable `(Int a)` (a `Type`
+        // parameter used as a generic width) all check clean; an over-ceiling `(UInt 65)` keeps its CDZ0302.
+        for ok in [
+            "(module m (def (f (: a (Int 64))) a) (export f))",
+            "(module m (def (f (: a (Int 7))) a) (export f))",
+            "(module m (def (f (: a Type) (: x (Int a))) x) (export f))",
+        ] {
+            assert!(
+                diags(ok)
+                    .iter()
+                    .all(|d| d.severity != crate::abi::Severity::Error),
+                "a valid width form checks clean: {ok} → {:?}",
+                diags(ok)
+            );
+        }
+        let over = diags("(module m (def (f (: a (UInt 65))) a) (export f))");
+        assert!(
+            over.iter().any(|d| d.code.as_deref() == Some("CDZ0302")),
+            "an over-ceiling width keeps its CDZ0302 (not the unbound-width path): {over:?}"
+        );
+    }
+
     // ── integer widths (I3, fold): named widths, per-width bounds, annotations, odd widths ────────
 
     #[test]


### PR DESCRIPTION
Automated CI-gated candidate for v-diagnostics MR 000000021370-195069-merge-request.json (ref d5973785e3236f4ad51a57bc311277f9ce0b3651).