### PR TITLE
rcdzc: lowercase 'unit' is a VALUE not a type param — don't collect it in collect_type_params (fix generic-sum rust non-Ord decline)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/db.rs
+++ b/implementation/seed/crates/rcdzc/src/db.rs
@@ -5529,6 +5529,19 @@ fn collect_type_params(ast: &Arenas, occ: StructId, params: &mut Vec<String>) {
         Struct::Atom(_) => {
             if let Some(n) = ast.as_name(occ)
                 && n.starts_with(|c: char| c.is_ascii_lowercase())
+                // `unit` is the prelude VALUE (the empty product / units-module), NOT a type — the language
+                // splits value/type spelling (`true` the value, `Bool` the type), so lowercase `unit` is the
+                // value and capital `Unit` is the type. It is therefore NOT a type parameter: without this,
+                // a variant payload `(Nil unit)` harvested `unit` as a spurious type PARAM, so `(type (Box a)
+                // (Full a) (Nil unit))` read as 2-parameter `[a, unit]` → `(Full 1)` typed `Sum{Box, args:
+                // [Int64, <free Var>]}` (the unfilled phantom param) → the stray free Var left the sum
+                // non-Eq/non-Ord, DECLINING a Set/Map of it on the rust backend (wasm erased the open arg).
+                // A concrete unit-typed payload is spelled `(Nil Unit)` (capital, a `ground_type_record`),
+                // exactly like `(Nil Bool)`; a type-position lowercase `unit` now correctly fails to reduce
+                // to a type (it is a value) — the value/type-split ruling (concierge (B), 2026-08-03). The
+                // bare-atom analogue of the lowercase compound-type ALIASES (`tuple`/`record`/`list`/`map`)
+                // skipped in the List arms below.
+                && n != "unit"
                 && !params.iter().any(|p| p == n)
             {
                 params.push(n.to_string());

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -24106,6 +24106,38 @@ mod match_engine {
     }
 
     #[test]
+    fn a_generic_sum_with_a_unit_typed_variant_has_exactly_its_declared_params() {
+        use crate::testkit::parse;
+        // `unit` is the VALUE (empty product), `Unit` the TYPE — so a variant payload TYPE is `Unit`
+        // (capital), like `(Nil Bool)`. `collect_type_params` no longer harvests lowercase `unit` as a
+        // spurious param, so `(type (Box a) (Full a) (Nil Unit))` has EXACTLY ONE param `a` (was 2:
+        // `[a, unit]`, whose unfilled phantom left a stray Var making the sum non-Eq/non-Ord → a Set/Map of
+        // it DECLINED on the rust backend; v-rust-backend routed it). Value side: a match over both variants
+        // runs (the `(Nil …)` variant is CONSTRUCTED with the `unit` VALUE; its declared payload TYPE is
+        // `Unit`).
+        assert_eq!(
+            run_returns::<i64>(
+                &component(
+                    "(module m (type (Box a) (Full a) (Nil Unit)) \
+                       (def (main) (match (Full 6) ((Full v) (+ v 1)) ((Nil _u) -1))) (export main))"
+                ),
+                "main"
+            ),
+            7
+        );
+        // The rust-decline witness: a Set of the generic Unit-payload sum must EMIT rust (the spurious stray
+        // Var previously left it non-Ord → "Set with a non-Ord element"). Exactly the shape the ask flagged;
+        // a HARD emit check on the RUST target (storeless-safe — no run).
+        let src = "(module m (type (Box a) (Full a) (Nil Unit)) \
+                   (def (main (: k Int64)) (Set.len (Set.of (list (Full 1) (Full k) (Nil unit))))) (export main))";
+        let mut dbr = crate::db::Db::load(parse(src));
+        let layr = crate::layout::compute(&mut dbr).expect("layout");
+        crate::backend::emit(crate::backend::Target::Rust, &mut dbr, &layr, None, None).expect(
+            "a Set of a generic Unit-payload sum must emit rust — no spurious stray-Var non-Ord decline",
+        );
+    }
+
+    #[test]
     fn a_generic_same_name_newtype_constructs_and_matches() {
         // Generic + same-name compose: `(type Box (Box a))` constructs `(Box 42)` by the type name and
         // matches `(Box n)`, erasing to the raw payload. (The head-position rule fires on the USER node;
@@ -55988,9 +56020,10 @@ mod stage1 {
         .expect("a top-level value def may bind a record");
         assert_eq!(run_returns::<i64>(&bytes, "main"), 8);
         // A value def may bind a SUM value, matched by a sibling function — the self-hosting compiler's
-        // top-level constant AST/config-node shape. `chosen = (C.G unit)` dispatches to arm 2.
+        // top-level constant AST/config-node shape. `chosen = (C.G unit)` dispatches to arm 2. The variant
+        // payload TYPE is `Unit` (capital — the type); it is CONSTRUCTED with the `unit` VALUE (lowercase).
         let bytes = compile_component(&crate::codec::encode(&parse(
-            "(module m (type C (R unit) (G unit) (B unit)) (def chosen (C.G unit)) \
+            "(module m (type C (R Unit) (G Unit) (B Unit)) (def chosen (C.G unit)) \
                (def (main) (match chosen ((C.R _) 1) ((C.G _) 2) ((C.B _) 3))) (export main))",
         )))
         .expect("a top-level value def may bind a sum value");

--- a/spec/semantics/05-compound-types.sexp
+++ b/spec/semantics/05-compound-types.sexp
@@ -1290,7 +1290,7 @@
            top-level opcode record. Pins that a top-level value definition binding a sum is in scope for
            every function and dispatches by its variant, exactly as a bound record projects.")
   (input  (do
-            (type C (R unit) (G unit) (B unit))
+            (type C (R Unit) (G Unit) (B Unit))
             (def chosen (C.G unit))
             (def (main) (match chosen ((C.R _) 1) ((C.G _) 2) ((C.B _) 3)))
             (export main)))
@@ -17217,7 +17217,7 @@
            two monomorphs' payload slots) breaks the application or the scalar read — the sum-payload
            twin of the generic-tuple fn-slot pin.")
   (input  (do
-        (type (Box a) (Full a) (Nil unit))
+        (type (Box a) (Full a) (Nil Unit))
         (def (main (: k Int64))
           (do
             (def b (Full (fn ((: y Int64)) (* y k))))
@@ -17236,7 +17236,7 @@
            salt (or a payload slot hashed as a raw handle) splits the rope key from the flat probe;
            a tag-blind hash collapses Full/Nil.")
   (input  (do
-        (type (Box a) (Full a) (Nil unit))
+        (type (Box a) (Full a) (Nil Unit))
         (def (main (: k Int64))
           (do
             (def s (Set.of (list (Full 1) (Full k) (Nil unit))))


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref 881a415db77d37e13a30c9af70a746572b1c9b71, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.