### PR TITLE
docs(nix): correct the scoping doc — operator redesign (hash-from-built-bytes) supersedes the N0–N4 plan

### DIFF
--- a/fleet/NIX-FLAKE-PIPELINE-SCOPING.md
+++ b/fleet/NIX-FLAKE-PIPELINE-SCOPING.md
@@ -1,10 +1,28 @@
 # Scoping: move the build/test pipeline to a Nix flake
 
-Status: COMMITTED DIRECTION — N0 DONE, N1+ held for CI-lanes cutover (v-fleet-tooling, 2026-08-02;
-see the Status section at the bottom for the resolved operator decisions). Owner: `v-fleet-tooling`
-(owns gate/CI/build pipeline). Trigger: operator idea relayed by concierge (note seq 32/33) — a Nix
-flake that builds + wires *everything*, with incremental test-skipping, no committed-wasm, and a
-shared cache.
+> **⚡ CURRENT STATE (2026-08-03, owner `v-nix`) — READ THIS FIRST; the N0–N4 plan below is the
+> ORIGINAL scoping, since SUPERSEDED by an operator redesign.** Ownership moved from `v-fleet-tooling`
+> to a dedicated **`v-nix`** vertical (2026-08-02). The operator then clarified the hash approach
+> (2026-08-03): the wasm content hash must be **DERIVED FROM THE BUILT BYTES** (it falls out of nix
+> building the artifact), **never** a hand-pinned literal and **not** read from `runtime_abi.rs`. Target
+> architecture: **a derivation per wasm component** (rust or cadenza) → all in a **nix store** keyed by
+> derived hash → the **runtime + harness load by hash** → **nix builds the whole repo deterministically**.
+> Full north star + staging + coordination = the `nix-deterministic-build-north-star-hash-from-built-wasm`
+> memory. **LANDED on trunk:** N0 devShell; N1 runtime + debug-counters as NORMAL (input-addressed)
+> derivations with `packages.*-hash` derived from the built bytes + `checks.*-hash-parity` (parity vs the
+> committed `REQUIRED_RUNTIME_HASH`, read only to compare); N2 `packages.reducer-guest` +
+> `packages.cedar-guest` built from source; R2 `packages.store` (all four components as
+> `<derived-hash>.wasm`). **NEXT (cross-territory, coordinated):** R4 = a `CDZ_STORE` env override in
+> cdz-run's `default_store()` (v-runtime owns it; kernel + host need ZERO change — both are
+> content-address-agnostic) + a flake hook exporting it; R3 = invert `xtask codegen` to CONSUME the
+> nix-built hash; consumer test-arms (reducer `REDUCER_GUEST_COMPONENT`, cedar `CEDAR_POLICY_COMPONENT`).
+> No cutover — the nix store is opt-in first, parallel-proven, before retiring `target/cadenza-store`.
+
+Status (ORIGINAL scoping, historical): COMMITTED DIRECTION — N0 DONE, N1+ held for CI-lanes cutover
+(v-fleet-tooling, 2026-08-02; see the Status section at the bottom for the resolved operator decisions).
+Owner: `v-fleet-tooling` (owns gate/CI/build pipeline). Trigger: operator idea relayed by concierge
+(note seq 32/33) — a Nix flake that builds + wires *everything*, with incremental test-skipping, no
+committed-wasm, and a shared cache.
 
 This started as a feasibility + incremental-path read and is now the COMMITTED direction (operator
 GO, 2026-08-02 — see the Status section at the bottom). The CI-gated parallel-lanes rewire


### PR DESCRIPTION
Candidate PR for v-nix's merge-request (ref 1a6cd049439cf20e2434d90658696021d469bfd6, lane docs). Auto-merge armed; pr-sync's schedule-pass reaps on green.