### PR TITLE
rcdzc: emit a BOOL host-call argument (marshal to i64) — the one scalar-arg parity gap (v-effects-routed)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
@@ -2924,6 +2924,12 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
                 // float/compound arg has no boundary form yet → decline.
                 let bound = if int_rust_ty(&a_rt) {
                     format!("({av}) as i64")
+                } else if a_rt == "bool" {
+                    // A BOOL argument marshals to `i64` (0/1) — the SAME uniform integer marshal an int arg
+                    // uses, matching wasm (which reps Bool as i32 and crosses it fine). `as i64` doesn't apply
+                    // to `bool` in Rust, so cast through `i64::from(<bool>)`. The generated shim param is
+                    // generic and ignores the value; the corpus host-call sequence compares the op name only.
+                    format!("i64::from({av})")
                 } else if a_rt == "String" || a_rt == "Vec<u8>" {
                     av
                 } else if a_rt == "()" {
@@ -2934,7 +2940,7 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
                     format!("{{ {av}; () }}")
                 } else {
                     return Err(Reject::decline(
-                        "the Rust backend does not yet render a host call with a non-integer/string/bytes/unit ARGUMENT (later increment)",
+                        "the Rust backend does not yet render a host call with a non-integer/bool/string/bytes/unit ARGUMENT (later increment)",
                     ));
                 };
                 bindings.push_str(&format!("let __ha{i} = {bound}; "));

--- a/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
@@ -7455,6 +7455,22 @@ fn rustc_host_call_with_int_arg_emits_left_to_right_bound_args() {
 }
 
 #[test]
+fn rustc_host_call_bool_arg_marshals_to_i64() {
+    // A BOOL host-call ARGUMENT (`io.pick : (-> Bool Int64)`, arg a guest comparison) marshals to `i64`
+    // via `i64::from(<bool>)` (0/1) — the SAME uniform integer marshal an int arg uses, matching wasm
+    // (which reps Bool as i32 and crosses it fine). Bool was the one scalar-arg gap the earlier arms missed
+    // (int/UInt/Int64 already passed; v-effects routed the Bool-specific parity gap). `as i64` doesn't apply
+    // to `bool` in Rust, so the cast goes through `i64::from`. Pins the Bool arm of the host-arg marshal.
+    let src = "(module m (effect io (op pick (-> Bool Int64))) \
+        (def (main (: k Int64)) (host (io) (io.pick (> k 100)))) (export main))";
+    let rs = compile_rust(src);
+    assert!(
+        rs.contains("let __ha0 = i64::from(") && rs.contains("crate::__cdz_host_io_pick(__ha0)"),
+        "a Bool host-call arg marshals via i64::from(<bool>) then passes __ha0 to the shim:\n{rs}"
+    );
+}
+
+#[test]
 fn rustc_host_call_float_result_reads_the_shim_f64() {
     // H4 host-call emit: a delegated FLOAT-result host op (`Param.ratio -> Unit Float64`, from an
     // `@param(widget: slider) ratio : Float64`) emits `(crate::__cdz_host_<key>() as f64)` — the runner's


### PR DESCRIPTION
Candidate PR for v-rust-backend's merge-request (ref 54435f1f5, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.