### PR TITLE
rcdzc(effects): adv-62b — force-keep a let-binding whose CALL init reaches a host call (record-face host double-fire fix)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/lower.rs
+++ b/implementation/seed/crates/rcdzc/src/lower.rs
@@ -3931,6 +3931,32 @@ fn count_localref_reads(db: &mut Db, id: StructId, binder: StructId, n: &mut usi
     }
 }
 
+/// Whether the LOWERED CORE of `id` reaches a `Core::HostCall` anywhere in its subtree — walking the
+/// maintained `core_child_ids` enumeration, so it FOLLOWS a call into its inlined callee body (unlike the
+/// AST-based [`subtree_reaches_host_call`], whose List arm recurses only the syntactic children and so
+/// MISSES a host call inside a nullary call's body — `(mk)` where `mk`'s body is `(host (io) (let ((v
+/// (io.get))) …))` lowers to a `Core::Let` whose init IS the host call, reachable HERE but not through the
+/// AST walk). adv-62b: a `let`-binding whose init is such a call must be FORCE-KEPT (materialized once), or
+/// each use re-inlines the callee's `(host …)` block → the host op fires per use (double-fire trap). Reads
+/// memoized `core_of` results (no re-lower, no `kept_bindings`/`captured_ref` perturbation). Bounded by a
+/// visited set — a lowered core can share sub-nodes (a kept binding referenced twice), so a plain recursion
+/// could re-walk; the set keeps it linear and cycle-safe.
+fn core_reaches_host_call(
+    db: &mut Db,
+    id: StructId,
+    seen: &mut std::collections::HashSet<StructId>,
+) -> bool {
+    if !seen.insert(id) {
+        return false;
+    }
+    if matches!(core_of(db, id), Core::HostCall { .. }) {
+        return true;
+    }
+    crate::backend::wasm::select::core_child_ids(db, id)
+        .into_iter()
+        .any(|child| core_reaches_host_call(db, child, seen))
+}
+
 /// The non-exhaustiveness fault of the match form `id`, if it has one — for the WELL-FORMEDNESS pass
 /// (`compile::collect_faults` via `infer::collect_node`) to surface a CDZ0210 over EVERY match, not only
 /// the ones the emit path lowers. `cdz check` runs `type_errors` on every def body but the reached-poison
@@ -13455,7 +13481,28 @@ fn should_keep_binding(db: &mut Db, init: StructId, uses: &BindingUses) -> bool 
     // through). Keeping such a compound would instead force an unlowerable heap build. Only an init that IS
     // (or reduces to) the perform — not one that merely aggregates performs into a fold-through shape — is
     // force-kept here; the compound's elements are single-evaluated by the compound, not by naming it.
-    if subtree_reaches_host_call(db, init)
+    // The host-reach test has TWO detectors. `subtree_reaches_host_call` (AST walk) catches a DIRECT perform
+    // in the init. But adv-62b (HIGH wasm soundness): when the init is a CALL whose CALLEE BODY reaches a
+    // host call — `(let ((r (mk))) …)` with `mk = (host (io) (let ((v (io.get))) (record …)))` — the AST
+    // walk stops at the nullary-call node `(mk)` (its only child is the `mk` name ref) and MISSES the host
+    // call in mk's body, so `r` was copy-propagated and each `(. r •)` re-inlined the `(host …)` block → the
+    // host op fired once per use (double-fire trap). `core_reaches_host_call` follows the call into mk's
+    // INLINED core (`core_of((mk))` is a `Core::Let` whose init IS the host call) and catches it, so `r` is
+    // force-kept (materialized once; every projection reads the shared slot). Gated to a CALL init (`core_of`
+    // is `Core::Call`, OR the init reduced to a `Core::Let`/compound wrapping the callee body — i.e. NOT
+    // already caught by the AST walk) so the extra core-walk cost stays off the common direct-perform path.
+    // The call-following `core_reaches_host_call` runs ONLY when the init is a CALL (`Resolved::Apply`) —
+    // the one shape whose host call the AST walk can't see (it stops at the call node). A COMPOUND-literal
+    // init (`Resolved::Record`/`Tuple`/`List` holding a capturing lambda) must NOT trigger it: walking the
+    // compound's core `core_of`s its contained lambda, SPECULATIVELY LIFTING it (`lower_lambda_value`) and
+    // polluting `db.captured_ref` → poisons the projected-closure fold (an INVALID module — the exact hazard
+    // the lambda short-circuits above avoid; it regressed `a capturing closure stored in a let-bound
+    // tuple/record is projected and applied`). Those compound inits reach no host call and are handled by the
+    // `compound_contains_lambda` propagate-arm above anyway; only a genuine CALL init needs the deeper walk.
+    let host_reaching = subtree_reaches_host_call(db, init)
+        || (matches!(resolved_of(db, init), Resolved::Apply { .. })
+            && core_reaches_host_call(db, init, &mut std::collections::HashSet::new()));
+    if host_reaching
         && !matches!(
             core_of(db, init),
             Core::Tuple { .. } | Core::Record { .. } | Core::ListNew { .. }

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -65776,6 +65776,48 @@ mod stage1 {
     }
 
     #[test]
+    fn adv62b_a_host_result_captured_by_two_closures_in_a_record_fires_the_host_op_once() {
+        // adv-62b: the RECORD-face sibling of adv-62. `mk` returns a RECORD of two closures capturing the
+        // let-bound host result `v`, from inside `(host (io) …)`; `main` projects + calls both. BUG: `r`'s
+        // init `(mk)` reaches a host call THROUGH THE CALL, but the AST-based `subtree_reaches_host_call`
+        // stopped at the `(mk)` node and missed it → `r` copy-propagated → each `(. r •)` re-inlined the
+        // `(host …)` block → io.get fired per projection → 2nd call has no recorded response → TRAP. FIX:
+        // `should_keep_binding`'s host-force-keep now ALSO follows a CALL init into its inlined callee body
+        // (`core_reaches_host_call`, gated to a `Resolved::Apply` init), so `r` is force-kept + materialized
+        // once; both projections read the shared record slot. Run with EXACTLY ONE response: the pre-fix
+        // double-fire traps here. io.get=21 → f(10)=31 + g(100)=2100 = 2131.
+        let Some(runtime) = find_runtime_wasm() else {
+            eprintln!("[adv62b] runtime wasm not in the store; skipping run");
+            return;
+        };
+        let src = "(do (effect io (op get (-> Unit Int64))) \
+                   (def (mk) (host (io) (let ((v (io.get unit))) \
+                     (record (f (fn ((: x Int64)) (+ v x))) (g (fn ((: x Int64)) (* v x))))))) \
+                   (def (main) (let ((r (mk))) (+ ((. r f) 10) ((. r g) 100)))) (export main))";
+        let bytes = compile_component(&crate::codec::encode(&parse(src)))
+            .expect("adv-62b record-of-closures host-capture must compile");
+        let opts = cdz_run::RunOpts {
+            export: Some("main".to_string()),
+            args: vec![],
+            runtime: Some(runtime),
+            runtime_cache_dir: None,
+            host_responses: vec![cdz_run::HostResponse {
+                op: "io.get".to_string(),
+                value: "21".to_string(),
+            }],
+        };
+        match cdz_run::run(&bytes, &opts).expect("run") {
+            cdz_run::Outcome::Value(s) => assert_eq!(
+                s, "2131",
+                "io.get (=21) fires ONCE, shared by both record-field closures: 31 + 2100 = 2131"
+            ),
+            cdz_run::Outcome::Trap(t) => panic!(
+                "adv-62b regressed: the record-held host call fired more than once → trap: {t}"
+            ),
+        }
+    }
+
+    #[test]
     fn a_runtime_string_host_arg_is_marshaled_into_shared_memory_and_runs() {
         // The host `_mem` RUNTIME-string-arg path (slice 2). A CONSTANT string host arg crosses via the data
         // segment; a RUNTIME string (a value-heap rope) had declined ("a host call with a non-constant string

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -1787,6 +1787,7 @@ pass	a host op returning Bool crosses the boundary and drives a branch
 pass	a host op whose result is a QUANTITY crosses the boundary as its inner scalar (unit erased)
 pass	a host op with a String parameter composes with the value-heap runtime
 pass	a host response SIZES a guest-built collection which is then folded and keyed
+pass	a host result captured by two closures stored in a RECORD fires the host op once (adv-62b)
 pass	a host-called closure applied to a different argument tracks the input
 pass	a host-called closure capturing a HEAP LIST indexes it at call dispatch
 pass	a host-called closure with a different body dispatches the right code

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -1784,6 +1784,7 @@ pass	a host effect with a non-kebab NAME crosses under a normalized interface ex
 pass	a host effect with a non-kebab OPERATION name crosses under a normalized func extern name
 pass	a host op whose result is a QUANTITY crosses the boundary as its inner scalar (unit erased)
 pass	a host response SIZES a guest-built collection which is then folded and keyed
+todo	a host result captured by two closures stored in a RECORD fires the host op once (adv-62b)
 pass	a host-called closure applied to a different argument tracks the input
 pass	a host-called closure with a different body dispatches the right code
 pass	a host-crossing closure captures a CHAMP map and set and reads both per call

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5485,6 +5485,7 @@ todo	a host effect with a non-kebab OPERATION name crosses under a normalized fu
 todo	a host op whose result is a QUANTITY crosses the boundary as its inner scalar (unit erased)
 todo	a host op with a String parameter composes with the value-heap runtime
 todo	a host response SIZES a guest-built collection which is then folded and keyed
+todo	a host result captured by two closures stored in a RECORD fires the host op once (adv-62b)
 todo	a host-delegated result SEEDS an in-program handler's initial state
 todo	a host-op argument COMPUTED by guest arithmetic crosses the boundary evaluated
 todo	a mutually-recursive decoder returns a heap value and cursor and its heap slot is dispatched

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -6910,3 +6910,31 @@
   (host-responses (respond io.ping (: 99 Int64)) (respond io.get (: 7 Int64)))
   (host-calls (call io.ping) (call io.get))
   (call   main (: 3 Int64)) (output (: 10 Int64)))
+
+(case "a host result captured by two closures stored in a RECORD fires the host op once (adv-62b)"
+  (doc    "adv-62b (breaker→v-effects, HIGH wasm soundness): the RECORD-face sibling of adv-62 — a
+           `let`-bound host-call result captured by two closures stored in a RECORD must fire the host op
+           EXACTLY ONCE. `(def (mk) (host (io) (let ((v (io.get))) (record (f (fn (x) (+ v x))) (g (fn (x)
+           (* v x)))))))` + `(def (main) (let ((r (mk))) (+ ((. r f) 10) ((. r g) 100))))` → 2131 (io.get=21
+           once: f(10)=31 + g(100)=2100). The bug: `r`'s init `(mk)` reaches a host call THROUGH THE CALL,
+           but `subtree_reaches_host_call`'s AST walk stopped at the `(mk)` node and missed the host call in
+           mk's body → `r` was copy-propagated → each `(. r •)` re-inlined the `(host …)` block → io.get
+           fired PER projection → the 2nd call had no recorded response and TRAPPED. FIX (v-effects): the
+           `should_keep_binding` host-force-keep test now ALSO follows a CALL init into its inlined callee
+           body (`core_reaches_host_call`, a Core-tree walk, gated to a `Resolved::Apply` init), so `r` is
+           force-kept — materialized ONCE, every projection reads the shared record slot via `LocalRef`.
+           rust declines the record-of-closures-through-host shape (a separate frontier). The tuple/match
+           face is adv-62 (#1528); this is the record face.")
+  (input  (do
+            (effect io (op get (-> Unit Int64)))
+            (def (mk)
+              (host (io)
+                (let ((v (io.get unit)))
+                  (record (f (fn ((: x Int64)) (+ v x))) (g (fn ((: x Int64)) (* v x)))))))
+            (def (main)
+              (let ((r (mk)))
+                (+ ((. r f) 10) ((. r g) 100))))
+            (export main)))
+  (host-responses (respond io.get (: 21 Int64)))
+  (host-calls (call io.get))
+  (output (: 2131 Int64)))


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref b0a0bcca0, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.