### PR TITLE
[v-core-opt] 72bc982ba

### DIFF
--- a/implementation/seed/crates/rcdzc/src/lower.rs
+++ b/implementation/seed/crates/rcdzc/src/lower.rs
@@ -17298,10 +17298,19 @@ fn lower_float_of(db: &mut Db, id: StructId, args: &[StructId]) -> Core {
     match core_of(db, args[0]) {
         Core::Poison(r) => Core::Poison(r),
         Core::ConstFloat(d) => {
-            // Round the exact source value to the target width: `as f32 as f64` for a Float32 target
-            // (narrowing rounds to nearest binary32), the f64 value unchanged for a Float64 target
+            // Read the source value AT THE SOURCE OPERAND'S OWN width first — a `Float32` source literal IS
+            // its binary32 value, so demote before converting (else a widen/identity `Float64.of` of a
+            // `Float32` promotes the un-demoted f64 payload the reader parsed, diverging from the runtime
+            // `f32.promote` of the real f32 slot: `(Float64.of (: 0.1 Float32))` → 0.1 instead of
+            // 0.10000000149011612 — the adv-61 fold-precision class, here in the width conversion).
+            let src = f64::from_bits(const_float_bits_at_operand_width(
+                db,
+                args[0],
+                d.to_f64_bits(),
+            ));
+            // Then round the source value to the TARGET width: `as f32 as f64` for a Float32 target
+            // (narrowing rounds to nearest binary32), the value unchanged for a Float64 target
             // (a promote/identity is exact). Rounding once at the target width matches the runtime op.
-            let src = f64::from_bits(d.to_f64_bits());
             let rounded = if width == 32 { src as f32 as f64 } else { src };
             match crate::ast::Decimal::from_f64(rounded) {
                 Some(nd) => {

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -8803,6 +8803,55 @@ fn a_constant_float32_compare_folds_at_binary32_precision() {
     }
 }
 
+/// adv-61b regression: a float-WIDTH conversion const-fold (`Float64.of`/`Float32.of`) must read the
+/// source operand AT ITS OWN width before rounding to the target — else a widen/identity of a `Float32`
+/// literal promotes the un-demoted f64 payload the reader parsed instead of the source's binary32 value.
+/// `(Float64.of (: 0.1 Float32))` must fold to `0.1f32 as f64` (0.10000000149011612), the SAME value the
+/// runtime `f32.promote` produces — before the fix it folded to the raw f64 `0.1` (a const-vs-runtime
+/// divergence on both backends, sibling of the compare-fold adv-61). Controls: a `Float32.of` of a
+/// Float64 literal (narrowing — the target round already handled it) and a `Float64.of` of a Float64
+/// literal (identity — unchanged) must stay exactly as they were. Bits-compared at f64.
+#[test]
+fn a_float_width_conversion_const_fold_reads_the_source_at_its_own_width() {
+    use crate::testkit::parse;
+    // (program, expected f64 result-by-bits). All fold to a ConstFloat (no runtime import).
+    let cases: &[(&str, f64)] = &[
+        // THE BUG: promote a Float32 literal — must give the binary32 value widened, not the f64 payload.
+        (
+            "(module m (def (main) (Float64.of (: 0.1 Float32))) (export main))",
+            0.1f32 as f64,
+        ),
+        // A second widen face (0.2f32 → f64) — 0.2 is also not representable in binary32.
+        (
+            "(module m (def (main) (Float64.of (: 0.2 Float32))) (export main))",
+            0.2f32 as f64,
+        ),
+        // CONTROL narrowing: Float32.of a Float64 literal rounds to binary32 (the target round; unchanged).
+        (
+            "(module m (def (main) (Float64.of (Float32.of (: 0.1 Float64)))) (export main))",
+            0.1f32 as f64,
+        ),
+        // CONTROL identity: Float64.of a Float64 literal is exact (the un-demoted f64 value is correct here).
+        (
+            "(module m (def (main) (Float64.of (: 0.1 Float64))) (export main))",
+            0.1f64,
+        ),
+    ];
+    for (src, want) in cases {
+        let bytes = compile_component(&crate::codec::encode(&parse(src))).expect("compile");
+        assert!(
+            cdz_run::required_runtime(&bytes).expect("valid").is_none(),
+            "a float-width conversion of a constant folds, importing no runtime: {src}"
+        );
+        let got: f64 = run_returns(&bytes, "main");
+        assert_eq!(
+            got.to_bits(),
+            want.to_bits(),
+            "float-width conversion reads the source at its own width: {src}"
+        );
+    }
+}
+
 #[test]
 fn a_float32_if_result_grounds_its_bare_literal_branches_to_f32_not_f64() {
     use crate::testkit::parse;


### PR DESCRIPTION
CI-gated candidate for spec_placeholder (lane: lower). Auto-dispatched by pr-sync.