### PR TITLE
rcdzc: higher-order closure round-trips cross the Rust export boundary (host-closure S4)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/rust/mod.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/mod.rs
@@ -69,6 +69,26 @@ fn is_capture_scalar(t: &crate::ty::Ty) -> bool {
     )
 }
 
+/// A closure ARG type admitted by the S4-HIGHER-ORDER slice: an `s2_arg_ok` scalar/compound, OR a
+/// closure (`Ty::Fn`) whose own arg/result spine is itself `arg_ok_or_fn` (recursively). A closure whose
+/// arg is itself a closure (`(-> (-> Int64 Int64) Int64)`) is the higher-order round-trip shape — the
+/// consumer applies it to an IN-GUEST-built inner closure (`(g (fn (y) …))`, which the emitter already
+/// lowers), and the higher-order producer (`mk`) is passed by the harness as `Rc::new(mk)`. Distinct from
+/// `s2_arg_ok` (which rejects every `Ty::Fn`) so the base non-higher-order gates keep their exact behavior.
+fn arg_ok_or_fn(t: &crate::ty::Ty) -> bool {
+    if let crate::ty::Ty::Fn(_, _) = t.strip_nominal() {
+        let mut cur = t.strip_nominal();
+        while let crate::ty::Ty::Fn(p, r) = cur {
+            if !arg_ok_or_fn(p) {
+                return false;
+            }
+            cur = r.strip_nominal();
+        }
+        return arg_ok_or_fn(cur);
+    }
+    s2_arg_ok(t)
+}
+
 /// Whether a closure ARG type is OK for the host-closure FACTORY slice: a scalar (Int/Bool/Float — the
 /// harness passes each as a literal), a String/Bytes applied IN-GUEST (a literal the emitter lowers — see
 /// the arm's own comment for the in-guest-vs-host-boundary distinction), or a COMPOUND the harness's
@@ -326,6 +346,12 @@ fn s3_result_ok(t: &crate::ty::Ty) -> bool {
 fn fn_result_renderable(db: &mut Db, ty: &crate::ty::Ty) -> bool {
     let mut cur = ty.strip_nominal();
     while let crate::ty::Ty::Fn(p, r) = cur {
+        // NOTE: a returned closure's ARG stays `s2_arg_ok` (NOT `arg_ok_or_fn`) — a higher-order FACTORY
+        // (a def whose RESULT is a closure whose arg is itself a closure, e.g. `mk`-ALONE returning
+        // `(-> (-> Int64 Int64) Int64)`) has NO consumer sibling to drive it, so the host would have to
+        // supply the inner closure over the boundary — which declines (the "closure-typed closure ARG on
+        // the DIRECT-CALL path is declined" pin). The higher-order ROUND-TRIP cases work via the CONSUMER
+        // path (`app` consumes `mk`), where `mk` is eta-peeled to a consumer — NOT this factory gate.
         if !s2_arg_ok(p) {
             return false;
         }
@@ -830,7 +856,11 @@ fn emit_signature(
         // `s2_arg_ok` returns false for it. (This lands the S3-compound-closure-result consumer shape.)
         let mut cur = t.strip_nominal();
         while let crate::ty::Ty::Fn(p, r) = cur {
-            if !s2_arg_ok(p) {
+            // S4-HIGHER-ORDER: a closure ARG may itself be a closure (`arg_ok_or_fn` admits `Ty::Fn`), so a
+            // consumer taking `g: (-> (-> Int64 Int64) Int64)` is admitted — the inner closure it applies
+            // `g` to is built IN-GUEST (`(g (fn (y) …))`, already lowered), and the harness supplies `g`
+            // from its higher-order producer sibling (`Rc::new(mk)`).
+            if !arg_ok_or_fn(p) {
                 return false;
             }
             cur = r.strip_nominal();
@@ -874,6 +904,36 @@ fn emit_signature(
                 && ep.result.strip_nominal() == closure_ret
         })
     };
+    // S4-HIGHER-ORDER: whether THIS def is itself a PRODUCER for some sibling export's closure param — i.e.
+    // this def's own signature, viewed as a closure `(-> param0 param1 … result)`, MATCHES a `Ty::Fn` param
+    // of another export. In the higher-order round-trip, `mk : (-> (-> Int64 Int64) Int64)` is `app`'s `g`
+    // param's producer; `mk` itself takes a closure param `f : (-> Int64 Int64)` that has NO producer
+    // sibling — but that's fine, because `mk`'s `f` is supplied IN-GUEST by `app` (`(g (fn (y) …))`), never
+    // by the host. So the host NEVER calls `mk` directly with a synthesized `f`; it passes `mk` (as
+    // `Rc::new(mk)`) as `app`'s `g`, and `app`'s body builds the inner closure. Thus a consumer whose
+    // closure param lacks a producer is STILL emittable when the consumer is itself such a producer — its
+    // in-guest-fed closure param needs no host synthesis. Emit it as a plain `pub fn` (rustc compiles it;
+    // the harness drives only the OUTER consumer `app`).
+    let def_is_producer_for_sibling = || -> bool {
+        // Build this def's own closure type: `(-> p0 (-> p1 … result))` (curried), matching how a closure
+        // param's arrow spine is written. A def with NO params can't be a closure producer here.
+        if params.is_empty() {
+            return false;
+        }
+        let mut own_fn = result.clone();
+        for (_, pt) in params.iter().rev() {
+            own_fn = crate::ty::Ty::Fn(Box::new(pt.clone()), Box::new(own_fn));
+        }
+        let own_fn = own_fn.strip_nominal();
+        // Does any OTHER export have a `Ty::Fn` param equal to this def's own closure type?
+        layout.exports.iter().any(|ep| {
+            ep.def != def
+                && ep
+                    .params
+                    .iter()
+                    .any(|(_, pt)| is_fn_ty(pt) && pt.strip_nominal() == own_fn)
+        })
+    };
     // Whether a closure param has a FACTORY producer specifically (a sibling whose RESULT is the closure
     // type) — a STRICTER form of `has_producer_for` (which also accepts a PEELED producer). In ASYNC mode
     // the driver can drive a factory producer through `block_on` (the factory is an `async fn` returning a
@@ -911,12 +971,19 @@ fn emit_signature(
             "`{name}`: an async closure-PARAMETER consumer whose closure has no FACTORY producer sibling is not yet driven by the Rust backend"
         )));
     }
+    // S4-HIGHER-ORDER: a closure param is admissible when it is shape-OK (`closure_param_is_simple`) AND
+    // EITHER it has a producer sibling (`has_producer_for` — the host synthesizes it) OR this def is itself
+    // a producer for a sibling's closure param (`def_is_producer_for_sibling` — the param is fed IN-GUEST by
+    // that sibling, so no host synthesis is needed and the def just emits as a plain `pub fn`). The
+    // `def_is_producer_for_sibling` check is def-wide (not per-param), evaluated once — it says "this whole
+    // def is a producer, so its closure params are guest-internal", which is the higher-order producer case.
+    let is_producer_for_sibling = def_is_producer_for_sibling();
     if public
         && params.iter().any(|(_, t)| is_fn_ty(t))
-        && (!params
-            .iter()
-            .all(|(_, t)| !is_fn_ty(t) || (closure_param_is_simple(t) && has_producer_for(t)))
-            || result_render_unsupported)
+        && (!params.iter().all(|(_, t)| {
+            !is_fn_ty(t)
+                || (closure_param_is_simple(t) && (has_producer_for(t) || is_producer_for_sibling))
+        }) || result_render_unsupported)
     {
         return Err(Reject::decline(format!(
             "`{name}`: this closure-PARAMETER export shape (higher-order / compound arg / Bytes-String result / no producing sibling) does not cross the Rust export boundary yet"

--- a/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
@@ -6170,6 +6170,52 @@ fn rustc_roundtrip_closure_parameter_consumer_with_a_producer_sibling() {
 }
 
 #[test]
+fn rustc_roundtrip_higher_order_closure_arg_consumer_s4() {
+    // S4-HIGHER-ORDER: a consumer `app` takes a closure whose ARG is ITSELF a closure — `g: (-> (-> Int64
+    // Int64) Int64)` — and applies it to an INNER closure built IN-GUEST (`(g (fn (y) (+ y x)))`). The
+    // higher-order producer `mk` (whose signature `(-> (-> Int64 Int64) Int64)` = app's `g` type) supplies
+    // `g`. Two emit pieces make this work: (1) `arg_ok_or_fn` admits a `Ty::Fn` closure arg in the consumer
+    // gate; (2) `def_is_producer_for_sibling` exempts `mk` from the producer requirement for its OWN `f`
+    // param (fed in-guest by app, never host-supplied) — so `mk` emits as a plain `pub fn mk(f: Rc<dyn
+    // Fn>)`. The harness recognizes `mk` as a higher-order producer and passes it `Rc::new(mk)`.
+    let m = compile_rust(
+        "(module m \
+           (def (mk) (fn ((: f (-> Int64 Int64))) (f 10))) \
+           (def (app (: g (-> (-> Int64 Int64) Int64)) (: x Int64)) (g (fn (y) (+ y x)))) \
+           (export mk) (export app))",
+    );
+    assert!(
+        m.contains("pub fn mk(f: std::rc::Rc<dyn Fn(i64) -> i64>) -> i64"),
+        "the higher-order producer mk emits as a plain fn taking an Rc<dyn Fn> param:\n{m}"
+    );
+    assert!(
+        m.contains("pub fn app(g: std::rc::Rc<dyn Fn(std::rc::Rc<dyn Fn(i64) -> i64>) -> i64>"),
+        "the consumer app emits a higher-order Rc<dyn Fn(Rc<dyn Fn>)> param:\n{m}"
+    );
+    // Driven producer→consumer: `app(Rc::new(mk), 5)` — mk is the higher-order closure, app applies it to
+    // the in-guest `(fn (y) (+ y 5))`, so mk calls that on 10 → 10+5 = 15.
+    if let Some(out) = rustc_run(
+        &m,
+        "app(std::rc::Rc::new(mk as fn(std::rc::Rc<dyn Fn(i64)->i64>)->i64), 5)",
+    ) {
+        assert_eq!(
+            out, "15",
+            "app(mk, 5): mk applies the in-guest (+ y 5) to 10 → 15"
+        );
+    }
+    // A HIGHER-ORDER closure export called ALONE (no consumer sibling) still DECLINES — the host would have
+    // to supply the inner `(-> Int64 Int64)` over the boundary (no rep). `def_is_producer_for_sibling` is
+    // false (nothing consumes mk's type), and `f` has no producer → declines.
+    let mk_alone = compile_rust_result(
+        "(module m (def (mk) (fn ((: f (-> Int64 Int64))) (f 10))) (export mk))",
+    );
+    assert!(
+        mk_alone.is_err(),
+        "a higher-order closure export with no consuming sibling declines (host can't supply the inner closure):\n{mk_alone:?}"
+    );
+}
+
+#[test]
 fn rustc_roundtrip_closure_parameter_consumer_with_a_compound_arg_closure_s2() {
     // CLOSURE-PARAMETER CONSUMER, S2: the consumer's closure param takes a COMPOUND arg (a Tuple) with a
     // scalar result. The consumer applies `(g p)` where `p` is a tuple built in its OWN body; the producing

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5542,8 +5542,8 @@ pass	an entrypoint delegation reaches an effect performed in a recursive callee
 pass	and performs the right operand's effect when the left is true
 pass	and short-circuit does not perform the right operand's effect
 pass	binary operator operands are evaluated left to right
-todo	distinct-sig round-trip: a higher-order closure + a scalar closure of another sig — the higher-order one
-todo	distinct-sig round-trip: a higher-order closure-typed arg on one group + a scalar closure on another
+pass	distinct-sig round-trip: a higher-order closure + a scalar closure of another sig — the higher-order one
+pass	distinct-sig round-trip: a higher-order closure-typed arg on one group + a scalar closure on another
 todo	expect on an overflowing checked add traps
 todo	expect traps on the absent case of a runtime optional
 pass	function arguments are evaluated left to right
@@ -5554,12 +5554,12 @@ pass	or performs the right operand's effect when the left is false
 pass	or short-circuit does not perform the right operand's effect
 pass	quoted Asts as SET elements dedup by structural content
 todo	read of malformed text is a coded reject, not a wrong value
-todo	round-trip: a HIGHER-ORDER closure arg composed with a SUM result
-todo	round-trip: a HIGHER-ORDER closure — its argument is itself a closure built in-guest
-todo	round-trip: a higher-order closure applied to TWO distinct inner closures
-todo	round-trip: a higher-order closure whose inner closure CAPTURES and is applied twice
-todo	round-trip: a higher-order closure whose inner closure takes an UNANNOTATED compound param
-todo	round-trip: an UNANNOTATED inner closure with a List param via the context arrow
+pass	round-trip: a HIGHER-ORDER closure arg composed with a SUM result
+pass	round-trip: a HIGHER-ORDER closure — its argument is itself a closure built in-guest
+pass	round-trip: a higher-order closure applied to TWO distinct inner closures
+pass	round-trip: a higher-order closure whose inner closure CAPTURES and is applied twice
+pass	round-trip: a higher-order closure whose inner closure takes an UNANNOTATED compound param
+pass	round-trip: an UNANNOTATED inner closure with a List param via the context arrow
 pass	the program manifest is the union of its entrypoints' delegations
 pass	the same conditional delegation makes no host call when the branch is not taken
 pass	tuple elements are evaluated left to right

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5460,7 +5460,7 @@ pass	wrapping-sub wraps a boundary-crossing runtime Int64 at the min boundary
 pass	zero divided by a runtime value folds to zero but keeps the zero-divisor guard
 pass	α-equivalence (aconv) recognizes (λx.x) and (λy.y) as the same term up to bound-variable renaming
 pass	α-equivalence handles nesting and distinguishes a bound variable from a same-numbered free variable
-todo	Ast values key a map across quote and Ast.* construction routes
+pass	Ast values key a map across quote and Ast.* construction routes
 todo	Set.of over runtime lists at two different element types declines pending the recursive-generic tie
 todo	Type is a first-class value
 todo	a @param accessor splices into a quasiquote and the eval computes with the host value
@@ -5474,7 +5474,7 @@ todo	a @param slice window whose length exceeds the remaining bytes yields None
 todo	a @param value SEEDS an in-program handler's state
 todo	a @param value crosses into a closure capture and applies
 todo	a @param value drives a CHAMP map lookup as the KEY
-todo	a DRAINED set compares equal to the literal empty set — removal restores the canonical empty rep
+pass	a DRAINED set compares equal to the literal empty set — removal restores the canonical empty rep
 todo	a Float64 closure captures a Float64 build-time host effect result
 todo	a Float64-inner Qty host result crosses as its float magnitude
 todo	a Quantity @param generates a Qty-result accessor the host supplies as a scalar magnitude
@@ -5514,7 +5514,7 @@ todo	an @param of a Bool type generates a Bool-typed accessor
 todo	an @param of a Float64 type generates a Float64-typed accessor
 todo	an @param site generates a Param accessor a host delegation reads at run time
 todo	an @param with no widget config still generates its typed accessor
-todo	an Ast as a MAP key looks up by structural content
+pass	an Ast as a MAP key looks up by structural content
 todo	an abortive handler abandons a host call in the path it discards
 todo	an abortive perform in a recursive callee with a PENDING continuation in the handle body abandons it
 todo	an effectful host arg flowing into a compound then a destructuring match is evaluated ONCE
@@ -5541,7 +5541,7 @@ todo	one @param accessor performed TWICE consumes two host responses in order
 todo	one @param read bound ONCE fans out to a map key, a set probe, and arithmetic
 todo	or performs the right operand's effect when the left is false
 todo	or short-circuit does not perform the right operand's effect
-todo	quoted Asts as SET elements dedup by structural content
+pass	quoted Asts as SET elements dedup by structural content
 todo	read of malformed text is a coded reject, not a wrong value
 todo	round-trip: a HIGHER-ORDER closure arg composed with a SUM result
 todo	round-trip: a HIGHER-ORDER closure — its argument is itself a closure built in-guest
@@ -5551,7 +5551,7 @@ todo	round-trip: a higher-order closure whose inner closure takes an UNANNOTATED
 todo	round-trip: an UNANNOTATED inner closure with a List param via the context arrow
 todo	the generated Param accessor carries the @param's declared type into arithmetic
 todo	the program manifest is the union of its entrypoints' delegations
-todo	the same conditional delegation makes no host call when the branch is not taken
+pass	the same conditional delegation makes no host call when the branch is not taken
 todo	the same program with a different response gives a different deterministic result
 todo	tuple elements are evaluated left to right
 todo	two @param accessors INTERLEAVED (a b a) consume per-op response queues in perform order

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2577,10 +2577,17 @@ fn build_closure_consumer_call(
                 cap: src_params.len(),
                 shape,
             });
-        } else if !src_params.iter().any(|p| is_closure_param(p)) {
-            // PEELED candidate: a plain fn (no closure param, non-closure return). Its equivalent closure
-            // type is `Rc<dyn Fn(<param types>) -> <ret>>`; the raw `fn(<param types>) -> <ret>` is used
-            // for the coercion. (A fn with a closure param is a CONSUMER, not a producer — skip it.)
+        } else {
+            // PEELED candidate: a fn whose EQUIVALENT closure value is `Rc::new(fn-item)`. Its closure type
+            // is `Rc<dyn Fn(<param types>) -> <ret>>` and the raw `fn(<param types>) -> <ret>` is the
+            // coercion target. `param_type_of` yields each param's full Rust type — so a HIGHER-ORDER
+            // producer (S4: a fn that itself takes a closure param, `fn mk(f: Rc<dyn Fn(i64)->i64>) -> i64`)
+            // is a valid producer whose closure type is `Rc<dyn Fn(Rc<dyn Fn(i64)->i64>)->i64>`. It is
+            // supplied to the consumer as `Rc::new(prog::mk as fn(Rc<dyn Fn…>)->i64)`. (Previously a fn WITH
+            // a closure param was skipped as "a consumer, not a producer" — but the higher-order round-trip
+            // has mk be BOTH: a producer for app's `g` AND a consumer of an in-guest `f`. Pairing is by
+            // erased closure-type via `ty_matches` below, so a genuine consumer that matches no sibling
+            // closure param is simply never paired — accepting it as a producer candidate is harmless.)
             let param_types: Vec<String> = src_params.iter().map(|p| param_type_of(p)).collect();
             let ret = psig
                 .ret_head


### PR DESCRIPTION
Candidate PR for v-rust-backend's merge-request (ref 4a87cda6d, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.