### PR TITLE
rcdzc(effects): host-arg Bytes scaffolding — HostParam::Bytes variant + list<u8>-index-threaded functype (gate-neutral foundation)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/wasm/host.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/host.rs
@@ -34,6 +34,13 @@ pub enum HostParam {
     Scalar(AbiValType),
     /// A `string` parameter — its component valtype is `string`; its core form is `(ptr: i32, len: i32)`.
     Str,
+    /// A `list<u8>` (Cadenza `Bytes`) parameter — its component valtype is the shared `(list u8)` DEFINED
+    /// type (referenced by index within the import instance-type, unlike `string`'s inline primitive), and
+    /// its core form is `(ptr: i32, len: i32)` — IDENTICAL to `Str` at the core level (the guest copies the
+    /// rope bytes into shared `mem` and passes `(ptr,len)`; the canon `Lower` reads them via `Memory(0)`,
+    /// no realloc for an argument). Only the COMPONENT boundary type differs (list<u8> vs string). adv-62b's
+    /// sibling: closes the wasm-vs-rust reverse-parity gap where a runtime Bytes host-arg declined.
+    Bytes,
 }
 
 /// One host-delegated operation the program performs — its declaring effect's NAME (the WIT interface),

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/mod.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/mod.rs
@@ -888,7 +888,7 @@ pub fn emit(
             .iter()
             .map(|h| envelope::HostFn {
                 op: h.op.clone(),
-                comp_functype: host_op_comp_functype(h),
+                comp_functype: host_op_comp_functype(h, 0),
                 core_functype: Vec::new(), // unused by the envelope (the core module builds its own)
             })
             .collect();
@@ -1328,7 +1328,7 @@ fn collect_cont_host_arg_strings(db: &mut Db, cont: &crate::core::SumCont, out: 
     }
 }
 
-fn host_op_comp_functype(h: &host::HostImport) -> Vec<u8> {
+fn host_op_comp_functype(h: &host::HostImport, list_type_idx: u32) -> Vec<u8> {
     use host::HostParam;
     let mut item = vec![wasm_abi::COMP_FUNCTYPE_FORM];
     let mut param_items = Vec::new();
@@ -1336,10 +1336,18 @@ fn host_op_comp_functype(h: &host::HostImport) -> Vec<u8> {
         let pname = format!("p{i}");
         param_items.extend_from_slice(&(pname.len() as u8).to_le_bytes());
         param_items.extend_from_slice(pname.as_bytes());
-        param_items.push(match p {
-            HostParam::Scalar(v) => v.comp_byte(),
-            HostParam::Str => wasm_abi::COMP_STRING,
-        });
+        match p {
+            // A SCALAR / STRING param is an INLINE primitive valtype byte.
+            HostParam::Scalar(v) => param_items.push(v.comp_byte()),
+            HostParam::Str => param_items.push(wasm_abi::COMP_STRING),
+            // A `list<u8>` (Bytes) param references the shared `(list u8)` DEFINED type by its
+            // instance-type-local INDEX (uleb128), NOT an inline byte — mirrors the export-side
+            // `comp_functype`'s `BoundaryResult::Bytes` result encoding (`envelope::comp_functype`). The
+            // caller prepends `list_u8_defined_type()` to the import instance-type and passes its index as
+            // `list_type_idx`; `0` is a safe placeholder while no host set produces a Bytes param yet
+            // (`collect_host_imports` does not push `HostParam::Bytes` until the emit brick).
+            HostParam::Bytes => encode::uleb128(list_type_idx as u64, &mut param_items),
+        }
     }
     item.extend_from_slice(&encode::wasm_vec(h.params.len(), &param_items));
     match h.result {
@@ -1357,7 +1365,9 @@ fn host_op_comp_functype(h: &host::HostImport) -> Vec<u8> {
 fn host_param_abi(p: &host::HostParam) -> Option<runtime_abi::AbiValType> {
     match p {
         host::HostParam::Scalar(v) => Some(*v),
-        host::HostParam::Str => None,
+        // Str and Bytes both use the `(ptr,len)` shared-memory shape, which has no scalar peer-ABI form —
+        // a String/Bytes-param PEER op declines this increment (the host-arg support is host-only).
+        host::HostParam::Str | host::HostParam::Bytes => None,
     }
 }
 
@@ -2103,7 +2113,7 @@ fn emit_runtime_resource(
             .iter()
             .map(|hi| envelope::HostFn {
                 op: hi.op.clone(),
-                comp_functype: host_op_comp_functype(hi),
+                comp_functype: host_op_comp_functype(hi, 0),
                 core_functype: Vec::new(),
             })
             .collect();
@@ -3883,7 +3893,7 @@ fn emit_closure_host_resource(
         .iter()
         .map(|hi| envelope::HostFn {
             op: hi.op.clone(),
-            comp_functype: host_op_comp_functype(hi),
+            comp_functype: host_op_comp_functype(hi, 0),
             core_functype: Vec::new(),
         })
         .collect();
@@ -7041,7 +7051,7 @@ fn emit_runtime_bytes_resource(
             .iter()
             .map(|hi| envelope::HostFn {
                 op: hi.op.clone(),
-                comp_functype: host_op_comp_functype(hi),
+                comp_functype: host_op_comp_functype(hi, 0),
                 core_functype: Vec::new(),
             })
             .collect();
@@ -7338,7 +7348,7 @@ fn emit_runtime_sum_resource(
             .iter()
             .map(|hi| envelope::HostFn {
                 op: hi.op.clone(),
-                comp_functype: host_op_comp_functype(hi),
+                comp_functype: host_op_comp_functype(hi, 0),
                 core_functype: Vec::new(),
             })
             .collect();
@@ -7590,7 +7600,7 @@ fn emit_recursive_sum_resource(
             .iter()
             .map(|hi| envelope::HostFn {
                 op: hi.op.clone(),
-                comp_functype: host_op_comp_functype(hi),
+                comp_functype: host_op_comp_functype(hi, 0),
                 core_functype: Vec::new(),
             })
             .collect();

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/serialize.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/serialize.rs
@@ -59,14 +59,24 @@ fn host_import_functype(f: &crate::backend::wasm::host::HostImport) -> Vec<u8> {
     for p in &f.params {
         match p {
             HostParam::Scalar(v) => params.push(v.core_byte()),
-            HostParam::Str => params.extend_from_slice(&[wasm_abi::CORE_I32, wasm_abi::CORE_I32]),
+            // Str AND Bytes both cross as `(ptr: i32, len: i32)` at the CORE level — 2 i32 slots. (Only the
+            // COMPONENT boundary type differs: string inline vs a `list<u8>` type-index; see mod.rs.)
+            HostParam::Str | HostParam::Bytes => {
+                params.extend_from_slice(&[wasm_abi::CORE_I32, wasm_abi::CORE_I32])
+            }
         }
     }
-    // A string param is 2 core slots, so count the total slots (not the param count).
+    // A string/bytes param is 2 core slots, so count the total slots (not the param count).
     let slot_count = f
         .params
         .iter()
-        .map(|p| if matches!(p, HostParam::Str) { 2 } else { 1 })
+        .map(|p| {
+            if matches!(p, HostParam::Str | HostParam::Bytes) {
+                2
+            } else {
+                1
+            }
+        })
         .sum::<usize>();
     item.extend_from_slice(&wasm_vec(slot_count, &params));
     match f.result {


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref c07bbeca9f7be5df94e6d6e79a0d028f5ebb572d, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.