### PR TITLE
rcdzc: a user-module member miss names the module, not a record (diagnostic wording)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/db.rs
+++ b/implementation/seed/crates/rcdzc/src/db.rs
@@ -4008,6 +4008,17 @@ impl Db {
             .map(|m| m.occ)
     }
 
+    /// The NAME of the module whose SYNTHESIZED record is `record` (`m` for `(module m …)`), or `None` if
+    /// `record` is not a module's synth record. The name-returning companion of [`Db::module_by_synth_record`]
+    /// — used by `member_category` to name a USER-module member miss "the `m` module has no member `k`"
+    /// (matching the prelude-module arm), instead of leaking the internal "record has no field `k`" spelling.
+    pub fn module_name_by_synth_record(&self, record: StructId) -> Option<&str> {
+        self.modules
+            .iter()
+            .find(|m| m.synth == Some(record))
+            .map(|m| m.name.as_str())
+    }
+
     /// The constructor-field occurrence a BARE variant name denotes — `NLit` for `(type Node (NLit …) …)`,
     /// the same field a qualified `(. Node NLit)` projects. A nullary variant used as a VALUE may be
     /// written bare (`NNil`, not `(. Node NNil)` — `core-semantics.md` §A Sum Type Constructor Is A

--- a/implementation/seed/crates/rcdzc/src/infer.rs
+++ b/implementation/seed/crates/rcdzc/src/infer.rs
@@ -11343,7 +11343,7 @@ pub fn type_errors(db: &mut Db, id: StructId) -> Vec<Reject> {
 /// Returns `(subject, member_word)` where the message is `<subject> has no <member_word> \`key\``. The
 /// `has no <word> \`` shape is the shared DEDUP invariant (`compile::dedup_faults`' `no_field_key` splits on
 /// it), so every category still collapses its infer/emit twin.
-pub(crate) fn member_category(db: &Db, operand: StructId, key: &str) -> (String, &'static str) {
+pub(crate) fn member_category(db: &mut Db, operand: StructId, key: &str) -> (String, &'static str) {
     let _ = key;
     if let Some(name) = db.ast.as_name(operand) {
         if db.effect_decl_by_name(name).is_some() {
@@ -11357,6 +11357,18 @@ pub(crate) fn member_category(db: &Db, operand: StructId, key: &str) -> (String,
         if db.type_decl_by_name(name).is_some() {
             return (format!("the type `{name}`"), "variant");
         }
+    }
+    // A USER `(module m …)` value — a bare `m` OR a nested projection `(. outer inner)` — reduces to the
+    // module's SYNTHESIZED record. Name it "the `m` module has no member `k`" (matching the prelude-module
+    // arm) rather than leaking the internal "record has no field `k`" — a user module is a module, not a
+    // bare record, so an absent-member miss should read as a module miss. Recognized by ORIGIN (the reduced
+    // record IS a module's synth record, `module_name_by_synth_record`), not by name — a nested projection
+    // has no operand name for the `as_name` arms above to catch. Falls through to the record arm below for a
+    // genuine record value (whose reduced record is not a module synth).
+    if let Some(record) = crate::eval::reduce_to_record_id(db, operand)
+        && let Some(mname) = db.module_name_by_synth_record(record)
+    {
+        return (format!("the `{mname}` module"), "member");
     }
     ("record".to_string(), "field")
 }

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -58394,6 +58394,27 @@ mod stage1 {
         );
     }
 
+    #[test]
+    fn an_absent_user_module_member_names_the_module_not_a_record() {
+        // A member miss on a USER `(module m …)` value names the MODULE category — "the `m` module has no
+        // member `secret`" — matching the prelude-module arm, NOT the internal "record has no field"
+        // (a module is a module to the author, not a bare record — the export record is an implementation
+        // detail). `member_category` recognizes it by ORIGIN: the operand reduces to the module's SYNTH
+        // record (`module_name_by_synth_record`), so a NESTED projection `(. (. outer inner) k)` — which has
+        // no operand NAME to key on — is named too. The `secret` def exists but is not exported, so it is
+        // genuinely out of reach through `m`'s export record. Still CDZ0201 (this is a wording fix, not a
+        // code change); the "field" spelling stays reserved for a GENUINE record value.
+        let src = "(module top (module m (def (pub x) (+ x 1)) (def (secret x) (+ x 100)) (export pub)) \
+                    (def (main) ((. m secret) 5)) (export main))";
+        let msg = compile_component(&crate::codec::encode(&parse(src)))
+            .expect_err("an unexported user-module member must decline")
+            .message;
+        assert!(
+            msg.contains("the `m` module has no member `secret`"),
+            "a user-module member miss names the module, not a record: {msg}"
+        );
+    }
+
     // ── arithmetic intrinsics: application of a built-in operation, generic over the integer type ──
 
     #[test]


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref 220900b5a57da8047c75a2cf665498a15e4bbd82, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.