### PR TITLE
cdz-run+cdz: CDZ_STORE env override in default_store (R4 — flag > env > compiled default)

### DIFF
--- a/implementation/seed/crates/cdz-run/src/cli.rs
+++ b/implementation/seed/crates/cdz-run/src/cli.rs
@@ -324,9 +324,17 @@ pub fn content_address(bytes: &[u8]) -> String {
     s
 }
 
-/// The default content-addressed store: `<repo>/target/cadenza-store`, resolved from this crate's
-/// manifest location (crate lives at `<repo>/implementation/seed/crates/cdz-run`).
+/// The default content-addressed store: the `CDZ_STORE` env var if set, else `<repo>/target/cadenza-store`
+/// resolved from this crate's manifest location (crate lives at `<repo>/implementation/seed/crates/cdz-run`).
+/// The `--store` flag still wins over this (callers `unwrap_or_else(default_store)`), so precedence is
+/// flag > `CDZ_STORE` > compiled default — matching `resolve_nfc_from_store`'s NFC-component resolution so a
+/// single env var repoints the WHOLE store (value-heap runtime + NFC) at a Nix-provided path (R4).
 fn default_store() -> PathBuf {
+    store_from_env_or(std::env::var_os("CDZ_STORE"), compiled_default_store)
+}
+
+/// The compiled fallback store path (`<repo>/target/cadenza-store`) — used only when `CDZ_STORE` is unset.
+fn compiled_default_store() -> PathBuf {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     // <repo>/implementation/seed/crates/cdz-run → up 4 → <repo>
     let repo = manifest
@@ -361,6 +369,18 @@ fn resolve_runtime_cache_dir(
     } else {
         // `--runtime <path>` given: honor an explicit `--store` (scopes NFC), else `None`.
         store
+    }
+}
+
+/// Pure precedence: `CDZ_STORE` (as an already-read `OsString`) wins over the compiled fallback. Split out
+/// so the env-var precedence is unit-testable without mutating the process-global environment.
+fn store_from_env_or(
+    env: Option<std::ffi::OsString>,
+    fallback: impl FnOnce() -> PathBuf,
+) -> PathBuf {
+    match env {
+        Some(dir) => PathBuf::from(dir),
+        None => fallback(),
     }
 }
 
@@ -407,5 +427,33 @@ mod cache_dir_tests {
         // `--runtime P` with NO `--store`: don't cache a debug-override runtime; NFC falls back to
         // CDZ_STORE/default (handled downstream in resolve_nfc_from_store), so no dir is pinned here.
         assert_eq!(resolve_runtime_cache_dir(true, true, None), None);
+    }
+}
+
+#[cfg(test)]
+mod store_tests {
+    use super::*;
+
+    #[test]
+    fn cdz_store_env_wins_over_compiled_default() {
+        let picked = store_from_env_or(Some("/nix/store/abc-cadenza-store".into()), || {
+            PathBuf::from("/should/not/be/used")
+        });
+        assert_eq!(picked, PathBuf::from("/nix/store/abc-cadenza-store"));
+    }
+
+    #[test]
+    fn compiled_default_used_when_env_unset() {
+        let picked = store_from_env_or(None, || PathBuf::from("/repo/target/cadenza-store"));
+        assert_eq!(picked, PathBuf::from("/repo/target/cadenza-store"));
+    }
+
+    #[test]
+    fn empty_env_value_is_still_honored_not_treated_as_unset() {
+        // An explicitly-set-but-empty CDZ_STORE is a caller choice (var_os returns Some("")), distinct from
+        // unset (None). We honor it verbatim rather than silently falling back — the flag layer above can
+        // still override, and an empty path fails loudly at store-open rather than masking a misconfig.
+        let picked = store_from_env_or(Some("".into()), || PathBuf::from("/fallback"));
+        assert_eq!(picked, PathBuf::from(""));
     }
 }

--- a/implementation/seed/crates/cdz/src/main.rs
+++ b/implementation/seed/crates/cdz/src/main.rs
@@ -6628,10 +6628,15 @@ fn locate_cdz_run() -> Option<PathBuf> {
         .filter(|p| p.exists())
 }
 
-/// The default content-addressed runtime store — `<repo>/target/cadenza-store`, resolved relative to this
-/// binary (`target/<profile>/cdz` → up two → `target` → `cadenza-store`). Mirrors `cdz-run`'s own default
-/// so `cdz test` and a direct `cdz-run` agree on where the value-heap runtime lives.
+/// The default content-addressed runtime store — the `CDZ_STORE` env var if set, else
+/// `<repo>/target/cadenza-store` resolved relative to this binary (`target/<profile>/cdz` → up two →
+/// `target` → `cadenza-store`). Mirrors `cdz-run`'s own `default_store` (flag > `CDZ_STORE` > compiled
+/// default) so `cdz test`, `cdz run`, and a direct `cdz-run` all agree on where the value-heap runtime
+/// lives — a single env var repoints the whole store at a Nix-provided path (R4).
 fn default_store() -> PathBuf {
+    if let Some(dir) = std::env::var_os("CDZ_STORE") {
+        return PathBuf::from(dir);
+    }
     std::env::current_exe()
         .ok()
         .and_then(|p| {


### PR DESCRIPTION
Candidate PR for v-runtime's merge-request (ref 4096063e3, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.