### PR TITLE
rcdzc: value-eq over an empty collection of an unconstrained element type (rust backend)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/rust/enums.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/enums.rs
@@ -746,8 +746,12 @@ pub(super) fn ty_derives_eq(
         // A `List`/`Set` of an `Eq` element → `Vec<T>`/`BTreeSet<T>` is `Eq` (elementwise); a `Map` is `Eq`
         // when both key and value are. Recurse into the element/key/value type (a `List Float64` is NOT Eq,
         // caught by the recursion). `BTreeMap`/`BTreeSet` `==` compares by content, matching value equality.
-        Ty::List(e) | Ty::Set(e) => ty_derives_eq(db, e, visited),
-        Ty::Map(k, v) => ty_derives_eq(db, k, visited) && ty_derives_eq(db, v, visited),
+        // A FREE-VAR element is a special case: an EMPTY collection (`(Set.of (list))`) never constrains its
+        // element type, so it stays `Set(Var _)` — but it emits with a concrete default rep (`BTreeSet<i64>`)
+        // on BOTH sides of a `=`, which unifies and is `Eq`, so treat a free-var leaf as Eq (the drained-set
+        // value-equality case). `ty_leaf_eq_or_free` recurses the same way but admits a bare free var.
+        Ty::List(e) | Ty::Set(e) => ty_leaf_eq_or_free(db, e, visited),
+        Ty::Map(k, v) => ty_leaf_eq_or_free(db, k, visited) && ty_leaf_eq_or_free(db, v, visited),
         // A `Qty` erases to its inner magnitude in `lower` (the unit is compile-time), so a runtime `=` over
         // a quantity IS the `=` over its inner numeric type — Eq-derivable iff the inner is. A `(Qty BigInt …)`
         // / `(Qty Rational …)` / `(Qty Int64 …)` leaf in a compound thus compares by its erased magnitude.
@@ -755,6 +759,29 @@ pub(super) fn ty_derives_eq(
         // A function/closure, a free `Ty::Var`/`Any` — not `Eq`-derivable here (no native rep or not `Eq`).
         // Conservative: an unknown type declines the derive.
         _ => false,
+    }
+}
+
+/// A collection ELEMENT/key/value type for the `Eq` check, admitting an unconstrained free var. Like
+/// `ty_derives_eq` but a bare free `Ty::Var`/`Any` returns `true`: reaching a free-var leaf means the
+/// enclosing collection was never constrained, i.e. it is EMPTY (a non-empty one would have solved the
+/// element from its inserted values). An empty collection emits a concrete default rep (`BTreeSet<i64>`)
+/// identically on both sides of a runtime `=`, so the native `==` type-checks and compares equal — which
+/// is exactly what the value semantics want for a drained/empty collection. Nested collections recurse
+/// (an empty `Set (List ?e)` is still fine). Any OTHER type defers to `ty_derives_eq` (a `List Float64`
+/// still declines — its element is a solved non-Eq float, not a free var).
+fn ty_leaf_eq_or_free(
+    db: &mut Db,
+    ty: &crate::ty::Ty,
+    visited: &mut std::collections::HashSet<crate::ast::StructId>,
+) -> bool {
+    use crate::ty::Ty;
+    match ty {
+        Ty::Var(n) if *n < PARAM_SENTINEL_BASE => true,
+        Ty::Any => true,
+        Ty::List(e) | Ty::Set(e) => ty_leaf_eq_or_free(db, e, visited),
+        Ty::Map(k, v) => ty_leaf_eq_or_free(db, k, visited) && ty_leaf_eq_or_free(db, v, visited),
+        other => ty_derives_eq(db, other, visited),
     }
 }
 

--- a/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
@@ -5362,6 +5362,27 @@ fn rustc_roundtrip_value_eq_over_bytes_string_and_compounds() {
 }
 
 #[test]
+fn rustc_value_eq_over_an_empty_set_of_an_unconstrained_element_type() {
+    // `Core::ValueEq` over an EMPTY collection whose element type is an UNSOLVED FREE VAR: `(Set.of (list))`
+    // never constrains its element (nothing is inserted), so its type stays `Set(Var _)`. Previously the
+    // eq-derivability check rejected the free-var element → ValueEq declined "runtime structural equality
+    // not yet rendered" (while wasm ran it — the drained-set case). Now `ty_leaf_eq_or_free` admits a
+    // free-var leaf: an empty set emits a concrete default rep (`BTreeSet<i64>`) on BOTH sides, so the
+    // native `==` type-checks and compares equal. Here a drained set (build {k}, remove k) equals the
+    // literal empty set. `main(5)` = 1 (they compare equal). Pins the empty-collection-openvar Eq path.
+    let src = "(module m (def (drained-eq (: k Int64)) \
+        (if (= (Set.of (list)) (Set.remove (Set.of (list k)) k)) 1 0)) (export drained-eq))";
+    let rs = compile_rust(src);
+    assert!(
+        rs.contains("=="),
+        "an empty-Set value-eq emits a native == (not a decline):\n{rs}"
+    );
+    if let Some(out) = rustc_run(&rs, "drained_eq(5)") {
+        assert_eq!(out, "1", "a drained set compares equal to the empty set");
+    }
+}
+
+#[test]
 fn rustc_roundtrip_single_variant_newtype_literal_payload_arm_at_narrow_widths() {
     // A single-variant newtype matched with a LITERAL-payload arm (`(match (W.Wrap n) ((W.Wrap 0) 100)
     // ((W.Wrap x) x))`, `W = (Wrap UInt8)`). The newtype tag ERASES (`(W.Wrap n)` → `n`), so `lower`

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5499,7 +5499,7 @@ pass	α-equivalence handles nesting and distinguishes a bound variable from a sa
 todo	Ast values key a map across quote and Ast.* construction routes
 todo	Set.of over runtime lists at two different element types declines pending the recursive-generic tie
 todo	Type is a first-class value
-todo	a DRAINED set compares equal to the literal empty set — removal restores the canonical empty rep
+pass	a DRAINED set compares equal to the literal empty set — removal restores the canonical empty rep
 pass	a Float64 closure captures a Float64 build-time host effect result
 pass	a Float64-inner Qty host result crosses as its float magnitude
 pass	a build-time delegated effect whose result a returned closure captures does not escape
@@ -5576,7 +5576,7 @@ pass	an ordering <= of two same-bits Float32 literals const-folds true
 pass	an ordering >= of two same-bits Float32 literals const-folds true
 pass	Float32 subtraction const-folds at f32 (0.4f32 - 0.1f32 = 0.3f32)
 pass	Float32 division const-folds at f32 (0.3f32 / 3.0f32 = 0.1f32)
-todo	two DISTINCT let-bound host calls each captured by its own escaping closure fire once each in order (adv-62)
+pass	two DISTINCT let-bound host calls each captured by its own escaping closure fire once each in order (adv-62)
 pass	promoting a Float32 literal to Float64 promotes the binary32 VALUE, not the un-demoted f64 payload (const fold)
 pass	the runtime control for the Float32-to-Float64 promote reads the f32 value at its own width
 pass	a UInt8 wrapping-add result feeds a CHECKED add — the MASKED value is what the checked op sees


### PR DESCRIPTION
Candidate PR for v-rust-backend's merge-request (ref 34338bd92, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.