### PR TITLE
rcdzc: order-independent Set element Ord-check + ALIASED_INT_WIDTHS cleanup; baseline the generic-user-sum flip (post-#1674)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
@@ -1892,10 +1892,15 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
             // caught by the `SetInsert` guard below.
             // A bare `Float` element is OK — it keys via the `CdzF64` wrapper (`ty_is_ord_key`). A
             // float-CARRYING compound element still declines (the wrapper isn't threaded through it).
-            let e0_ty = elems.first().map(|&e0| type_of(db, e0));
-            if let Some(et) = &e0_ty
-                && !types::ty_is_ord_key(db, et)
-            {
+            // ELEMENT-TYPE grounding is ORDER-INDEPENDENT: a Set is homogeneous, so all elements share ONE
+            // element type, but `type_of` on a given node can be UNDER-GROUND (a `(Nil unit)` variant of
+            // `(Box a)` reads as `Box <openvar>` while a sibling `(Full k)` reads as the solved `Box Int64`).
+            // Check the BEST-grounded element (the first whose type `ty_is_ord_key` accepts), NOT `elems[0]`:
+            // else `Set.of (list (Nil unit) (Full k))` (Nil first) declined "non-Ord" while `(Full k)` first
+            // compiled — an order-dependent decline (breaker/v-inference, post-#1674, ground_open_vars class).
+            // Decline ONLY when NO element grounds to an Ord-key type (a genuinely-open or float-carrying set).
+            let elem_tys: Vec<Ty> = elems.iter().map(|&e| type_of(db, e)).collect();
+            if !elem_tys.is_empty() && !elem_tys.iter().any(|et| types::ty_is_ord_key(db, et)) {
                 return Err(Reject::decline(
                     "a Set with a non-Ord element (a float-carrying element, or a Bytes element whose order the spec does not bless) has no BTreeSet rep on the Rust backend",
                 ));
@@ -4472,7 +4477,7 @@ fn emit_arith(
                         //    SLOT's min (i32::MIN for Int24), NOT the declared min (-2^23), so the guard would
                         //    never fire (adv-67). Compute `-(1{t} << (w-1))` — the declared min fits the
                         //    strictly-wider slot (w < slot bits), no overflow.
-                        let decl_min = if matches!(w, 8 | 16 | 32 | 64) {
+                        let decl_min = if crate::ty::ALIASED_INT_WIDTHS.contains(&w) {
                             format!("{t}::MIN")
                         } else {
                             format!("(-(1{t} << {}))", w - 1)
@@ -4595,7 +4600,8 @@ fn emit_arith(
                 // max 15, `24>>3`==3 round-trips clean → 24 escaped, poisoning a CHAMP Set). So for an odd
                 // width ADD a DECLARED-RANGE check on `r` (the same `[min_N, max_N]` bound the checked +/-/*
                 // unusual-width path uses). An aliased width keeps ONLY the round-trip (slot==declared).
-                let odd_width = (1..=64).contains(&width) && !matches!(width, 8 | 16 | 32 | 64);
+                let odd_width =
+                    (1..=64).contains(&width) && !crate::ty::ALIASED_INT_WIDTHS.contains(&width);
                 let range_check = if odd_width {
                     let signed = it.ground_signed();
                     let (min_n, max_n): (i128, i128) = if signed {

--- a/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
@@ -5512,6 +5512,51 @@ fn rustc_value_eq_over_an_empty_set_of_an_unconstrained_element_type() {
 }
 
 #[test]
+fn rustc_set_element_ord_check_is_order_independent_across_members() {
+    // ORDER-INDEPENDENT element grounding (breaker/v-inference post-#1674, ground_open_vars class): a Set
+    // is homogeneous, but `type_of` on a `(Nil unit)` variant of `(Box a)` reads as `Box <openvar>` (under-
+    // ground) while a sibling `(Full k)` reads as the solved `Box Int64`. The Ord-check must consult the
+    // BEST-grounded element across ALL members, NOT `elems[0]`: else Nil-FIRST declined "non-Ord" while
+    // Full-first compiled — an order-dependent decline. Both orders now emit + run (dedup → len 2).
+    let nil_first = compile_rust(
+        "(module m (type (Box a) (Full a) (Nil unit)) \
+           (def (go (: k Int64)) (Set.len (Set.of (list (Nil unit) (Full k))))) (export go))",
+    );
+    assert!(
+        nil_first.contains("BTreeSet") && !nil_first.contains("__cdz_"),
+        "Nil-FIRST set-of a unit-payload generic sum emits a BTreeSet (was an order-dependent decline):\n{nil_first}"
+    );
+    if let Some(out) = rustc_run(&nil_first, "go(1)") {
+        assert_eq!(
+            out, "2",
+            "Nil-first {{Full 1, Nil}} has 2 distinct elements"
+        );
+    }
+    // Full-FIRST (already worked) — pin it stays correct (the fix must not regress the working order).
+    let full_first = compile_rust(
+        "(module m (type (Box a) (Full a) (Nil unit)) \
+           (def (go (: k Int64)) (Set.len (Set.of (list (Full k) (Nil unit))))) (export go))",
+    );
+    if let Some(out) = rustc_run(&full_first, "go(1)") {
+        assert_eq!(
+            out, "2",
+            "Full-first order is unchanged (still 2 distinct elements)"
+        );
+    }
+    // CONTROL: a genuinely NON-Ord element (a `List Float64` — a float list has no total order; the
+    // per-element `__CdzF` wrapper is NOT threaded through a List) still declines — the fix only admits a
+    // set where SOME member grounds to an Ord-key type, it does not make every set Ord.
+    let float_list_elem = compile_rust_result(
+        "(module m (def (go (: d Float64)) \
+           (Set.len (Set.of (list (list d) (list d))))) (export go))",
+    );
+    assert!(
+        float_list_elem.is_err(),
+        "a Set of a `List Float64` element still declines (no Ord member):\n{float_list_elem:?}"
+    );
+}
+
+#[test]
 fn rustc_roundtrip_single_variant_newtype_literal_payload_arm_at_narrow_widths() {
     // A single-variant newtype matched with a LITERAL-payload arm (`(match (W.Wrap n) ((W.Wrap 0) 100)
     // ((W.Wrap x) x))`, `W = (Wrap UInt8)`). The newtype tag ERASES (`(W.Wrap n)` → `n`), so `lower`


### PR DESCRIPTION
Candidate PR for v-rust-backend's merge-request (ref 82f808ad8, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.