### PR TITLE
cdz-agent-host: fix stale "by kind" executor-routing comments (fix-forward on PR #1620 review)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -1,7 +1,7 @@
 //! The agent HOST — assembles the kernel building blocks into a process that RUNS agents.
 //!
 //! This is the milestone the crate exists for: the kernel provides a `Session` (log + KV + the durable
-//! dispatch/fold loop), a reducer, a `CompositeExecutor` that routes effects by kind, and an `Authorize`
+//! dispatch/fold loop), a reducer, a `CompositeExecutor` that routes effects by family string, and an `Authorize`
 //! gate. Individually those are library pieces. [`AgentHost`] is what *assembles* them into a live,
 //! long-running host: it holds a **registry** of running sessions keyed by id, and for each one owns the
 //! Session plus the reducer / authorizer / executor that drive it. Delivering an inbound event to a
@@ -58,7 +58,7 @@ pub struct HostedSession {
 
 impl HostedSession {
     /// Start a fresh session from a genesis reducer hash, with its executor set + authorizer. The
-    /// `reducer` drives folds; `executor` (a by-kind [`CompositeExecutor`]) performs authorized effects;
+    /// `reducer` drives folds; `executor` (a by-family-string [`CompositeExecutor`]) performs authorized effects;
     /// `authz` gates them (SEC-F1). This is the assembly point — real executors (Now/Model/Http) go into
     /// `executor`, a real policy into `authz`.
     ///

--- a/implementation/seed/crates/cdz-agent-host/tests/agent_runs_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/agent_runs_e2e.rs
@@ -82,7 +82,8 @@ fn now_cap() -> Authorizer {
 async fn agent_loop_runs_end_to_end_through_the_real_clock_executor() {
     let reducer = ClockAgent;
     let authz = now_cap();
-    // The real executor, wired by kind exactly as the Bedrock Model executor will be alongside it.
+    // The real executor, registered by canonical family string exactly as the Bedrock Model executor
+    // will be alongside it.
     let mut exec =
         CompositeExecutor::new().with_effect(effect_ct::NOW, Box::new(ClockExecutor::new()));
     let mut session = Session::genesis(Hash::of(b"clock-agent-v1"));


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 8b93253bd, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.