### PR TITLE
rcdzc(effects): wasm host-ARG Bytes crosses as list<u8> — closes the wasm-vs-rust reverse-parity gap (Brick 2, behavior)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/wasm/envelope.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/envelope.rs
@@ -646,11 +646,19 @@ pub fn assemble_provider_runtime(
 pub struct HostFn {
     pub op: String,
     /// The op's component functype item bytes (`0x40 …`) — declared in the effect's instance-type AND
-    /// (re)used for the core import functype indirectly via the lowered form.
+    /// (re)used for the core import functype indirectly via the lowered form. When `has_list_param` is
+    /// true, this functype references the shared `(list u8)` DEFINED type by INDEX (built with
+    /// `host_op_comp_functype(h, 0)` — index 0 is the list type the instance-type prepends).
     pub comp_functype: Vec<u8>,
     /// The op's CORE functype item bytes (`0x60 <params> <results>`) — the type the program's core module
     /// imports the lowered op under. Built by the caller from the op's core valtypes.
     pub core_functype: Vec<u8>,
+    /// Whether this op has a `list<u8>` (Bytes) parameter. When ANY host fn in the set does, the import
+    /// instance-type PREPENDS a `(list u8)` defined type as its type index 0 (so a Bytes param's
+    /// `comp_functype` reference resolves) and the per-op func types shift to 1..=h — the export decls
+    /// reference `i+1`. A pure scalar/string set (`has_list_param` false for all) is byte-identical (no
+    /// prepend, func types 0..h). See `list_u8_defined_type` + the export-side `comp_functype` mirror.
+    pub has_list_param: bool,
 }
 
 /// The HOST-IMPORT shape (E2h-2): a program that DELEGATES a single effect `iface` to the host, importing
@@ -1374,22 +1382,7 @@ pub fn assemble_host_runtime(
     // sec 7: TWO instance-types — component type 0 (the effect) then component type 1 (the runtime). Each
     // is `0x42` + a vec of 2*count interleaved (ty, export) decls, exactly as the single-import shapes.
     let type_sec = {
-        let host_it = {
-            let mut decls = Vec::new();
-            for (i, f) in host_fns.iter().enumerate() {
-                decls.push(0x01);
-                decls.extend_from_slice(&f.comp_functype);
-                decls.push(0x04);
-                decls.extend_from_slice(&extern_name(
-                    &crate::backend::common::export_name::kebab_extern_name(&f.op),
-                ));
-                decls.push(0x01);
-                uleb128(i as u64, &mut decls);
-            }
-            let mut it = vec![0x42];
-            it.extend_from_slice(&wasm_vec(2 * h, &decls));
-            it
-        };
+        let host_it = host_effect_instance_type(host_fns);
         let rt_it = {
             let mut decls = Vec::new();
             for (i, op) in imports.iter().enumerate() {
@@ -1587,22 +1580,7 @@ pub fn assemble_host_runtime_mem(
     // sec 7: TWO instance-types — host effect (comp type 0) then runtime (comp type 1) — identical to the
     // memoryless host+runtime shape (the shared memory is a CORE detail, invisible to the component types).
     let type_sec = {
-        let host_it = {
-            let mut decls = Vec::new();
-            for (i, f) in host_fns.iter().enumerate() {
-                decls.push(0x01);
-                decls.extend_from_slice(&f.comp_functype);
-                decls.push(0x04);
-                decls.extend_from_slice(&extern_name(
-                    &crate::backend::common::export_name::kebab_extern_name(&f.op),
-                ));
-                decls.push(0x01);
-                uleb128(i as u64, &mut decls);
-            }
-            let mut it = vec![0x42];
-            it.extend_from_slice(&wasm_vec(2 * h, &decls));
-            it
-        };
+        let host_it = host_effect_instance_type(host_fns);
         let rt_it = {
             let mut decls = Vec::new();
             for (i, op) in imports.iter().enumerate() {
@@ -2640,22 +2618,7 @@ pub fn assemble_host_runtime_resource(
     // sec 7: TWO instance-types — the host effect (comp type 0, its h ops) then the runtime (comp type 1,
     // its k ops).
     let type_sec = {
-        let host_it = {
-            let mut decls = Vec::new();
-            for (i, f) in host_fns.iter().enumerate() {
-                decls.push(0x01);
-                decls.extend_from_slice(&f.comp_functype);
-                decls.push(0x04);
-                decls.extend_from_slice(&extern_name(
-                    &crate::backend::common::export_name::kebab_extern_name(&f.op),
-                ));
-                decls.push(0x01);
-                uleb128(i as u64, &mut decls);
-            }
-            let mut it = vec![0x42];
-            it.extend_from_slice(&wasm_vec(2 * h, &decls));
-            it
-        };
+        let host_it = host_effect_instance_type(host_fns);
         let rt_it = {
             let mut decls = Vec::new();
             for (i, op) in imports.iter().enumerate() {
@@ -3433,22 +3396,7 @@ pub fn assemble_host_runtime_resource_with_scalar_methods(
 
     // sec 7: TWO instance-types — the host effect (comp type 0, its h ops) then the runtime (comp type 1).
     let type_sec = {
-        let host_it = {
-            let mut decls = Vec::new();
-            for (i, f) in host_fns.iter().enumerate() {
-                decls.push(0x01);
-                decls.extend_from_slice(&f.comp_functype);
-                decls.push(0x04);
-                decls.extend_from_slice(&extern_name(
-                    &crate::backend::common::export_name::kebab_extern_name(&f.op),
-                ));
-                decls.push(0x01);
-                uleb128(i as u64, &mut decls);
-            }
-            let mut it = vec![0x42];
-            it.extend_from_slice(&wasm_vec(2 * h, &decls));
-            it
-        };
+        let host_it = host_effect_instance_type(host_fns);
         let rt_it = {
             let mut decls = Vec::new();
             for (i, op) in imports.iter().enumerate() {
@@ -9090,6 +9038,39 @@ fn memory_alias_item(instance: u32, name: &str) -> Vec<u8> {
 /// `wasm-encoder` does not expose as a constant, pinned by the R0 byte-identity oracle.
 fn list_u8_defined_type() -> Vec<u8> {
     vec![0x70, wasm_abi::COMP_U8]
+}
+
+/// Build the HOST-effect import instance-type (`0x42 <decls>`) from `host_fns`. Each op is a `ty` decl
+/// (`01 <comp_functype>`) + an `export` decl (`04 <name> 01 <func-type-index>`). When ANY op has a
+/// `list<u8>` (Bytes) parameter (`has_list_param`), PREPEND a `(list u8)` defined type as instance-type
+/// type index 0 — a Bytes param's `comp_functype` references it by index 0 — and the per-op func types
+/// then occupy indices `1..=h`, so each export decl references `base + i` where `base = 1`. A pure
+/// scalar/string set (no Bytes param) takes `base = 0`, no prepend, `2*h` decls — byte-identical to the
+/// pre-Bytes shape. Shared by every host-import assembly variant so the prepend/shift is defined once.
+fn host_effect_instance_type(host_fns: &[HostFn]) -> Vec<u8> {
+    let h = host_fns.len();
+    let needs_list = host_fns.iter().any(|f| f.has_list_param);
+    let mut decls = Vec::new();
+    // The prepended `(list u8)` type is a bare `ty` decl (`01 <deftype>`) → instance-type type index 0.
+    if needs_list {
+        decls.push(0x01);
+        decls.extend_from_slice(&list_u8_defined_type());
+    }
+    let base: u64 = if needs_list { 1 } else { 0 };
+    for (i, f) in host_fns.iter().enumerate() {
+        decls.push(0x01);
+        decls.extend_from_slice(&f.comp_functype);
+        decls.push(0x04);
+        decls.extend_from_slice(&extern_name(
+            &crate::backend::common::export_name::kebab_extern_name(&f.op),
+        ));
+        decls.push(0x01); // sort: component func
+        uleb128(base + i as u64, &mut decls);
+    }
+    let decl_count = if needs_list { 2 * h + 1 } else { 2 * h };
+    let mut it = vec![0x42]; // instance type form
+    it.extend_from_slice(&wasm_vec(decl_count, &decls));
+    it
 }
 
 /// The sec-7 defined-type item for a component `tuple<vt0, vt1, …>`: `6f <count> <vt>*` — the component-

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/host.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/host.rs
@@ -341,6 +341,11 @@ fn collect_host_imports_at(db: &mut Db, id: StructId, out: &mut Vec<HostImport>)
                 match &at {
                     Ty::Unit => {}
                     Ty::String if !peer_bound => params.push(HostParam::Str),
+                    // A runtime `Bytes` arg crosses as `list<u8>` — the (ptr,len) shared-memory shape (same
+                    // core form as String, distinct component type). Closes the wasm-vs-rust reverse-parity
+                    // gap where a Bytes host-arg declined on wasm. A PEER-bound Bytes crosses as a heap
+                    // handle (`extern_abi_val_type` in the `_` arm below), not this host-boundary list<u8>.
+                    Ty::Bytes if !peer_bound => params.push(HostParam::Bytes),
                     _ => {
                         let v = if peer_bound {
                             extern_abi_val_type(&at)
@@ -663,9 +668,13 @@ pub fn host_import_index(imports: &[HostImport], effect: &str, op: &str) -> Opti
 /// shared-memory module + a Memory canon-option on each string op's lower. A scalar-only host set needs no
 /// memory (byte-identical to the E2h-2 scalar shape).
 pub fn set_needs_memory(imports: &[HostImport]) -> bool {
-    imports
-        .iter()
-        .any(|h| h.params.iter().any(|p| matches!(p, HostParam::Str)))
+    // A Str OR Bytes param crosses as `(ptr,len)` read out of the program's linear memory, so either
+    // requires the shared-memory core module + the canon `Lower`'s `Memory(0)` option.
+    imports.iter().any(|h| {
+        h.params
+            .iter()
+            .any(|p| matches!(p, HostParam::Str | HostParam::Bytes))
+    })
 }
 
 /// The first host operation the subtree at `id` performs whose BOUNDARY SIGNATURE this increment cannot
@@ -724,11 +733,16 @@ pub fn first_unrepresentable_host_op(
         if !matches!(result, Ty::Unit) && !ty_undetermined(&result) && !abi_ok(&result) {
             return Some((op, "result", result.render_name()));
         }
-        // Each ARGUMENT: emittable iff Unit, String, or (peer-bound) a handle-crossable value / (host) a
-        // scalar. An undetermined arg type (a synthesized node) is skipped for the same reason as the result.
+        // Each ARGUMENT: emittable iff Unit, String, Bytes, or (peer-bound) a handle-crossable value /
+        // (host) a scalar. A `Bytes` arg now crosses as `list<u8>` at the host boundary (the `(ptr,len)`
+        // shared-memory shape, same as String), so it is emittable — no longer a deferred compound. An
+        // undetermined arg type (a synthesized node) is skipped for the same reason as the result.
         for &a in &args {
             let at = crate::infer::type_of(db, a);
-            if !matches!(at, Ty::Unit | Ty::String) && !ty_undetermined(&at) && !abi_ok(&at) {
+            if !matches!(at, Ty::Unit | Ty::String | Ty::Bytes)
+                && !ty_undetermined(&at)
+                && !abi_ok(&at)
+            {
                 return Some((op, "argument", at.render_name()));
             }
         }

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/mod.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/mod.rs
@@ -889,6 +889,7 @@ pub fn emit(
             .map(|h| envelope::HostFn {
                 op: h.op.clone(),
                 comp_functype: host_op_comp_functype(h, 0),
+                has_list_param: h.params.iter().any(|p| matches!(p, host::HostParam::Bytes)),
                 core_functype: Vec::new(), // unused by the envelope (the core module builds its own)
             })
             .collect();
@@ -971,7 +972,8 @@ pub fn emit(
             .map(|e| envelope::HostFn {
                 op: e.op.clone(),
                 comp_functype: extern_op_comp_functype(e),
-                core_functype: Vec::new(), // unused by the envelope (the core module builds its own)
+                core_functype: Vec::new(),
+                has_list_param: false, // unused by the envelope (the core module builds its own)
             })
             .collect();
         // A consumer that ALSO uses the value-heap runtime (it inspects a compound `value` handle the
@@ -2114,6 +2116,10 @@ fn emit_runtime_resource(
             .map(|hi| envelope::HostFn {
                 op: hi.op.clone(),
                 comp_functype: host_op_comp_functype(hi, 0),
+                has_list_param: hi
+                    .params
+                    .iter()
+                    .any(|p| matches!(p, host::HostParam::Bytes)),
                 core_functype: Vec::new(),
             })
             .collect();
@@ -2221,6 +2227,7 @@ fn emit_runtime_resource(
             op: e.op.clone(),
             comp_functype: extern_op_comp_functype(e),
             core_functype: Vec::new(),
+            has_list_param: false,
         })
         .collect();
     Ok(envelope::assemble_extern_runtime_resource(
@@ -3894,6 +3901,10 @@ fn emit_closure_host_resource(
         .map(|hi| envelope::HostFn {
             op: hi.op.clone(),
             comp_functype: host_op_comp_functype(hi, 0),
+            has_list_param: hi
+                .params
+                .iter()
+                .any(|p| matches!(p, host::HostParam::Bytes)),
             core_functype: Vec::new(),
         })
         .collect();
@@ -7052,6 +7063,10 @@ fn emit_runtime_bytes_resource(
             .map(|hi| envelope::HostFn {
                 op: hi.op.clone(),
                 comp_functype: host_op_comp_functype(hi, 0),
+                has_list_param: hi
+                    .params
+                    .iter()
+                    .any(|p| matches!(p, host::HostParam::Bytes)),
                 core_functype: Vec::new(),
             })
             .collect();
@@ -7169,6 +7184,7 @@ fn emit_runtime_bytes_resource(
             op: e.op.clone(),
             comp_functype: extern_op_comp_functype(e),
             core_functype: Vec::new(),
+            has_list_param: false,
         })
         .collect();
     Ok(
@@ -7349,6 +7365,10 @@ fn emit_runtime_sum_resource(
             .map(|hi| envelope::HostFn {
                 op: hi.op.clone(),
                 comp_functype: host_op_comp_functype(hi, 0),
+                has_list_param: hi
+                    .params
+                    .iter()
+                    .any(|p| matches!(p, host::HostParam::Bytes)),
                 core_functype: Vec::new(),
             })
             .collect();
@@ -7439,6 +7459,7 @@ fn emit_runtime_sum_resource(
             op: e.op.clone(),
             comp_functype: extern_op_comp_functype(e),
             core_functype: Vec::new(),
+            has_list_param: false,
         })
         .collect();
     Ok(envelope::assemble_extern_runtime_resource(
@@ -7601,6 +7622,10 @@ fn emit_recursive_sum_resource(
             .map(|hi| envelope::HostFn {
                 op: hi.op.clone(),
                 comp_functype: host_op_comp_functype(hi, 0),
+                has_list_param: hi
+                    .params
+                    .iter()
+                    .any(|p| matches!(p, host::HostParam::Bytes)),
                 core_functype: Vec::new(),
             })
             .collect();
@@ -7676,6 +7701,7 @@ fn emit_recursive_sum_resource(
             op: e.op.clone(),
             comp_functype: extern_op_comp_functype(e),
             core_functype: Vec::new(),
+            has_list_param: false,
         })
         .collect();
     Ok(envelope::assemble_extern_runtime_resource(

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
@@ -11421,12 +11421,17 @@ fn emit(
                 match at {
                     // A unit argument carries no boundary value.
                     Ty::Unit => continue,
-                    // A STRING argument crosses as `(ptr, len)` into the SHARED host memory (`assemble_host_mem`
-                    // provides it; `set_needs_memory` fires for any String-param op). A CONSTANT string's bytes
-                    // were laid in the data segment at `host_string_offset` — push that ptr + len. A RUNTIME
-                    // string (a value-heap rope) is MARSHALED here: copy its bytes into a fixed scratch region
-                    // of `mem` past the const-string data, then push `(scratch_base, len)`.
-                    Ty::String => match core_of(db, arg) {
+                    // A STRING or BYTES argument crosses as `(ptr, len)` into the SHARED host memory
+                    // (`assemble_host_mem` provides it; `set_needs_memory` fires for any String/Bytes-param
+                    // op). A CONSTANT string's bytes were laid in the data segment at `host_string_offset` —
+                    // push that ptr + len. Everything else (a RUNTIME string rope OR any `Bytes` value, const
+                    // or runtime — a `Bytes.of`/slice-view byte-buffer) is MARSHALED here: copy its logical
+                    // bytes into a fixed scratch region of `mem` via the rep-agnostic `bytes-len`/`bytes-get`
+                    // walk (transparent through a rope OR a slice-view), then push `(scratch_base, len)`. The
+                    // component boundary declares the Bytes param as `list<u8>` (a defined type-index) vs the
+                    // String's inline `string`; the CORE marshalling here is identical. adv-62b sibling: this
+                    // is the wasm side of the Bytes-host-arg reverse-parity gap (rust already crossed it).
+                    Ty::String | Ty::Bytes => match core_of(db, arg) {
                         Core::ConstStr(s) => {
                             let offset = layout.host_string_offset(&s).ok_or_else(|| {
                                 Reject::decline(

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -66104,6 +66104,54 @@ mod stage1 {
     }
 
     #[test]
+    fn a_runtime_bytes_host_arg_crosses_as_list_u8_and_runs() {
+        // The host BYTES-ARG path (the sibling of the runtime-string-arg test above): a runtime `Bytes`
+        // argument crosses the host boundary as `list<u8>` — the SAME `(ptr,len)` shared-memory core
+        // marshalling as a String arg (the guest copies the byte-buffer into `mem` via the rep-agnostic
+        // `bytes-len`/`bytes-get` walk), but the COMPONENT boundary type is `list<u8>` (a DEFINED type
+        // referenced by index in the import instance-type — the instance-type prepends `(list u8)` as type 0
+        // and shifts the op func types to 1..=h) vs the String's inline `string`. Previously a Bytes host arg
+        // DECLINED on wasm while rust crossed it (reverse-parity gap). `main(n)` builds a 2-byte runtime
+        // `Bytes.of` value and passes it to host op `h`, returning h's response (7). Pins: (a) it COMPILES
+        // (was a decline), (b) the composed component is VALID (the instance-type index-shift is well-formed —
+        // the `host_effect_instance_type` list-type prepend), (c) it RUNS. The canon Lower carries Memory(0),
+        // no realloc (a Bytes ARG is guest→host: guest allocates, host reads).
+        use crate::testkit::parse;
+        let Some(runtime) = find_runtime_wasm() else {
+            eprintln!("[host-mem-runtime-bytes-arg] runtime wasm not in the store; skipping run");
+            return;
+        };
+        let src = "(do (effect H (op h (-> Bytes Int64))) \
+                   (def (main (: n Int64)) \
+                     (host (H) (H.h (Bytes.of (list ((UInt 8).wrap n) ((UInt 8).wrap 66)))))) \
+                   (export main))";
+        let bytes = compile_component(&crate::codec::encode(&parse(src)))
+            .expect("a runtime Bytes host arg must cross as list<u8>, not decline");
+        // The composed component must be VALID — the list<u8> defined-type + the instance-type index-shift
+        // must produce a well-formed component (wasmtime rejects a malformed instance-type).
+        let engine = wasmtime::Engine::default();
+        wasmtime::component::Component::from_binary(&engine, &bytes)
+            .expect("the host-mem runtime-bytes-arg component (list<u8> import) must be valid");
+        let opts = cdz_run::RunOpts {
+            export: Some("main".to_string()),
+            args: vec!["65".to_string()],
+            runtime: Some(runtime),
+            runtime_cache_dir: None,
+            host_responses: vec![cdz_run::HostResponse {
+                op: "h".to_string(),
+                value: "7".to_string(),
+            }],
+        };
+        match cdz_run::run(&bytes, &opts).expect("run") {
+            cdz_run::Outcome::Value(s) => assert_eq!(
+                s, "7",
+                "the runtime Bytes arg crosses as list<u8> + the host call returns its response"
+            ),
+            cdz_run::Outcome::Trap(t) => panic!("runtime-bytes host-arg run trapped: {t}"),
+        }
+    }
+
+    #[test]
     fn a_runtime_string_host_arg_handles_empty_and_multibyte_lengths() {
         // EDGE-LENGTH coverage for the `_mem` runtime-string-arg copy loop (the primary test uses a 1-byte
         // string). Two edges an off-by-one in the loop guard `pos >= len → done` would break: (1) an EMPTY
@@ -86657,6 +86705,7 @@ mod closure_host_resource {
             op: "emit".to_string(),
             comp_functype: comp_ft,
             core_functype: Vec::new(),
+            has_list_param: false,
         }];
         let dtor = crate::backend::wasm::serialize::resource_dtor_module_with_drop();
         let s64_comp = crate::backend::wasm::runtime_abi::AbiValType::S64.comp_byte();
@@ -88976,6 +89025,7 @@ mod cross_component_oracle {
             op: "f".to_string(),
             comp_functype,
             core_functype: Vec::new(),
+            has_list_param: false,
         }];
         let exports = [BoundaryExport {
             name: "main".to_string(),

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -2781,6 +2781,7 @@ pass	a runtime Bytes rope in a record field compares equal to its flat twin
 pass	a runtime Bytes rope is found as a Set element by its flat twin
 pass	a runtime Bytes rope map key is looked up by its flat twin
 pass	a runtime Bytes rope nested in a tuple compares equal to its flat twin
+pass	a runtime Bytes value crosses a host op boundary as list<u8> (H-bytes-arg)
 pass	a runtime Bytes.of value is equality-comparable (the runtime-Bytes control)
 pass	a runtime FLOAT width nested in a compound annotation is rejected
 pass	a runtime Float quantity comparison against NaN is the IEEE partial order (false)

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -2769,6 +2769,7 @@ pass	a runtime Bytes rope in a record field compares equal to its flat twin
 pass	a runtime Bytes rope is found as a Set element by its flat twin
 pass	a runtime Bytes rope map key is looked up by its flat twin
 pass	a runtime Bytes rope nested in a tuple compares equal to its flat twin
+pass	a runtime Bytes value crosses a host op boundary as list<u8> (H-bytes-arg)
 pass	a runtime Bytes.of value is equality-comparable (the runtime-Bytes control)
 pass	a runtime FLOAT width nested in a compound annotation is rejected
 pass	a runtime Float quantity comparison against NaN is the IEEE partial order (false)

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -2745,6 +2745,7 @@ pass	a runtime Bytes rope in a record field compares equal to its flat twin
 pass	a runtime Bytes rope is found as a Set element by its flat twin
 pass	a runtime Bytes rope map key is looked up by its flat twin
 pass	a runtime Bytes rope nested in a tuple compares equal to its flat twin
+todo	a runtime Bytes value crosses a host op boundary as list<u8> (H-bytes-arg)
 pass	a runtime Bytes.of value is equality-comparable (the runtime-Bytes control)
 pass	a runtime FLOAT width nested in a compound annotation is rejected
 pass	a runtime Float quantity comparison against NaN is the IEEE partial order (false)

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -6958,3 +6958,26 @@
   (host-responses (respond io.get (: 21 Int64)))
   (host-calls (call io.get))
   (output (: 2131 Int64)))
+
+(case "a runtime Bytes value crosses a host op boundary as list<u8> (H-bytes-arg)"
+  (doc    "The wasm host-ARG Bytes path: a runtime `Bytes` argument to a host op crosses the component
+           boundary as `list<u8>` (the (ptr,len) shared-memory shape, same core marshalling as a String arg
+           but a `list<u8>` component type — a DEFINED type referenced by index in the import instance-type,
+           vs String's inline `string`). Previously DECLINED on wasm while the rust backend crossed it — a
+           reverse-parity coverage gap (v-rust-backend flagged, breaker banked the probe). `main(k)` slices a
+           runtime `to-bytes` rope `(Bytes.slice … k 3)` and passes the 3-byte view to `io.sink`; the host
+           answers 99. Pins that a Bytes host arg (a) COMPILES on wasm and (b) the emitted component is valid
+           (`sink: func(p0: list<u8>) -> s64`, wasm-tools-verified) and (c) RUNS. rust already passed it;
+           rust-async declines the multi-def host-do shape (todo). The canon Lower carries Memory(0) (no
+           realloc for an argument — the guest allocates, the host reads).")
+  (input  (do
+            (effect io (op sink (-> Bytes Int64)))
+            (def (main (: k Int64))
+              (host (io)
+                (match (Bytes.slice (String.to-bytes (String.concat "abc" "defgh")) k 3)
+                  ((Some cut) (io.sink cut))
+                  ((None _u) -1))))
+            (export main)))
+  (host-responses (respond io.sink (: 99 Int64)))
+  (host-calls (call io.sink))
+  (call   main (: 2 Int64)) (output (: 99 Int64)))


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 2ee559f3477b6dfad7849bd5e6fbe5eeb1e0cd4a, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.