### PR TITLE
rcdzc: type-position lowercase 'unit' reduces to Ty::Unit, not a spurious sum type-param (fix generic-sum rust non-Ord decline, ruling A)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/db.rs
+++ b/implementation/seed/crates/rcdzc/src/db.rs
@@ -5529,6 +5529,17 @@ fn collect_type_params(ast: &Arenas, occ: StructId, params: &mut Vec<String>) {
         Struct::Atom(_) => {
             if let Some(n) = ast.as_name(occ)
                 && n.starts_with(|c: char| c.is_ascii_lowercase())
+                // `unit` is the prelude UNIT value/type (the empty product), NOT a type PARAMETER. Without
+                // this, a variant payload `(None unit)` / `(Nil unit)` harvested `unit` as a spurious type
+                // param, so `(type (Box a) (Full a) (Nil unit))` read as 2-parameter `[a, unit]` → `(Full 1)`
+                // typed `Sum{Box, args:[Int64, <free Var>]}` (the unfilled phantom); the stray free Var left
+                // the sum non-Eq/non-Ord → a Set/Map of it DECLINED on the rust backend (wasm erased the open
+                // arg + tolerated it). `unit` in a type position instead reduces to `Ty::Unit` (a concrete
+                // type — see `typeval_of`'s unit arm), so the pervasive nullary-variant idiom `(None unit)`
+                // (prelude.rs §"the pervasive nullary-variant idiom"; guide PatternMatching) keeps resolving
+                // unchanged — it is NOT a param. The bare-atom analogue of the lowercase compound-type
+                // ALIASES (`tuple`/`record`/`list`/`map`) skipped in the List arms below.
+                && n != "unit"
                 && !params.iter().any(|p| p == n)
             {
                 params.push(n.to_string());

--- a/implementation/seed/crates/rcdzc/src/eval.rs
+++ b/implementation/seed/crates/rcdzc/src/eval.rs
@@ -3038,6 +3038,15 @@ fn typeval_of_uncached(db: &mut Db, id: StructId) -> Option<crate::ty::Ty> {
         }
         // A native ground type prim (`Bool`/`Unit`) held in a `(meta t)` field.
         Resolved::Prim(p) => p.ground_type(),
+        // The prelude UNIT value (the empty product) used in a TYPE position → `Ty::Unit`. The pervasive
+        // nullary-variant idiom writes a unit-typed payload as lowercase `(None unit)` / `(Nil unit)` /
+        // `(Red unit)` (prelude.rs §"the pervasive nullary-variant idiom"; guide PatternMatching), where the
+        // bare `unit` follows a `Ref` to `Resolved::Unit`. `unit` is NOT a type parameter (excluded in
+        // `collect_type_params`), so a variant payload `unit` reduces here to the concrete `Ty::Unit` — the
+        // type-position lenient-alias for the capital `Unit` (concierge ruling A, 2026-08-03), so
+        // `(type (Box a) (Full a) (Nil unit))` has EXACTLY one param `a` (no spurious `unit` param + stray
+        // Var → fixes the rust Set/Map non-Ord decline) while the taught `(None unit)` idiom keeps resolving.
+        Resolved::Unit => Some(crate::ty::Ty::Unit),
         // A built `(typeval …)` node carries the type directly.
         Resolved::TypeVal(t) => Some(t),
         // A `let` whose BODY is a type expression — `(let ((t Int64)) t)` evaluates to the body's value,

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -24112,6 +24112,39 @@ mod match_engine {
     }
 
     #[test]
+    fn a_lowercase_unit_variant_payload_is_ty_unit_not_a_spurious_type_param() {
+        use crate::testkit::parse;
+        // The pervasive nullary-variant idiom `(None unit)` / `(Nil unit)` writes a unit-typed payload with
+        // the lowercase `unit` VALUE (prelude empty product). `collect_type_params` must NOT harvest it as a
+        // type param, and `typeval_of` maps a type-position `unit` → `Ty::Unit` (ruling A) — so
+        // `(type (Box a) (Full a) (Nil unit))` has EXACTLY ONE param `a` (was 2: `[a, unit]`, whose unfilled
+        // phantom left a stray Var making the sum non-Eq/non-Ord → a Set/Map of it DECLINED on the rust
+        // backend). Value side: a match over both variants runs, WITH the lowercase idiom intact (no
+        // migration to capital `Unit`).
+        assert_eq!(
+            run_returns::<i64>(
+                &component(
+                    "(module m (type (Box a) (Full a) (Nil unit)) \
+                       (def (main) (match (Full 6) ((Full v) (+ v 1)) ((Nil _u) -1))) (export main))"
+                ),
+                "main"
+            ),
+            7
+        );
+        // The rust-decline witness: a Set of the generic lowercase-unit-payload sum must EMIT rust (the
+        // spurious stray Var previously left it non-Ord → "Set with a non-Ord element"). Exactly the shape
+        // the v-rust-backend ask flagged + the guide/playground idiom the (B) attempt's reject exposed; a
+        // HARD emit check on the RUST target (storeless-safe — no run).
+        let src = "(module m (type (Box a) (Full a) (Nil unit)) \
+                   (def (main (: k Int64)) (Set.len (Set.of (list (Full 1) (Full k) (Nil unit))))) (export main))";
+        let mut dbr = crate::db::Db::load(parse(src));
+        let layr = crate::layout::compute(&mut dbr).expect("layout");
+        crate::backend::emit(crate::backend::Target::Rust, &mut dbr, &layr, None, None).expect(
+            "a Set of a generic lowercase-unit-payload sum must emit rust — no spurious stray-Var non-Ord decline",
+        );
+    }
+
+    #[test]
     fn a_generic_same_name_newtype_constructs_and_matches() {
         // Generic + same-name compose: `(type Box (Box a))` constructs `(Box 42)` by the type name and
         // matches `(Box n)`, erasing to the raw payload. (The head-position rule fires on the USER node;


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref ecec1c3f702c85ce8b0efdb67602280f5b06cc48, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.