### PR TITLE
rcdzc: a monomorphic float-carrying sum gets a custom impl Ord — usable as a BTree* key (rust backend)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/rust/enums.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/enums.rs
@@ -370,10 +370,63 @@ fn emit_one_enum(db: &mut Db, i: usize) -> Result<String, Reject> {
     // consumer of the emitted `.rs` (or the gate's driver) can name the type and its variants. `Clone`
     // so a matched-and-rebuilt value composes; `#[allow(dead_code)]` since a declared-but-unused variant
     // is normal in generated code. Variants are `pub` implicitly (an enum's variants share its visibility).
-    Ok(format!(
+    let enum_decl = format!(
         "#[derive({derives})]\n#[allow(dead_code)]\npub enum {name}{generics} {{ {} }}\n",
         variants.join(", ")
-    ))
+    );
+    // A float-carrying MONOMORPHIC sum (`Ast` — a `Float`+`List Ast` sum) cannot `#[derive(Eq/Ord)]` (f64 is
+    // not `Eq`/`Ord`), so it emits `#[derive(Clone)]` only above. But if it is used as a `BTreeSet`/`BTreeMap`
+    // key/element the collection needs `Ord` (+ `Eq`). For such a sum we emit HAND-WRITTEN
+    // `impl PartialEq/Eq/PartialOrd/Ord` that delegate to `__eq_<Ident>`/`__ord_<Ident>` walk helpers
+    // (float leaf by canonical bits, recursion via the helper's call-indirection — the SAME walks a runtime
+    // `=`/`compare` uses). `sum_is_custom_ord` gates this (monomorphic, float-walkable, no flip-Option). The
+    // helpers are emitted alongside (deduped by name). This makes `BTreeSet<Ast>` instantiable with an order
+    // that agrees byte-for-byte with the wasm value-cmp walk.
+    if crate::backend::rust::expr::sum_is_custom_ord(db, &sentinel_sum_of(&decl)) {
+        let sum_ty = sentinel_sum_of(&decl); // monomorphic → args empty
+        let mut helpers: Vec<String> = Vec::new();
+        // Delegating bodies (also populate `helpers` with the recursive `__eq_`/`__ord_` fns).
+        let eq_body = crate::backend::rust::expr::emit_value_eq_walk(
+            db,
+            &sum_ty,
+            "self",
+            "other",
+            &mut helpers,
+        );
+        let ord_body = crate::backend::rust::expr::emit_value_ord_walk(
+            db,
+            &sum_ty,
+            "self",
+            "other",
+            &mut helpers,
+        );
+        if let (Ok(eq_body), Ok(ord_body)) = (eq_body, ord_body) {
+            let impls = format!(
+                "\n{helpers}\nimpl PartialEq for {name} {{ fn eq(&self, other: &Self) -> bool {{ {eq_body} }} }}\n\
+                 impl Eq for {name} {{}}\n\
+                 impl PartialOrd for {name} {{ fn partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering> {{ core::option::Option::Some(self.cmp(other)) }} }}\n\
+                 impl Ord for {name} {{ fn cmp(&self, other: &Self) -> core::cmp::Ordering {{ {ord_body} }} }}\n",
+                helpers = helpers.join("\n"),
+            );
+            return Ok(format!("{enum_decl}{impls}"));
+        }
+        // A walk declined (an unexpected payload shape) — fall back to the plain enum (Clone only); a use as
+        // a key then declines at the construction site, as before (reject-don't-miscompile).
+    }
+    Ok(enum_decl)
+}
+
+/// The monomorphic-or-sentinel `Ty::Sum` for a declaration — `args` are the sentinel params (empty for a
+/// monomorphic sum). Used to query `sum_is_custom_ord` / drive the eq/ord walk generators for the enum's
+/// hand-written impls.
+fn sentinel_sum_of(decl: &crate::db::TypeDecl) -> crate::ty::Ty {
+    crate::ty::Ty::Sum {
+        decl: decl.occ,
+        name: decl.name.clone(),
+        args: (0..decl.params.len())
+            .map(|k| crate::ty::Ty::Var(PARAM_SENTINEL_BASE + k as u32))
+            .collect(),
+    }
 }
 
 /// Whether some USER (source-node) declaration emits the SAME Rust enum ident as `decl` — i.e. a user

--- a/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
@@ -3171,6 +3171,30 @@ fn ty_float_walkable(db: &mut Db, ty: &Ty) -> bool {
     ty_float_walkable_seen(db, ty, &mut Vec::new())
 }
 
+/// Whether a float-carrying MONOMORPHIC sum can be given a hand-written `impl Ord` (so it is usable as a
+/// `BTreeSet`/`BTreeMap` key) via [`emit_value_ord_walk`]. TRUE iff: it is a `Ty::Sum`; it is NOT already
+/// native-`Ord` (that path derives `Ord` directly — this is only for the ELSE); every payload is
+/// float-walkable (`ty_float_walkable` — the eq/ord walks render exactly this domain); it carries NO
+/// flip-order `Option` (the ord-walk's native-`.cmp()` fast path would give the WRONG order for an Option
+/// leaf — excluded here, declined rather than miscompiled); and it is MONOMORPHIC (no type args — a generic
+/// helper signature is a follow-up). `Ast` (a `Float`+`List Ast` sum, no Option, monomorphic) qualifies.
+pub(super) fn sum_is_custom_ord(db: &mut Db, ty: &Ty) -> bool {
+    let Ty::Sum { args, .. } = ty else {
+        return false;
+    };
+    if !args.is_empty() {
+        return false; // generic — a generic __ord_ helper signature is a follow-up
+    }
+    // Native-Ord sums derive Ord (handled elsewhere); this predicate is only for the float-carrying ELSE.
+    if super::enums::ty_supports_eq(db, ty) {
+        return false;
+    }
+    if ty_uses_flip_order_option(db, ty) {
+        return false; // an Option leaf's native .cmp() order is the reverse of Cadenza's — decline
+    }
+    ty_float_walkable(db, ty)
+}
+
 /// `ty_float_walkable` with a recursion guard for the SUM descent — a self-referential sum (e.g. `Ast` via
 /// `Ast.List (List Ast)`) closes on `seen` so the walk terminates. `emit_value_eq_walk`'s `Ty::Sum` arm
 /// renders EXACTLY this domain (the doc invariant that both backends route the same types).
@@ -3249,7 +3273,7 @@ fn ty_float_walkable_seen(db: &mut Db, ty: &Ty, seen: &mut Vec<crate::ast::Struc
 /// rust_type's element order, which for a record is sorted-key order); a NOMINAL → its inner (the newtype is
 /// transparent). `l`/`r` are already-bound identifiers (or field projections built on them), so re-reading
 /// them per leaf is sound (a projection of a bound value; the enclosing bind is done once by the caller).
-fn emit_value_eq_walk(
+pub(super) fn emit_value_eq_walk(
     db: &mut Db,
     ty: &Ty,
     l: &str,
@@ -3257,6 +3281,226 @@ fn emit_value_eq_walk(
     helpers: &mut Vec<String>,
 ) -> Result<String, Reject> {
     emit_value_eq_walk_seen(db, ty, l, r, &mut Vec::new(), helpers)
+}
+
+/// The ORD twin of [`emit_value_eq_walk`]: build a `core::cmp::Ordering` expression comparing two values of a
+/// FLOAT-CARRYING type (one that is NOT native-`Ord`-derivable — a float leaf makes the derive impossible)
+/// in the blessed lexicographic order, with each float leaf ordered by its CANONICAL BIT FORM (NaN folded to
+/// one form, matching the runtime's canonical-byte float order and `emit_value_eq_walk`'s float arm). Used to
+/// give a float-carrying sum (`Ast`) a hand-written `impl Ord` so it can be a `BTreeSet`/`BTreeMap` key —
+/// `enums.rs` wraps the generated `__ord_<Ident>` helper in the trait impl. Mirrors the eq-walk's shape
+/// (native-`Ord` fast path, tuple/record lexicographic, list element-wise-then-length, sum via a recursive
+/// helper). REQUIRES the type carry no flip-order `Option` (the admission gate ensures this): the native
+/// `.cmp()` fast path for an Option-free native-Ord leaf is then the correct Cadenza order.
+pub(super) fn emit_value_ord_walk(
+    db: &mut Db,
+    ty: &Ty,
+    l: &str,
+    r: &str,
+    helpers: &mut Vec<String>,
+) -> Result<String, Reject> {
+    emit_value_ord_walk_seen(db, ty, l, r, &mut Vec::new(), helpers)
+}
+
+fn emit_value_ord_walk_seen(
+    db: &mut Db,
+    ty: &Ty,
+    l: &str,
+    r: &str,
+    seen: &mut Vec<Ty>,
+    helpers: &mut Vec<String>,
+) -> Result<String, Reject> {
+    // A NATIVELY-`Ord` leaf (Int/Bool/Bytes/String/BigInt/… and any all-`Ord`-DERIVING compound/sum) — a
+    // plain `.cmp()`. Checked FIRST so an `Ord` sub-tree compares in one `.cmp()` rather than being walked;
+    // it is also the ONLY spelling for a map/set leaf the walk does not descend. Gate on `ty_derives_eq`
+    // (the DERIVE condition), NOT `ty_is_ord`: a CUSTOM-ord sum (`Ast`) satisfies `ty_is_ord` but its `.cmp()`
+    // IS this very `__ord_` helper — short-circuiting to `l.cmp(&r)` would recurse forever. Such a sum must
+    // fall through to the `Ty::Sum` walk arm. A flip-order Option would also be wrong here, but the admission
+    // gate (`sum_is_custom_ord`) excludes it. The `&` handles a non-Copy compound.
+    if super::enums::ty_supports_eq(db, ty) {
+        // `ty_supports_eq` = the enum/compound DERIVES Eq (hence Ord) — a native `.cmp()` is the Cadenza
+        // order (BigInt/Rational also reach here and have a total `cmp`). A custom-ord sum is NOT Eq-deriving
+        // (it carries a float), so it does not take this path.
+        return Ok(format!("{l}.cmp(&{r})"));
+    }
+    // BigInt/Rational are `Ord` but not yet `ty_supports_eq`-true — still a native `.cmp()`.
+    if matches!(ty, Ty::BigInt | Ty::Rational) {
+        return Ok(format!("{l}.cmp(&{r})"));
+    }
+    match ty {
+        // A FLOAT leaf — order by the canonical bit pattern (NaN folded to one form), mirroring the eq-walk's
+        // float arm but with `.cmp()` on the bits (a total order over the canonicalized `u{32,64}`). This
+        // matches the runtime's canonical-byte float order (so a float set/map key agrees with wasm).
+        Ty::Float(ft) => {
+            let (canon_nan, bits_ty) = if ft.ground_width() == 32 {
+                ("0x7FC0_0000u32", "u32")
+            } else {
+                ("0x7FF8_0000_0000_0000u64", "u64")
+            };
+            let canon = |v: &str| {
+                format!(
+                    "({{ let __f = {v}; if __f.is_nan() {{ {canon_nan} }} else {{ __f.to_bits() as {bits_ty} }} }})"
+                )
+            };
+            Ok(format!("{}.cmp(&{})", canon(l), canon(r)))
+        }
+        // A TUPLE — lexicographic: compare element 0, and only on `Equal` fall through (`.then_with`).
+        Ty::Tuple(elems) => {
+            let elems = elems.clone();
+            let mut acc: Option<String> = None;
+            for (i, e) in elems.iter().enumerate() {
+                let part = emit_value_ord_walk_seen(
+                    db,
+                    e,
+                    &format!("{l}.{i}"),
+                    &format!("{r}.{i}"),
+                    seen,
+                    helpers,
+                )?;
+                acc = Some(match acc {
+                    None => part,
+                    Some(prev) => format!("{prev}.then_with(|| {part})"),
+                });
+            }
+            Ok(acc.unwrap_or_else(|| "core::cmp::Ordering::Equal".to_string()))
+        }
+        // A RECORD — a tuple in sorted-key order; same lexicographic chain over `.i`.
+        Ty::Record(fields) => {
+            let tys: Vec<Ty> = fields.values().cloned().collect();
+            let mut acc: Option<String> = None;
+            for (i, e) in tys.iter().enumerate() {
+                let part = emit_value_ord_walk_seen(
+                    db,
+                    e,
+                    &format!("{l}.{i}"),
+                    &format!("{r}.{i}"),
+                    seen,
+                    helpers,
+                )?;
+                acc = Some(match acc {
+                    None => part,
+                    Some(prev) => format!("{prev}.then_with(|| {part})"),
+                });
+            }
+            Ok(acc.unwrap_or_else(|| "core::cmp::Ordering::Equal".to_string()))
+        }
+        // A LIST — `Vec<T>` compared element-wise lexicographically, then by length (the derived-`Vec` Ord
+        // shape): the first non-Equal zipped element decides, else compare lengths. Built over bound refs.
+        Ty::List(elem) => {
+            let elem = (**elem).clone();
+            let elem_cmp = emit_value_ord_walk_seen(db, &elem, "__le", "__re", seen, helpers)?;
+            Ok(format!(
+                "{l}.iter().zip({r}.iter()).map(|(__le, __re)| {elem_cmp}).find(|__o| *__o != core::cmp::Ordering::Equal).unwrap_or_else(|| {l}.len().cmp(&{r}.len()))"
+            ))
+        }
+        // A NOMINAL newtype is transparent — walk the inner over the same operands (no projection).
+        Ty::Nominal { inner, .. } => {
+            let inner = (**inner).clone();
+            emit_value_ord_walk_seen(db, &inner, l, r, seen, helpers)
+        }
+        // A Qty erases to its inner magnitude — walk the inner (same operands).
+        Ty::Qty { inner, .. } => {
+            let inner = (**inner).clone();
+            emit_value_ord_walk_seen(db, &inner, l, r, seen, helpers)
+        }
+        // A SUM whose payloads carry a Float/List (so it is NOT native-Ord — that path was taken first).
+        // Compared through a generated recursive helper `fn __ord_<Ident>(l, r) -> Ordering` that matches
+        // `(l, r)`: a same-variant pair compares payloads (lexicographic over the payload walk); a
+        // mismatched pair compares the DECLARED discriminant ORDINALS (Cadenza declared order = the enum
+        // declaration order, which for a monomorphic user sum matches the emitted enum's variant order). The
+        // helper (call-indirection) makes a RECURSIVE sum (`Ast.List (List Ast)`) terminate at runtime —
+        // exactly like the eq-walk's `__eq_<Ident>`. Monomorphic only (a generic re-entry declines).
+        Ty::Sum { decl, args, name } => {
+            let enum_ty = super::types::rust_type(ty)
+                .ok_or_else(|| Reject::decline("sum ord: no rust type for the enum"))?;
+            let fn_name = format!("__ord_{}", super::types::sum_ident(name));
+            let sum_ty = ty.clone();
+            if seen.contains(&sum_ty) {
+                if !args.is_empty() {
+                    return Err(Reject::decline(
+                        "runtime ordering over a RECURSIVE GENERIC sum is not yet rendered by the Rust backend (needs a generic helper fn)",
+                    ));
+                }
+                return Ok(format!("{fn_name}(&{l}, &{r})"));
+            }
+            if !args.is_empty() {
+                return Err(Reject::decline(
+                    "runtime ordering over a GENERIC sum is not yet rendered by the Rust backend (needs a generic helper fn)",
+                ));
+            }
+            seen.push(sum_ty);
+            let variant_count = match db.type_decl_by_occ(*decl).map(|t| t.variants.len()) {
+                Some(n) => n,
+                None => {
+                    seen.pop();
+                    return Err(Reject::decline("sum ord: no variant count"));
+                }
+            };
+            // Same-variant arms compare payloads; the fallthrough compares declared ordinals. `__ord_pos`
+            // maps a ref to its declared position (a small helper match, emitted alongside).
+            let mut same_arms = Vec::with_capacity(variant_count + 1);
+            let mut pos_arms = Vec::with_capacity(variant_count);
+            let mut arm_err: Option<Reject> = None;
+            for disc in 0..variant_count as u32 {
+                let path = match sum_variant_path_of_ty(db, ty, disc) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        arm_err = Some(e);
+                        break;
+                    }
+                };
+                match variant_payload_ty(db, ty, disc) {
+                    None => {
+                        // Nullary — same-variant pair is `Equal`; position arm maps the bare ctor to its disc.
+                        same_arms.push(format!("({path}, {path}) => core::cmp::Ordering::Equal,"));
+                        pos_arms.push(format!("{path} => {disc}u32,"));
+                    }
+                    Some(payload_ty) => {
+                        let deref = if super::enums::variant_is_recursive(db, ty, disc) {
+                            "**"
+                        } else {
+                            "*"
+                        };
+                        let lp = format!("({deref}__lp)");
+                        let rp = format!("({deref}__rp)");
+                        match emit_value_ord_walk_seen(db, &payload_ty, &lp, &rp, seen, helpers) {
+                            Ok(cmp) => {
+                                same_arms.push(format!("({path}(__lp), {path}(__rp)) => {cmp},"));
+                                pos_arms.push(format!("{path}(_) => {disc}u32,"));
+                            }
+                            Err(e) => {
+                                arm_err = Some(e);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            seen.pop();
+            if let Some(e) = arm_err {
+                return Err(e);
+            }
+            // A same-discriminant pair is handled by an arm above; a mismatched pair compares declared
+            // ordinals via the position helper. The `__pos` closure maps each operand to its declared disc.
+            same_arms.push("_ => __pos(l).cmp(&__pos(r)),".to_string());
+            if !helpers
+                .iter()
+                .any(|h| h.contains(&format!("fn {fn_name}(")))
+            {
+                helpers.push(format!(
+                    "#[allow(unused)] fn {fn_name}(l: &{enum_ty}, r: &{enum_ty}) -> core::cmp::Ordering {{ \
+                     fn __pos(v: &{enum_ty}) -> u32 {{ match v {{ {} }} }} \
+                     match (l, r) {{ {} }} }}",
+                    pos_arms.join(" "),
+                    same_arms.join(" ")
+                ));
+            }
+            Ok(format!("{fn_name}(&{l}, &{r})"))
+        }
+        _ => Err(Reject::decline(
+            "runtime ordering over this compound is not yet rendered by the Rust backend",
+        )),
+    }
 }
 
 /// [`emit_value_eq_walk`] with a `seen` set of sum decls currently being expanded (the recursion guard that

--- a/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
@@ -1463,7 +1463,7 @@ fn rustc_roundtrip_map_and_set_compute_and_enumerate_in_order() {
 }
 
 #[test]
-fn a_bare_float_set_or_map_uses_cdz_f64_but_float_carrying_sum_declines() {
+fn a_bare_float_set_or_map_uses_cdz_f64_and_a_monomorphic_float_carrying_sum_gets_a_custom_ord() {
     // A `Set`/`Map` of a BARE FLOAT now COMPILES via the `CdzF64` total-order wrapper (a raw `f64` is only
     // `PartialOrd`; `CdzF64` orders by canonical bits, NaN-canonical — mirroring the runtime's `box-float`).
     // (WAS a decline — the "no BTreeSet<f64>" era, before the wrapper.) The float-insert into an EMPTY set is
@@ -1492,26 +1492,36 @@ fn a_bare_float_set_or_map_uses_cdz_f64_but_float_carrying_sum_declines() {
         "an Int-element Set still emits a BTreeSet:\n{set_int}"
     );
 
-    // FOLLOW-ON (Copilot PR#455): a sum CARRYING A FLOAT is one type-shape past a bare float key — its
-    // emitted enum derives no `Ord` (a float payload isn't `Eq`/`Ord`), so a `Set<Enum>`/`Map<Enum,_>`
-    // is still uncompilable. The old `ty_is_ord` returned `true` for EVERY `Ty::Sum` (comment claimed the
-    // enum-derive path caught it — but that's a rustc COMPILE ERROR, not the clean decline). Both the
-    // VALUE path (a construction op) and the TYPE-POSITION path (a param `(Set W)`, no construction op —
-    // caught by the `sum_representable` gate) must decline.
-    let sum_float_set_val = compile_rust_result(
+    // FOLLOW-ON (float-carrying-sum Ord-key): a MONOMORPHIC sum CARRYING A FLOAT is one type-shape past a
+    // bare float key. Its emitted enum can't `#[derive(Ord)]` (a float payload isn't `Eq`/`Ord`), so it
+    // NOW gets a HAND-WRITTEN `impl Ord` (delegating to a `__ord_<Ident>` walk that orders the float leaf by
+    // canonical bits) — making `Set<W>`/`Map<W,_>` compilable with an order that agrees with wasm. (This
+    // REVERSES the old decline: `ty_is_ord`'s Sum arm now admits a `sum_is_custom_ord` sum.) Both the VALUE
+    // path (a construction op) and the TYPE-POSITION path (a `(Set W)` param) now EMIT.
+    let sum_float_set_val = compile_rust(
         "(module m (type W (F Float64) (G)) \
            (def (main (: d Float64)) (Set.len (Set.of (list ((. W F) d))))) (export main))",
     );
     assert!(
-        sum_float_set_val.is_err(),
-        "a Set of a float-carrying sum (value) must DECLINE, got:\n{sum_float_set_val:?}"
+        sum_float_set_val.contains("impl Ord for W") && sum_float_set_val.contains("BTreeSet<W>"),
+        "a Set of a float-carrying sum (value) now emits a custom impl Ord + BTreeSet<W>:\n{sum_float_set_val}"
     );
-    let sum_float_set_param = compile_rust_result(
+    let sum_float_set_param = compile_rust(
         "(module m (type W (F Float64) (G)) (def (main (: s (Set W))) (Set.len s)) (export main))",
     );
     assert!(
-        sum_float_set_param.is_err(),
-        "a (Set W) PARAM where W carries a float must DECLINE (no BTreeSet<W>), got:\n{sum_float_set_param:?}"
+        sum_float_set_param.contains("BTreeSet<W>")
+            && sum_float_set_param.contains("impl Ord for W"),
+        "a (Set W) PARAM where W carries a float now emits BTreeSet<W> + custom impl Ord:\n{sum_float_set_param}"
+    );
+    // CONTROL: a GENERIC float-carrying sum still DECLINES as a key (a generic `__ord_` helper signature is
+    // a follow-up) — `sum_is_custom_ord` is monomorphic-only.
+    let generic_float_sum_set = compile_rust_result(
+        "(module m (type W a (F Float64 a) (G)) (def (main (: s (Set (W Int64)))) (Set.len s)) (export main))",
+    );
+    assert!(
+        generic_float_sum_set.is_err(),
+        "a (Set (W Int64)) where generic W carries a float must still DECLINE (monomorphic-only), got:\n{generic_float_sum_set:?}"
     );
     // CONTROL: an ALL-NULLARY sum (its enum DOES derive Ord) is a valid Set element/key — the fix is
     // Ord-derivability-specific, not "decline every sum key".
@@ -5328,6 +5338,36 @@ fn char_literal_escapes_c1_controls_not_just_c0() {
         assert_eq!(
             out, "133",
             "U+0085 round-trips through generated Rust as scalar 133"
+        );
+    }
+}
+
+#[test]
+fn rustc_float_carrying_sum_keys_a_set_via_a_custom_ord_impl() {
+    // A FLOAT-CARRYING sum (`Ast`, which has a `Float Float64` variant) cannot `#[derive(Eq/Ord)]` (f64 is
+    // not Eq/Ord), so it emits `#[derive(Clone)]` only — and previously could NOT be a `BTreeSet` element /
+    // `BTreeMap` key (the Set/Map construction declined "non-Ord element ... no BTreeSet rep"). Now the
+    // backend emits a HAND-WRITTEN `impl PartialEq/Eq/PartialOrd/Ord for Ast` delegating to `__eq_Ast` /
+    // `__ord_Ast` walk helpers (float leaf by canonical bits, recursion via the helper). So a set of quoted
+    // Asts dedups by structural content. `(quote (+ 1 2))` twice + `(quote (* 1 2))` once → 2 distinct.
+    let src = "(module m (def (go (: n Int64)) \
+        (Set.len (Set.of (list (quote (+ 1 2)) (quote (+ 1 2)) (quote (* 1 2)))))) (export go))";
+    let rs = compile_rust(src);
+    assert!(
+        rs.contains("impl Ord for Ast") && rs.contains("__ord_Ast"),
+        "a float-carrying sum used as a Set element emits a custom impl Ord + __ord_ helper:\n{rs}"
+    );
+    // partial_cmp must FULLY-QUALIFY `Option` (`core::option::Option`) — a user `(type Option …)` in the
+    // same module would otherwise shadow std's and the `-> Option<Ordering>` return would resolve to the
+    // 0-generic user enum (E0107). Pin the qualified spelling so that regression can't recur.
+    assert!(
+        rs.contains("-> core::option::Option<core::cmp::Ordering>"),
+        "partial_cmp fully-qualifies core::option::Option (user-Option-shadow safety):\n{rs}"
+    );
+    if let Some(out) = rustc_run(&rs, "go(0)") {
+        assert_eq!(
+            out, "2",
+            "a set of quoted Asts dedups by structural content: 2 distinct"
         );
     }
 }

--- a/implementation/seed/crates/rcdzc/src/backend/rust/types.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/types.rs
@@ -336,13 +336,21 @@ pub(super) fn ty_is_ord(db: &mut Db, ty: &Ty) -> bool {
         Ty::Nominal { inner, .. } => ty_is_ord(db, inner),
         Ty::List(e) | Ty::Set(e) => ty_is_ord(db, e),
         Ty::Map(k, v) => ty_is_ord(db, k) && ty_is_ord(db, v),
-        // A SUM/NOMINAL is orderable iff its enum derives `Ord` = iff it derives `Eq` — the Db-aware check
-        // that closes the float-carrying-sum hole (the whole point of this fix).
-        Ty::Sum { .. } => crate::backend::rust::enums::ty_derives_eq(
-            db,
-            ty,
-            &mut std::collections::HashSet::new(),
-        ),
+        // A SUM is orderable if EITHER (a) its enum derives `Ord` (= derives `Eq`; the native path), OR
+        // (b) it is a float-carrying MONOMORPHIC sum we give a hand-written `impl Ord` via a `__ord_<Ident>`
+        // walk (`sum_is_custom_ord` — e.g. `Ast`, a `Float`+`List Ast` sum used as a Set element / Map key).
+        // The custom-impl branch orders the float leaf by canonical bits (matching wasm's value-cmp order),
+        // so the `BTreeSet<Ast>`/`BTreeMap<Ast, _>` is instantiable and its order agrees cross-backend. NOTE:
+        // `sum_is_custom_ord` re-checks `ty_supports_eq` (native path) FIRST and returns false there, so the
+        // two branches are disjoint and there is no double-count; a float-carrying sum with a flip-Option or
+        // generic args still declines (neither branch admits it).
+        Ty::Sum { .. } => {
+            crate::backend::rust::enums::ty_derives_eq(
+                db,
+                ty,
+                &mut std::collections::HashSet::new(),
+            ) || crate::backend::rust::expr::sum_is_custom_ord(db, ty)
+        }
         // Every other representable type (Int/Bool/Unit/Char/String/Bytes and the NUMERIC BigInt/Rational,
         // which have a total order) maps to an `Ord` Rust type. A non-representable type declines earlier.
         _ => true,

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5501,7 +5501,7 @@ pass	wrapping-sub wraps a boundary-crossing runtime Int64 at the min boundary
 pass	zero divided by a runtime value folds to zero but keeps the zero-divisor guard
 pass	α-equivalence (aconv) recognizes (λx.x) and (λy.y) as the same term up to bound-variable renaming
 pass	α-equivalence handles nesting and distinguishes a bound variable from a same-numbered free variable
-todo	Ast values key a map across quote and Ast.* construction routes
+pass	Ast values key a map across quote and Ast.* construction routes
 todo	Set.of over runtime lists at two different element types declines pending the recursive-generic tie
 todo	Type is a first-class value
 pass	a DRAINED set compares equal to the literal empty set — removal restores the canonical empty rep
@@ -5527,7 +5527,7 @@ todo	a runtime bin match decodes a FINAL constant-size utf8 segment
 todo	a runtime-DISC `?` inside a stored closure applies per-call once BRICK 3b lands
 todo	a runtime-operand try as a list element declines pending brick 3b
 pass	an @param of a Float64 type generates a Float64-typed accessor
-todo	an Ast as a MAP key looks up by structural content
+pass	an Ast as a MAP key looks up by structural content
 todo	an abortive perform in a recursive callee with a PENDING continuation in the handle body abandons it
 pass	an entrypoint delegation lets a program reach its host function
 pass	an entrypoint delegation reaches an effect performed in a recursive callee
@@ -5544,7 +5544,7 @@ pass	host calls are observed in the order they were made
 pass	let bindings' initializers are evaluated in binding order
 pass	or performs the right operand's effect when the left is false
 pass	or short-circuit does not perform the right operand's effect
-todo	quoted Asts as SET elements dedup by structural content
+pass	quoted Asts as SET elements dedup by structural content
 todo	read of malformed text is a coded reject, not a wrong value
 todo	round-trip: a HIGHER-ORDER closure arg composed with a SUM result
 todo	round-trip: a HIGHER-ORDER closure — its argument is itself a closure built in-guest


### PR DESCRIPTION
Candidate PR for v-rust-backend's merge-request (ref b528144aa, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.