### PR TITLE
rcdzc(wasm): adv-66 — classify Bytes.compact CONSUMING in the Perceus dup pass (wasm UAF/OOB fix)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
@@ -1763,10 +1763,19 @@ fn mark_binder_dups_inner(
             false
         }
         // Borrowing reads: the operand is borrowed (a scalar element `Proj`, a length, a lookup's map, …).
-        Core::ListLen { operand }
-        | Core::BytesLen { operand }
-        | Core::StrScalarLen { operand }
-        | Core::BytesCompact { operand } => borrow(db, operand, live_after, sites),
+        Core::ListLen { operand } | Core::BytesLen { operand } | Core::StrScalarLen { operand } => {
+            borrow(db, operand, live_after, sites)
+        }
+        // `Bytes.compact` (adv-66) is NOT a borrow — it lowers to the SAME runtime `bytes-compact` op as
+        // `StrToBytes` (op_bytes_compact: flattens the rope IN PLACE and returns the SAME handle), so it
+        // CONSUMES its operand and hands the handle back as the result. `binding_escapes_dup_aware` already
+        // treats it consuming (the operand escapes into the result); this pass must AGREE — a binding
+        // consumed by `Bytes.compact` that has a LATER live use needs a `dup` before the compact, exactly
+        // like `StrToBytes` below. Misclassifying it as a borrow meant `(let ((flat (Bytes.compact rope)))
+        // …)` never dup'd `rope`: the compact consumes rope's handle + returns it as `flat` (an ALIAS), so a
+        // later consuming use of `flat` (`Bytes.concat flat …`) FBIP-freed the handle while `rope` (the same
+        // handle) was still read (`= rope flat` / `< rope …`) → use-after-free / OOB (a wasm-only miscompile).
+        Core::BytesCompact { operand } => consume(db, operand, live_after, sites),
         Core::Proj { operand, .. } => {
             let scalar_element = matches!(get_op(db, id), Ok(Some(_)));
             // A NESTED-COMPOUND projection (`get_op` None — `arr-get` returns the child HANDLE, a BORROW of

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -1114,6 +1114,56 @@ fn a_narrow_runtime_tuple_element_crosses_the_heap_boundary() {
     }
 }
 
+/// adv-66 (breaker/v-runtime, HIGH wasm-only UAF/OOB): `Bytes.compact` was mis-classified as a BORROW in
+/// the Perceus dup-placement pass (`mark_binder_dups`), but it lowers to the SAME runtime `bytes-compact`
+/// op as `String.to-bytes` — which CONSUMES its operand and returns the SAME handle (op_bytes_compact
+/// flattens the rope in place). So `(let ((flat (Bytes.compact rope))) …)` makes `flat` an ALIAS of
+/// `rope`'s handle; a later CONSUMING use of `flat` (`Bytes.concat flat …`) FBIP-freed the handle while
+/// `rope` (the same handle) was STILL read (`= rope flat` / `< rope …`) → use-after-free (n=2 trapped,
+/// n=10 OOB'd; rust computed 11). The COMBINATION is the trigger: a value-= that BORROWS rope+flat in one
+/// clause, then a consuming op on the SAME bindings in the next. Fix: classify `Bytes.compact` CONSUMING
+/// in the dup pass (matching its `StrToBytes` twin + `binding_escapes`) so `rope` is dup'd before the
+/// compact and its later reads see a live handle. Each clause ALONE always worked; only the combo faulted.
+#[test]
+fn bytes_compact_consumes_its_operand_so_a_later_use_of_the_aliased_source_is_dup_guarded() {
+    use crate::testkit::parse;
+    let src = "(module m \
+                 (def (build-rope (: n Int64) (: acc Bytes)) \
+                   (if (> n 0) (build-rope (- n 1) (Bytes.concat acc (Bytes.of (list (UInt8.wrap 65))))) acc)) \
+                 (def (main (: n Int64)) \
+                   (let ((rope (build-rope n (Bytes.of (list))))) \
+                     (let ((flat (Bytes.compact rope))) \
+                       (+ (if (= rope flat) 1 0) \
+                          (* 10 (if (< rope (Bytes.concat flat (Bytes.of (list (UInt8.wrap 66))))) 1 0)))))) \
+                 (export main))";
+    let bytes = compile_component(&crate::codec::encode(&parse(src))).expect("compile");
+    let Some(runtime) = find_runtime_wasm() else {
+        eprintln!("runtime wasm not found (run `cargo xtask build`); skipping composed run");
+        return;
+    };
+    // rope == flat by content (n copies of 'A'), so (= rope flat) = 1; rope < (flat ++ "B") = 1 (a proper
+    // prefix is less), so the value is 1 + 10*1 = 11. Before the fix: n=2 trapped, n=10 OOB'd (UAF on the
+    // aliased handle). n=2 and n=10 both pinned (the corpus pin corpus-bugfix banked at 11/11).
+    for n in ["2", "10"] {
+        let opts = cdz_run::RunOpts {
+            export: Some("main".to_string()),
+            args: vec![n.to_string()],
+            runtime: Some(runtime.clone()),
+            runtime_cache_dir: None,
+            host_responses: Vec::new(),
+        };
+        match cdz_run::run(&bytes, &opts).expect("run") {
+            cdz_run::Outcome::Value(s) => assert_eq!(
+                s, "11",
+                "adv-66 n={n}: = rope flat (1) + 10*(rope < flat++B) (1) = 11; a UAF on the compact-aliased handle would trap/OOB"
+            ),
+            cdz_run::Outcome::Trap(t) => panic!(
+                "adv-66 n={n}: Bytes.compact-aliased handle freed by a later consuming use while still read → UAF trap: {t}"
+            ),
+        }
+    }
+}
+
 /// COMMON-CONSTRUCTOR HOIST: `(if c (Some a) (Some b))` builds the `Some` variant ONCE and pushes the
 /// differing payload into a branchless `(if c a b)` (a scalar `select`), instead of DUPLICATING the
 /// whole `sum-new` construction in both `if`/`else` arms. Structurally: exactly ONE `sum-new`-style


### PR DESCRIPTION
Candidate PR for v-wasm-opt's merge-request (ref 2e328a69cd4782e11a729a9415773f27fd0962c0, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.