### PR TITLE
rcdzc: shared type-decl-head name decoder — de-dup head params + fix sibling name-readers (PR #1683 review)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/ast.rs
+++ b/implementation/seed/crates/rcdzc/src/ast.rs
@@ -1147,6 +1147,24 @@ impl Arenas {
         }
     }
 
+    /// The declared TYPE NAME from a `(type …)` decl's FIRST tail element `head_occ` (the element after the
+    /// `type` keyword). Two spellings: a BARE atom `(type Box …)` — the atom IS the name — OR a
+    /// PARENTHESIZED head `(type (Box a b…) …)` — a `(Name params…)` list whose HEAD atom is the name.
+    /// `None` if `head_occ` is neither (a malformed decl). The ONE place both spellings are decoded, so every
+    /// raw `(type …)`-tail name-reader (the linker's export/import `top_item_defined_name`, the
+    /// invariant-establish plan, the proptest `classify_sum`/`name_resolves_to_user_type`, and
+    /// `scan_type_decl` itself) agrees — a bare `head_occ.as_name()` returns `None` for a `(List)` head, so
+    /// without this a parenthesized-head generic type was INVISIBLE to those readers (un-exported / not a
+    /// known user type). See [`crate::db::scan_type_decl`].
+    pub fn type_decl_head_name(&self, head_occ: StructId) -> Option<&str> {
+        match self.get(head_occ) {
+            // Bare-atom name: `(type Box …)`.
+            Struct::Atom(_) => self.as_name(head_occ),
+            // Parenthesized `(Name params…)` head: the list's head atom is the name.
+            Struct::List(kids) => kids.first().and_then(|&h| self.as_name(h)),
+        }
+    }
+
     /// If `id` is a `List` headed by the STRING-LITERAL `head` (a primitive constructor spelling like
     /// `"tuple"`/`"record"`), the tail (the argument occurrences). The string-head twin of [`as_form`].
     pub fn as_ctor_form(&self, id: StructId, head: &str) -> Option<&[StructId]> {

--- a/implementation/seed/crates/rcdzc/src/db.rs
+++ b/implementation/seed/crates/rcdzc/src/db.rs
@@ -5445,31 +5445,31 @@ pub(crate) fn scan_type_decl(ast: &Arenas, item: StructId) -> Option<TypeDecl> {
     // NAME in a TYPE-EXPRESSION position — `(: b (Box Int64))` / `(: b Box)` / a `(Wrap (Box Int64))`
     // payload reported CDZ0101 "unknown type `Box`", while the built-in `(Option Int64)` (prelude) worked.
     let head = tail.first().copied();
-    let (name, head_params) = match head.map(|s| ast.get(s)) {
-        // Bare-atom name: `(type Box …)`.
-        Some(Struct::Atom(_)) => (
-            head.and_then(|s| ast.as_name(s)).unwrap_or("").to_string(),
-            Vec::new(),
-        ),
-        // Parenthesized `(Name params…)` head: the list's head atom is the name; its lowercase tail atoms
-        // are the declared type params (collected in first-appearance order alongside the payload-implied
-        // ones below, so a HEAD-ONLY param — a phantom `(type (P a) (Mk Int64))` — is not lost).
+    // The type NAME via the shared decoder (bare atom `(type Box …)` OR parenthesized `(type (Box a) …)`
+    // head), so every raw `(type …)`-tail name-reader agrees (see `Arenas::type_decl_head_name`).
+    let name = head
+        .and_then(|s| ast.type_decl_head_name(s))
+        .unwrap_or("")
+        .to_string();
+    // Explicit HEAD params from a parenthesized `(Name params…)` head — the lowercase tail atoms, in
+    // first-appearance order, DE-DUPED (a `(type (Box a a) …)` names `a` once — mirrors `collect_type_params`
+    // below, so `decl.params.len()` is the true arity, not an overcount). `unit` is the value/type, never a
+    // param. Empty for a bare-atom head. Payload-implied params are appended (also de-duped) below.
+    let head_params: Vec<String> = match head.map(|s| ast.get(s)) {
         Some(Struct::List(kids)) => {
-            let nm = kids
-                .first()
-                .and_then(|&h| ast.as_name(h))
-                .unwrap_or("")
-                .to_string();
-            let ps: Vec<String> = kids
-                .iter()
-                .skip(1)
-                .filter_map(|&p| ast.as_name(p))
-                .filter(|p| p.starts_with(|c: char| c.is_ascii_lowercase()) && *p != "unit")
-                .map(str::to_string)
-                .collect();
-            (nm, ps)
+            let mut ps: Vec<String> = Vec::new();
+            for &p in kids.iter().skip(1) {
+                if let Some(n) = ast.as_name(p)
+                    && n.starts_with(|c: char| c.is_ascii_lowercase())
+                    && n != "unit"
+                    && !ps.iter().any(|q| q == n)
+                {
+                    ps.push(n.to_string());
+                }
+            }
+            ps
         }
-        None => (String::new(), Vec::new()),
+        _ => Vec::new(),
     };
     // An OPEN sum ends in a trailing `.. r` row-variable marker (`type-system.md §204/§208`): `(type T
     // (Known Int64) .. r)`. The `..` token already lexes (list-rest); here it marks the sum OPEN and `r`

--- a/implementation/seed/crates/rcdzc/src/invariant_establish.rs
+++ b/implementation/seed/crates/rcdzc/src/invariant_establish.rs
@@ -280,9 +280,11 @@ pub(crate) fn synthesize(ast: &mut Arenas) -> crate::fxhash::FxHashSet<StructId>
         let Some(type_tail) = ast.as_form(inner, "type").map(<[_]>::to_vec) else {
             continue;
         };
+        // Name via the shared decoder (bare atom OR parenthesized `(Name a)` generic head), so an
+        // `@invariant` on a generic type declared `(type (Box a) …)` is recognized, not skipped.
         let Some(type_name) = type_tail
             .first()
-            .and_then(|&n| ast.as_name(n))
+            .and_then(|&n| ast.type_decl_head_name(n))
             .map(str::to_string)
         else {
             continue;

--- a/implementation/seed/crates/rcdzc/src/link.rs
+++ b/implementation/seed/crates/rcdzc/src/link.rs
@@ -772,10 +772,18 @@ fn top_item_defined_name(ast: &Arenas, item: StructId) -> Option<String> {
             _ => None,
         };
     }
-    if let Some(tail) = ast
-        .as_form(item, "type")
-        .or_else(|| ast.as_form(item, "effect"))
-    {
+    // A `(type …)` decl's name is decoded via the shared helper: a bare atom `(type Box …)` OR a
+    // parenthesized generic head `(type (Box a) …)` (the head atom is the name). Without the helper, a bare
+    // `tail.first().as_name()` returned `None` for a `(List)` head, so a parenthesized-head generic type was
+    // INVISIBLE to export/import name resolution (link.rs:413) — treated un-exported/absent (Copilot #1683).
+    if let Some(tail) = ast.as_form(item, "type") {
+        return tail
+            .first()
+            .and_then(|&s| ast.type_decl_head_name(s))
+            .map(str::to_string);
+    }
+    // An `(effect E …)` name is always a bare atom (no parenthesized generic-effect form), so read it plain.
+    if let Some(tail) = ast.as_form(item, "effect") {
         return tail
             .first()
             .and_then(|&s| ast.as_name(s))

--- a/implementation/seed/crates/rcdzc/src/proptest_gen.rs
+++ b/implementation/seed/crates/rcdzc/src/proptest_gen.rs
@@ -1195,7 +1195,7 @@ fn name_resolves_to_user_type(ast: &Arenas, ty: StructId, items: &[StructId]) ->
     items.iter().copied().any(|it| {
         type_decl_form(ast, it).is_some_and(|tail| {
             tail.first()
-                .is_some_and(|&n| ast.as_name(n) == Some(type_name))
+                .is_some_and(|&n| ast.type_decl_head_name(n) == Some(type_name))
         })
     })
 }
@@ -1209,7 +1209,7 @@ fn classify_sum(ast: &Arenas, type_name: &str, items: &[StructId], depth: usize)
     let decl_item = items.iter().copied().find(|&it| {
         type_decl_form(ast, it).is_some_and(|tail| {
             tail.first()
-                .is_some_and(|&n| ast.as_name(n) == Some(type_name))
+                .is_some_and(|&n| ast.type_decl_head_name(n) == Some(type_name))
         })
     })?;
     let decl_tail = type_decl_form(ast, decl_item)?;

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -24219,6 +24219,46 @@ mod match_engine {
     }
 
     #[test]
+    fn a_parenthesized_head_type_decl_dedups_repeated_head_params() {
+        // #1683 review gap (1): the parenthesized-head param collect must DE-DUP. A `(type (Box a a) …)`
+        // (a repeated head param — degenerate but well-formed input) must yield ONE param `a`, not `[a, a]`,
+        // so `decl.params.len()` is the true arity (an overcount made the ctor scheme read higher-arity →
+        // mis-type/render). `(Mk k)` through `(Box Int64)` = k.
+        assert_eq!(
+            run_returns_with::<i64>(
+                &component(
+                    "(module m (type (Box a a) (Mk a)) \
+                       (def (u (: b (Box Int64))) (match b ((Mk v) v))) \
+                       (def (main (: k Int64)) (u (Mk k))) (export main))"
+                ),
+                "main",
+                &[wasmtime::component::Val::S64(5)],
+            ),
+            5
+        );
+    }
+
+    #[test]
+    fn a_parenthesized_head_generic_type_name_is_visible_to_the_export_reader() {
+        // #1683 review gap (2): sibling `(type …)`-tail name-readers (the linker's `top_item_defined_name`,
+        // used for export/import name resolution) must decode the parenthesized `(type (Box a) …)` head via
+        // the shared `Arenas::type_decl_head_name`, not a bare `tail.first().as_name()` (which returns None
+        // for the `(Box a)` list head → the type was invisible/un-exported). A bare `(export Box)` of the
+        // generic type NAME now RESOLVES the name (it reaches the abstract-type-handle export path, whose
+        // single-module message names `Box` as a TYPE — proving the name resolved — rather than an
+        // "unknown"/absent). The message naming `Box` is the witness that the export reader saw the name.
+        let msg = compile_component(&crate::codec::encode(&crate::testkit::parse(
+            "(module m (type (Box a) (Mk a)) (def (main) 0) (export main) (export Box))",
+        )))
+        .expect_err("a bare type-handle export in a single module reports the no-importer message")
+        .message;
+        assert!(
+            msg.contains("`Box` names a TYPE") || msg.contains("abstract-type"),
+            "the export reader resolved the parenthesized-head generic name `Box`, got: {msg}"
+        );
+    }
+
+    #[test]
     fn a_generic_same_name_newtype_constructs_and_matches() {
         // Generic + same-name compose: `(type Box (Box a))` constructs `(Box 42)` by the type name and
         // matches `(Box n)`, erasing to the raw payload. (The head-position rule fires on the USER node;


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref cb0d1b28f8af196cc14193ee2ee3db1527717689, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.