### PR TITLE
rcdzc: odd-width signed div MIN/-1 guards the DECLARED min, not the slot min (adv-67, HIGH differential)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
@@ -4451,14 +4451,39 @@ fn emit_arith(
             let overflow_possible = crate::lower::divisor_can_be_neg_one(db, rhs)
                 && !crate::lower::value_provably_nonneg(db, lhs);
             let overflow_guard = match types::int_type_is_signed(it) && overflow_possible {
-                // `<T>::MIN` names the value type's minimum (the width `it` fixed the operands to). A
-                // divisor of `-1` only exists for a signed type, so this arm is signed-only.
-                true => match types::rust_type(&Ty::Int(it)) {
-                    Some(t) => format!(
-                        "else if l == {t}::MIN && r == -1 {{ panic!(\"{} overflow\") }} ",
-                        op_name(op)
-                    ),
-                    None => String::new(),
+                // `MIN / -1` overflows the DECLARED width (the quotient +2^(N-1) is out of range). The guard
+                // must test the DECLARED-width minimum, NOT the STORAGE slot's `<T>::MIN`: an odd width
+                // (Int24, Int48) is stored in the next-larger machine prim (i32/i64), so `<slot>::MIN`
+                // (i32::MIN = -2^31) is NOT the type's min (-2^23 for Int24) — a `l == i32::MIN` guard NEVER
+                // fires for an Int24 value, so `MIN(-8388608) / -1` computed the out-of-range +8388608 and it
+                // escaped into downstream unchecked math (adv-67, HIGH differential: rust returned it, wasm
+                // trapped). Compute the declared min `-(1 << (N-1))` from the width `w` and compare against
+                // THAT (as the checked +/-/* unusual-width path already re-checks the declared range). For an
+                // aliased width (8/16/32/64) the declared min == slot min, so this is behavior-identical there.
+                true => match (types::rust_type(&Ty::Int(it)), it.width) {
+                    (Some(t), Width::Fixed(w)) if (1..=64).contains(&w) => {
+                        // The declared minimum as a literal in the storage type `t`. TWO cases:
+                        //  • ALIASED width (8/16/32/64): the slot IS the declared width, so `{t}::MIN` is the
+                        //    exact declared min. MUST use it — the computed `-(1{t} << (w-1))` would OVERFLOW
+                        //    the slot at w==bits (`1i32 << 31` = 2^31 doesn't fit i32 → rustc "arithmetic
+                        //    operation will overflow"). This is the original behavior, preserved for the
+                        //    aliased widths (where it was already correct).
+                        //  • ODD width (Int24, Int48 — stored in the next-larger slot): `{t}::MIN` is the
+                        //    SLOT's min (i32::MIN for Int24), NOT the declared min (-2^23), so the guard would
+                        //    never fire (adv-67). Compute `-(1{t} << (w-1))` — the declared min fits the
+                        //    strictly-wider slot (w < slot bits), no overflow.
+                        let decl_min = if matches!(w, 8 | 16 | 32 | 64) {
+                            format!("{t}::MIN")
+                        } else {
+                            format!("(-(1{t} << {}))", w - 1)
+                        };
+                        format!(
+                            "else if l == {decl_min} && r == -1 {{ panic!(\"{} overflow\") }} ",
+                            op_name(op)
+                        )
+                    }
+                    // No storage type / non-fixed width — no guard (the operand type wasn't a fixed int).
+                    _ => String::new(),
                 },
                 false => String::new(),
             };

--- a/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
@@ -635,6 +635,50 @@ fn rustc_roundtrip_signed_div_min_by_neg1_traps_overflow_not_div_by_zero() {
 }
 
 #[test]
+fn rustc_odd_width_signed_div_min_by_neg1_guards_the_declared_min_not_the_slot_min() {
+    // adv-67 (HIGH differential): an ODD-width signed type (Int24, stored in the i32 slot) `MIN / -1` must
+    // trap OVERFLOW — the quotient +2^23 is OUT of the Int24 range. The bug: the guard tested `l == i32::MIN`
+    // (the SLOT min), but Int24's declared MIN is -2^23 = -8388608, which never equals i32::MIN, so the
+    // guard never fired and `l / r` yielded the out-of-range +8388608 (rust returned it; wasm trapped).
+    // Fix: the guard tests the DECLARED-width min `-(1i32 << 23)`, NOT `i32::MIN`.
+    let rs = compile_rust("(module m (def (d (: a (Int 24)) (: b (Int 24))) (/ a b)) (export d))");
+    assert!(
+        rs.contains("(-(1i32 << 23)) && r == -1") && rs.contains("panic!(\"division overflow\")"),
+        "an Int24 div guards the DECLARED min (-(1i32<<23)), NOT the i32 slot min:\n{rs}"
+    );
+    // The guard must NOT test the slot min (the adv-67 bug): `i32::MIN && r == -1` would never fire.
+    assert!(
+        !rs.contains("i32::MIN && r == -1"),
+        "the Int24 div guard must NOT test the slot i32::MIN (adv-67 regression):\n{rs}"
+    );
+    // End-to-end: Int24 MIN (-8388608) / -1 must TRAP overflow (was returning the out-of-range +8388608).
+    match rustc_run_traps(&rs, "d(-8388608, -1)") {
+        TrapRun::Trapped(msg) => assert!(
+            msg.contains("overflow") && !msg.contains("by zero"),
+            "Int24 MIN / -1 must trap OVERFLOW (the escaped +8388608 was adv-67); panic was:\n{msg}"
+        ),
+        TrapRun::RanOk(out) => {
+            panic!("Int24 MIN / -1 must TRAP (overflow), but ran → {out} (adv-67)")
+        }
+        TrapRun::NoRustc => {}
+    }
+    // A NORMAL Int24 division still computes: MIN / -2 = +4194304 (in range, no trap).
+    if let Some(out) = rustc_run(&rs, "d(-8388608, -2)") {
+        assert_eq!(
+            out, "4194304",
+            "Int24 MIN / -2 is a normal in-range division"
+        );
+    }
+    // CONTROL: an ALIASED width (Int32) keeps testing the slot min `i32::MIN` (slot == declared width), so
+    // the fix is behavior-identical there — the declared-min computation is ONLY for odd widths.
+    let aliased = compile_rust("(module m (def (d (: a Int32) (: b Int32)) (/ a b)) (export d))");
+    assert!(
+        aliased.contains("i32::MIN && r == -1"),
+        "an aliased Int32 div still guards i32::MIN (slot == declared width):\n{aliased}"
+    );
+}
+
+#[test]
 fn a_provably_safe_signed_division_elides_its_min_by_neg1_overflow_guard() {
     // BOTH-BACKEND PARITY (v-core-opt Slice-7): the signed `MIN/-1` overflow guard is the Div member of
     // the guard-elision family. The rust `/` emit now consults the SAME Core-tier predicates the wasm


### PR DESCRIPTION
Candidate PR for v-rust-backend's merge-request (ref bce49c398, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.