### PR TITLE
rcdzc: a record-pattern absent field reports ONE diagnostic, not a redundant CDZ0212 twin

### DIFF
--- a/implementation/seed/crates/rcdzc/src/infer.rs
+++ b/implementation/seed/crates/rcdzc/src/infer.rs
@@ -12297,6 +12297,23 @@ fn collect_node(db: &mut Db, id: StructId, out: &mut Vec<Reject>) {
         //= spec/capabilities/core-semantics.md#member-access-projects-a-record-field
         //# Member access naming a field the record does not contain MUST be rejected at compile time with the machine-readable code for a required field that is absent rather than produce an unspecified value or a runtime trap, so that a projection cannot name a field the operand's type never held.
         Resolved::Member { operand, key } => {
+            // A record-PATTERN field binder's arm-BODY reference resolves to this same `Member` shape:
+            // `((record (nope a)) a)` — the body `a` resolves (Case 6rec) to `Member{operand: scrutinee,
+            // key: nope}`, a PROJECTION of the matched value at the pattern's field. When `nope` is absent
+            // from the scrutinee's record, the canonical, richer CDZ0201 "a record pattern names field
+            // `nope`, which the matched value of type … does not have" ALREADY fires at the pattern
+            // (`lower.rs`), so a generic "record has no field `nope`" (CDZ0212) here is a REDUNDANT second
+            // diagnostic for one error. Distinguish this synthesized-Member body-ref from a genuine member
+            // ACCESS syntactically: a real `(. operand key)` is a LIST form, whereas a pattern-binder ref is
+            // a BARE NAME atom that merely RESOLVED to a Member. Skip the member no-field fault for a bare
+            // name — the pattern-lowering reject stays the sole primary. (Node-syntactic + safe: a genuine
+            // `(. …)` access on any record keeps its own reject, incl. a distinct absent field of the same
+            // name on another record; only the pattern binder's bare-name ref is suppressed. v-patterns
+            // traced this to the body-ref — the pattern-position binder is not the source, so a
+            // pattern-position or dedup-node key would miss it; the bare-name test at this fault site does.)
+            if db.ast.as_name(id).is_some() {
+                return;
+            }
             // Project via the evaluator (reduces refs / a ctor-built module), so a missing field on a
             // built module is caught too. A poison operand reports its OWN fault (via the descent
             // below), so we don't add a redundant "not a record" for it.

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -3917,6 +3917,26 @@ fn a_record_match_pattern_faults_are_actionable_and_lockstep() {
     )))
     .expect_err("absent field rejects");
     assert_eq!(absent.code.as_deref(), Some("CDZ0201"));
+    // SINGLE diagnostic — no redundant CDZ0212. The arm BODY's reference to the field binder `a` resolves
+    // (Case 6rec) to a Member projection of the scrutinee at `nope`; when `nope` is absent that Member used
+    // to ALSO fire a generic "record has no field `nope`" (CDZ0212) at the bare-name body-ref, double-
+    // reporting one error. `no_field_reject`'s Member arm now suppresses the fault for a BARE-NAME node (a
+    // pattern-binder ref, vs a genuine `(. …)` access), so the canonical pattern CDZ0201 is the sole primary.
+    let diags = crate::host::run_with_compiler_stack(|| {
+        crate::diagnostics(&mut crate::db::Db::load(parse(
+            "(module m (def (main) (match (record (x 3)) ((record (nope a)) a))) (export main))",
+        )))
+    });
+    let field_faults: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("field `nope`"))
+        .collect();
+    assert_eq!(
+        field_faults.len(),
+        1,
+        "one primary for an absent record-pattern field (the pattern CDZ0201), no redundant member CDZ0212: {field_faults:?}"
+    );
+    assert_eq!(field_faults[0].code.as_deref(), Some("CDZ0201"));
     // nested compound field value → clean decline, NOT CDZ0101
     let nested = compile_component(&crate::codec::encode(&parse(
         "(module m (def (main) \


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref 325ff49db720abce5dcf5281c3e07dd46304632b, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.