### PR TITLE
rcdzc(effects): adv-62 doc — cite the concrete op-ref regression, not "op-ref tests" (PR #1543 review follow-up)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/lower.rs
+++ b/implementation/seed/crates/rcdzc/src/lower.rs
@@ -8091,7 +8091,8 @@ fn scrutinee_reaches_host_perform(db: &mut Db, scrutinee: StructId) -> bool {
         // so a perform in `body` is an observable host call. Treat ANY `Resolved::Host` node as reaching a
         // host perform — a CONSERVATIVE OVER-APPROXIMATION, not a claim that every compiling host block
         // performs (it does not: an op-REFERENCE-only body like `(host (E) (E.get))` — the op named but
-        // never applied — compiles WITHOUT a perform; see the op-ref tests). Over-reporting is SAFE here:
+        // never applied — compiles WITHOUT a perform; see the regression `a_host_with_too_many_operands_
+        // is_cdz0201`, which asserts `(host (E) (E.get))` compiles OK). Over-reporting is SAFE here:
         // it only keeps the `MatchSum` wrapper (materialize the scrutinee ONCE), which is never wrong — a
         // non-performing host-block scrutinee is merely materialized rather than folded through, same value,
         // no re-emit. Under-reporting would be the bug. This is the ROBUST detector for a host perform

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -6810,8 +6810,9 @@
            TWICE → the second call had no recorded response and TRAPPED. FIX (v-effects): the guard now
            treats a `Resolved::Host` block in the scrutinee as reaching a host perform — a CONSERVATIVE
            OVER-APPROXIMATION (not every compiling host block performs: an op-reference-only body like
-           `(host (E) (E.get))` compiles without a perform; over-reporting is safe here because it only
-           keeps the wrapper, which merely materializes the scrutinee once), so the `MatchSum` wrapper is
+           `(host (E) (E.get))` compiles without a perform — see the rcdzc regression
+           `a_host_with_too_many_operands_is_cdz0201`; over-reporting is safe here because it only keeps
+           the wrapper, which merely materializes the scrutinee once), so the `MatchSum` wrapper is
            kept and the scrutinee materializes ONCE;
            and the wasm `Core::Let` emit maps the scalar value node → its slot so the two closures capture
            the SAME slot rather than re-lowering the host call. With io.get=21: `f(10)=21+10=31`,


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 5e334993e96ecd7b257d8753e4c22e617ce6dda9, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.