### PR TITLE
cdz-run: compute runtime_cache_dir AFTER peer-runtime resolution — a peer-induced runtime is --store-scoped for NFC too (PR #1633 review follow-on)

### DIFF
--- a/implementation/seed/crates/cdz-run/src/cli.rs
+++ b/implementation/seed/crates/cdz-run/src/cli.rs
@@ -127,9 +127,6 @@ fn real_run(cli: &RunArgs, prog: &str) -> anyhow::Result<ExitCode> {
         None => None,
     };
 
-    let runtime_cache_dir =
-        resolve_runtime_cache_dir(runtime.is_some(), cli.runtime.is_some(), cli.store.clone());
-
     // Parse each `--host-response op=value` into a `HostResponse`. A missing `=` takes the whole string
     // as the value with an empty op label (the ordered-consume model does not yet match on the op).
     let host_responses = cli
@@ -196,6 +193,13 @@ fn real_run(cli: &RunArgs, prog: &str) -> anyhow::Result<ExitCode> {
         }
         None => None,
     };
+
+    // Compute the runtime cache/NFC-store dir AFTER the peer-runtime resolution above — so a runtime induced
+    // by a PEER (consumer needs none, but a `--peer` does) is store-scoped for NFC too, not just a consumer's.
+    // Computing it earlier (before this block) missed the peer case: `runtime` was still `None` at that point,
+    // so an explicit `--store` did not scope NFC for the peer-induced runtime (PR #1633 review follow-on).
+    let runtime_cache_dir =
+        resolve_runtime_cache_dir(runtime.is_some(), cli.runtime.is_some(), cli.store.clone());
 
     // FINDING#23: the runtime imports `cadenza:nfc/normalize`, but the host now SELF-RESOLVES that NFC
     // component from the store inside `compose_nfc_into_runtime_linker` (via `runtime_cache_dir`/`CDZ_STORE`/


### PR DESCRIPTION
Candidate PR for v-cdz-tooling's merge-request (ref cd3f73d37da65bccf9dcbf688a7fb3cb30dbf64f, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.