### PR TITLE
rcdzc: extract the type name (+ head params) from a parenthesized (type (Name a) …) decl head

### DIFF
--- a/implementation/seed/crates/rcdzc/src/db.rs
+++ b/implementation/seed/crates/rcdzc/src/db.rs
@@ -5436,11 +5436,41 @@ pub(crate) fn scan_effect_decl(ast: &Arenas, item: StructId) -> Option<EffectDec
 /// prelude-sum synthesis, so a prelude `Option`/`Result` declaration scans exactly like a user one.
 pub(crate) fn scan_type_decl(ast: &Arenas, item: StructId) -> Option<TypeDecl> {
     let tail = ast.as_form(item, "type")?;
-    let name = tail
-        .first()
-        .and_then(|&s| ast.as_name(s))
-        .unwrap_or("")
-        .to_string();
+    // The type NAME is the first tail element in TWO spellings: a BARE atom `(type Box (Mk a))` — the name
+    // is the atom — OR a PARENTHESIZED head `(type (Box a b…) …)` — a `(Name params…)` list whose HEAD atom
+    // is the name and whose tail are the declared type parameters. Both are canonical in the corpus (`(type
+    // Box (Box a))` and `(type (Box a) (Full a) (Nil unit))`). Without the list-head case, `as_name` on the
+    // `(Box a)` list returned `None` → the name defaulted to `""`, so the type was registered under the
+    // empty string: it worked in VALUE position (resolved by its VARIANT names) but was UNRESOLVABLE by
+    // NAME in a TYPE-EXPRESSION position — `(: b (Box Int64))` / `(: b Box)` / a `(Wrap (Box Int64))`
+    // payload reported CDZ0101 "unknown type `Box`", while the built-in `(Option Int64)` (prelude) worked.
+    let head = tail.first().copied();
+    let (name, head_params) = match head.map(|s| ast.get(s)) {
+        // Bare-atom name: `(type Box …)`.
+        Some(Struct::Atom(_)) => (
+            head.and_then(|s| ast.as_name(s)).unwrap_or("").to_string(),
+            Vec::new(),
+        ),
+        // Parenthesized `(Name params…)` head: the list's head atom is the name; its lowercase tail atoms
+        // are the declared type params (collected in first-appearance order alongside the payload-implied
+        // ones below, so a HEAD-ONLY param — a phantom `(type (P a) (Mk Int64))` — is not lost).
+        Some(Struct::List(kids)) => {
+            let nm = kids
+                .first()
+                .and_then(|&h| ast.as_name(h))
+                .unwrap_or("")
+                .to_string();
+            let ps: Vec<String> = kids
+                .iter()
+                .skip(1)
+                .filter_map(|&p| ast.as_name(p))
+                .filter(|p| p.starts_with(|c: char| c.is_ascii_lowercase()) && *p != "unit")
+                .map(str::to_string)
+                .collect();
+            (nm, ps)
+        }
+        None => (String::new(), Vec::new()),
+    };
     // An OPEN sum ends in a trailing `.. r` row-variable marker (`type-system.md §204/§208`): `(type T
     // (Known Int64) .. r)`. The `..` token already lexes (list-rest); here it marks the sum OPEN and `r`
     // (a lowercase name) is the row variable. Detect it as the two FINAL elements of the `(type …)` tail
@@ -5493,9 +5523,13 @@ pub(crate) fn scan_type_decl(ast: &Arenas, item: StructId) -> Option<TypeDecl> {
             // (`ctor` is filled by `sums::synthesize` once the record is built.)
         }
     }
-    // Collect the IMPLICIT type parameters: a free LOWERCASE name in any payload, in first-appearance
-    // order across the variants (`(type Option (Some a) None)` → `["a"]`). A Capitalized name is a type.
-    let mut params: Vec<String> = Vec::new();
+    // Collect the type parameters. EXPLICIT head params (`(type (Box a) …)` → `["a"]`) come first, in the
+    // order declared; then the IMPLICIT payload params — a free LOWERCASE name in any variant payload, in
+    // first-appearance order (`(type Option (Some a) None)` → `["a"]`; a Capitalized name is a type). A
+    // param already named in the head is not re-added (a head-declared `a` mentioned again in a payload is
+    // one param). This keeps a HEAD-ONLY (phantom) param and de-dups the common case where the head param
+    // also appears in a payload.
+    let mut params: Vec<String> = head_params;
     for variant in &variants {
         for &p in &variant.payloads {
             collect_type_params(ast, p, &mut params);

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -24145,6 +24145,48 @@ mod match_engine {
     }
 
     #[test]
+    fn a_parenthesized_head_generic_sum_resolves_by_name_in_a_type_annotation() {
+        // A generic sum declared with the PARENTHESIZED-head spelling `(type (Container a) …)` (name +
+        // params in the head, a corpus-canonical form alongside `(type Box (Mk a))`) must resolve BY NAME in
+        // a TYPE-EXPRESSION position — a parameter annotation `(: b (Container Int64))` / a variant payload
+        // `(Wrap (Container Int64))`. `scan_type_decl` read the name off `tail.first()` as an ATOM, so a
+        // `(Container a)` LIST head gave `as_name = None` → the type registered under the EMPTY name "": it
+        // worked in VALUE position (resolved by its VARIANT names) but was UNRESOLVABLE by name in a type
+        // position — `(: b (Container Int64))` reported CDZ0101 "unbound name `Container`", while the
+        // built-in `(Option Int64)` worked. Now the name is taken from the `(Name …)` head. `(Full 7)`
+        // through `unwrap` = 7.
+        assert_eq!(
+            run_returns_with::<i64>(
+                &component(
+                    "(module m (type (Container a) (Full a)) \
+                       (def (unwrap (: b (Container Int64))) (match b ((Full v) v))) \
+                       (def (main (: k Int64)) (unwrap (Full k))) (export main))"
+                ),
+                "main",
+                &[wasmtime::component::Val::S64(7)],
+            ),
+            7
+        );
+        // A BARE (unapplied) generic name in an annotation now behaves EXACTLY like the built-in `(: b
+        // Option)`: CDZ0203 "`Container` is a type constructor — it needs a type argument here" (a generic
+        // type must be applied). Before the fix it was the WRONG "unknown type `Container`" (name unresolved
+        // entirely); now it resolves as a type constructor and correctly asks for its argument — the same
+        // diagnostic `Option` gives, confirming user generics resolve like built-ins.
+        let msg = compile_component(&crate::codec::encode(&crate::testkit::parse(
+            "(module m (type (Container a) (Full a)) \
+               (def (u (: b Container)) (match b ((Full v) v))) \
+               (def (main (: k Int64)) (u (Full k))) (export main))",
+        )))
+        .expect_err("a bare generic annotation must ask for its type argument")
+        .message;
+        assert!(
+            msg.contains("`Container` is a type constructor")
+                && msg.contains("needs a type argument"),
+            "bare generic annotation asks for its arg like Option, got: {msg}"
+        );
+    }
+
+    #[test]
     fn a_generic_same_name_newtype_constructs_and_matches() {
         // Generic + same-name compose: `(type Box (Box a))` constructs `(Box 42)` by the type name and
         // matches `(Box n)`, erasing to the raw payload. (The head-position rule fires on the USER node;


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref 4a7eabe67753673eb8c57e040cec31a619204f3a, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.