### PR TITLE
rcdzc(effects): adv-65 — a unit-result host op consumes its response row on wasm (was: cursor desync → next value op read the unit op's row)

### DIFF
--- a/implementation/seed/crates/cdz-run/src/lib.rs
+++ b/implementation/seed/crates/cdz-run/src/lib.rs
@@ -1901,8 +1901,30 @@ fn bind_host_imports(
                     format!("{op_label}\t{}", str_args.join(" "))
                 };
                 observed.lock().expect("observed calls mutex").push(entry);
-                // A unit-result op returns nothing and consumes no response. A scalar-result op pops the
-                // next recorded response, coerces it to the result type, and returns it.
+                // adv-65 (HIGH differential): a UNIT-result op returns nothing, but it STILL CONSUMES its
+                // response row when the fixture supplied one for it — the corpus model is "responses are
+                // consumed IN ORDER of the calls made", so a `(host (io) (do (io.ping k) (+ (io.get k) k)))`
+                // with responses [io.ping, io.get] must have `io.ping` advance the cursor past ITS row, so
+                // the later `io.get` reads its OWN row — not `io.ping`'s (the wasm-vs-rust wrong-value:
+                // io.get was reading ping's row → 0+3=3 instead of 7+3=10). Previously a unit op advanced
+                // NOTHING, desyncing every unit-op-then-value-op sequence. But a PURE observe-only unit op
+                // (H8's `log.emit` — no `(host-response …)` row at all) must NOT consume, or it would skip a
+                // later value op's row. So consume IFF the row at the cursor is FOR THIS OP: match the
+                // current response's recorded op against this op (both KEBAB-normalized, since the fixture's
+                // op may be source-cased while `op_label` is the WIT export name — the same two-sided
+                // normalization cdz-run uses elsewhere). Row-present-and-matching → consume-and-discard;
+                // row-absent-or-other-op (a pure observe-only unit op) → leave the cursor for the value op.
+                if results.is_empty() {
+                    let mut idx = cursor.lock().expect("host response cursor mutex");
+                    if let Some(resp) = responses.get(*idx) {
+                        let want = cadenza_syntax::extern_name::kebab_extern_name(&op_label);
+                        let have = cadenza_syntax::extern_name::kebab_extern_name(&resp.op);
+                        if want == have {
+                            *idx += 1;
+                        }
+                    }
+                }
+                // A scalar-result op pops the next recorded response, coerces it to the result type, returns it.
                 if let Some(slot) = results.get_mut(0) {
                     let ret_ty = ret_ty
                         .clone()

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -3502,6 +3502,7 @@ pass	a unary variant applied to a wrong-arity tuple payload is a type error
 pass	a unary variant applied to a wrong-type payload is a type error
 pass	a unit multiplied by its own inverse cancels to the dimensionless unit
 pass	a unit raised to the ZEROTH power is the dimensionless identity Unit.one
+pass	a unit-result host op consumes its response row so the next value op reads its own (adv-65)
 pass	a user Name variant does not capture the Ast sum's Name variant
 pass	a user SUM leaf inside a tuple key discriminates hits by variant AND payload
 pass	a user function may be named quote — its signature is a binding form, not a quote
@@ -5305,6 +5306,7 @@ pass	the union contains the elements of either set
 pass	the union of sets of TUPLES holds a shared tuple once and preserves component order
 pass	the unit recovered from a runtime-magnitude quantity is dimensionally checked
 pass	the unit value
+pass	the unit-op response-cursor discriminator: a nonzero ping row is not misread by the later get (adv-65)
 pass	the untaken branch's runtime div-by-zero does not fire
 pass	the unusual-width overflow check is width-parametric: a SECOND width (Int 12) also enforces its own range
 pass	the value-yielding insert of a new key adds the entry

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -3490,6 +3490,7 @@ pass	a unary variant applied to a wrong-arity tuple payload is a type error
 pass	a unary variant applied to a wrong-type payload is a type error
 pass	a unit multiplied by its own inverse cancels to the dimensionless unit
 pass	a unit raised to the ZEROTH power is the dimensionless identity Unit.one
+pass	a unit-result host op consumes its response row so the next value op reads its own (adv-65)
 pass	a user Name variant does not capture the Ast sum's Name variant
 pass	a user SUM leaf inside a tuple key discriminates hits by variant AND payload
 pass	a user function may be named quote — its signature is a binding form, not a quote
@@ -5271,6 +5272,7 @@ pass	the union contains the elements of either set
 pass	the union of sets of TUPLES holds a shared tuple once and preserves component order
 pass	the unit recovered from a runtime-magnitude quantity is dimensionally checked
 pass	the unit value
+pass	the unit-op response-cursor discriminator: a nonzero ping row is not misread by the later get (adv-65)
 pass	the untaken branch's runtime div-by-zero does not fire
 pass	the unusual-width overflow check is width-parametric: a SECOND width (Int 12) also enforces its own range
 pass	the value-yielding insert of a new key adds the entry

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -3466,6 +3466,7 @@ pass	a unary variant applied to a wrong-arity tuple payload is a type error
 pass	a unary variant applied to a wrong-type payload is a type error
 pass	a unit multiplied by its own inverse cancels to the dimensionless unit
 pass	a unit raised to the ZEROTH power is the dimensionless identity Unit.one
+todo	a unit-result host op consumes its response row so the next value op reads its own (adv-65)
 pass	a user Name variant does not capture the Ast sum's Name variant
 pass	a user SUM leaf inside a tuple key discriminates hits by variant AND payload
 pass	a user function may be named quote — its signature is a binding form, not a quote
@@ -5232,6 +5233,7 @@ pass	the union contains the elements of either set
 pass	the union of sets of TUPLES holds a shared tuple once and preserves component order
 pass	the unit recovered from a runtime-magnitude quantity is dimensionally checked
 pass	the unit value
+todo	the unit-op response-cursor discriminator: a nonzero ping row is not misread by the later get (adv-65)
 pass	the untaken branch's runtime div-by-zero does not fire
 pass	the unusual-width overflow check is width-parametric: a SECOND width (Int 12) also enforces its own range
 pass	the value-yielding insert of a new key adds the entry

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -6852,3 +6852,40 @@
   (host-responses (respond io.a (: 3 Int64)) (respond io.b (: 5 Int64)))
   (host-calls (call io.a) (call io.b))
   (output (: 513 Int64)))
+
+(case "a unit-result host op consumes its response row so the next value op reads its own (adv-65)"
+  (doc    "adv-65 (breaker, HIGH wasm differential): a UNIT-result host op must CONSUME its response row,
+           in order, so a later value-result op reads ITS OWN row — not the unit op's. `(host (io) (do
+           (io.ping k) (+ (io.get k) k)))` with responses [io.ping=0, io.get=7], k=3 → 10 (io.get reads
+           its own row 7: 7+3). The wasm host runner previously did NOT advance the response cursor on a
+           unit-result op (it returns nothing), so `io.get` read io.ping's row 0 → 3 (silent wrong value);
+           rust was correct (per-op response lists). FIX (v-effects, cdz-run): a unit-result op advances
+           the cursor IFF the row at the cursor is FOR THIS OP (kebab-normalized match) — consuming a
+           supplied row, but NOT skipping a value op's row for a pure observe-only unit op (H8's `log.emit`
+           shape, which supplies no row). The response model is in-order consumption of ALL calls.")
+  (input  (do
+            (effect io (op ping (-> Int64 Unit)) (op get (-> Int64 Int64)))
+            (def (main (: k Int64))
+              (host (io)
+                (do (io.ping k)
+                    (+ (io.get k) k))))
+            (export main)))
+  (host-responses (respond io.ping (: 0 Int64)) (respond io.get (: 7 Int64)))
+  (host-calls (call io.ping) (call io.get))
+  (call   main (: 3 Int64)) (output (: 10 Int64)))
+
+(case "the unit-op response-cursor discriminator: a nonzero ping row is not misread by the later get (adv-65)"
+  (doc    "adv-65 CURSOR DISCRIMINATOR: the same shape with io.ping's row = 99 (not 0) — if the unit op
+           failed to consume its row, io.get would read 99 → 102; consuming it correctly gives io.get its
+           own row 7 → 10. Pins that the fix READS THE RIGHT ROW, not merely that a zero happens to be
+           harmless.")
+  (input  (do
+            (effect io (op ping (-> Int64 Unit)) (op get (-> Int64 Int64)))
+            (def (main (: k Int64))
+              (host (io)
+                (do (io.ping k)
+                    (+ (io.get k) k))))
+            (export main)))
+  (host-responses (respond io.ping (: 99 Int64)) (respond io.get (: 7 Int64)))
+  (host-calls (call io.ping) (call io.get))
+  (call   main (: 3 Int64)) (output (: 10 Int64)))


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 7100aca7e, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.