### PR TITLE
rcdzc(effects): fix a marshalled String/Bytes host-arg BEFORE a scalar arg emitting an invalid module (i32/i64 slot-width clobber)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
@@ -11416,6 +11416,13 @@ fn emit(
             // Only ONE runtime string arg per host call (they share the one fixed scratch buffer); a second
             // declines above rather than silently overwriting the first.
             let mut runtime_string_arg_seen = false;
+            // Each arg is emitted above the scratch its predecessors consumed — `arg_base` rises to `*high`
+            // after every arg (as the ordinary `Core::Call` arg loop does, ~6330). WITHOUT this, a runtime
+            // String/Bytes marshal reserves i32 rope/len/pos slots at `base.max(*high)` and bumps `*high`, but
+            // a FOLLOWING scalar arg emitted with the stale `base` would tee its i64 checked-arith guard into
+            // that same slot — one wasm local declared at two widths → an invalid module (the marshalled-arg-
+            // BEFORE-scalar order; the reverse worked only because the scalar bumped `*high` first).
+            let mut arg_base = base;
             for &arg in &args {
                 let at = crate::infer::type_of(db, arg);
                 match at {
@@ -11459,7 +11466,7 @@ fn emit(
                             }
                             runtime_string_arg_seen = true;
                             let scratch_base = host_arg_scratch_base(layout);
-                            let rope_slot = base.max(*high);
+                            let rope_slot = arg_base.max(*high);
                             *high = (*high).max(rope_slot + 3);
                             scratch_ty.insert(rope_slot, ValType::I32);
                             let len_slot = rope_slot + 1;
@@ -11500,8 +11507,11 @@ fn emit(
                         }
                     },
                     // A scalar argument emits its value directly.
-                    _ => emit(db, arg, slots, base, high, scratch_ty, layout, out)?,
+                    _ => emit(db, arg, slots, arg_base, high, scratch_ty, layout, out)?,
                 }
+                // Raise the floor past ANY scratch this arg consumed, so the NEXT arg allocates fresh slots
+                // (never reusing — and thus never re-typing — a slot a prior marshal/checked-op still owns).
+                arg_base = (*high).max(arg_base);
             }
             out.push(Lir::CallHostImport(index));
             Ok(())

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -66391,6 +66391,54 @@ mod stage1 {
     }
 
     #[test]
+    fn a_marshalled_host_arg_before_a_scalar_arg_keeps_distinct_slots_valid_module() {
+        // The multi-arg SLOT-THREADING regression: a runtime String/Bytes host arg reserves i32 rope/len/pos
+        // scratch (at `base.max(high)`) and bumps `high`, but the HostCall emit arm formerly reused the STALE
+        // `base` for the FOLLOWING arg. So a scalar arg AFTER a marshalled one teed its i64 checked-arith
+        // guard into a slot the marshal had declared i32 — one wasm local at two widths → an INVALID module
+        // (`wasm-tools validate: expected i64, found i32`). Only the marshalled-BEFORE-scalar order tripped it
+        // (scalar-first worked because the scalar bumped `high` first). Fixed by threading a rising `arg_base`
+        // (as the ordinary call arg loop, ~6330, already does). `Component::from_binary` RE-VALIDATES the
+        // composed component — the exact guard that failed pre-fix — and the run proves the scalar (`n`, also
+        // re-read after the call as `10*n`) was NOT clobbered: send responds 5, so 5 + 10*7 = 75. The corpus
+        // case pins the same shape cross-backend; this is the unit-level invalid-module guard.
+        use crate::testkit::parse;
+        let Some(runtime) = find_runtime_wasm() else {
+            eprintln!("[host-arg-slot-thread] runtime wasm not in the store; skipping run");
+            return;
+        };
+        let src = "(do (effect io (op send (-> Bytes Int64 Int64))) \
+                   (def (main (: k Int64)) \
+                     (host (io) \
+                       (let ((n (+ k 7))) \
+                         (+ (io.send (Bytes.of (list ((UInt 8).wrap k))) n) (* 10 n))))) \
+                   (export main))";
+        let bytes = compile_component(&crate::codec::encode(&parse(src)))
+            .expect("a marshalled host arg before a scalar arg must compile, not decline");
+        let engine = wasmtime::Engine::default();
+        wasmtime::component::Component::from_binary(&engine, &bytes).expect(
+            "the marshalled-arg-before-scalar component must be VALID (no i32/i64 slot-width clobber)",
+        );
+        let opts = cdz_run::RunOpts {
+            export: Some("main".to_string()),
+            args: vec!["0".to_string()],
+            runtime: Some(runtime),
+            runtime_cache_dir: None,
+            host_responses: vec![cdz_run::HostResponse {
+                op: "send".to_string(),
+                value: "5".to_string(),
+            }],
+        };
+        match cdz_run::run(&bytes, &opts).expect("run") {
+            cdz_run::Outcome::Value(s) => assert_eq!(
+                s, "75",
+                "the scalar arg (n=7, re-read after the call) survives distinct from the marshal scratch: 5 + 10*7"
+            ),
+            cdz_run::Outcome::Trap(t) => panic!("marshalled-arg-before-scalar run trapped: {t}"),
+        }
+    }
+
+    #[test]
     fn a_runtime_string_host_arg_handles_empty_and_multibyte_lengths() {
         // EDGE-LENGTH coverage for the `_mem` runtime-string-arg copy loop (the primary test uses a 1-byte
         // string). Two edges an off-by-one in the loop guard `pos >= len → done` would break: (1) an EMPTY

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -2800,6 +2800,7 @@ pass	a runtime BigInt three-way compare reports Equal at a BEYOND-Int64 magnitud
 pass	a runtime BigInt three-way compare reports equality as Equal
 pass	a runtime BigInt-inner quantity used as a Map key hits, and a different magnitude misses
 pass	a runtime Bool-payload ctor binder threads its Bool through construction and destructure
+pass	a runtime Bytes host-arg BEFORE a scalar arg keeps distinct core slots (no width-clobber)
 pass	a runtime Bytes rope in a SUM payload compares equal to its flat twin
 pass	a runtime Bytes rope in a record field compares equal to its flat twin
 pass	a runtime Bytes rope is found as a Set element by its flat twin

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -2822,6 +2822,7 @@ pass	a runtime BigInt three-way compare reports Equal at a BEYOND-Int64 magnitud
 pass	a runtime BigInt three-way compare reports equality as Equal
 pass	a runtime BigInt-inner quantity used as a Map key hits, and a different magnitude misses
 pass	a runtime Bool-payload ctor binder threads its Bool through construction and destructure
+pass	a runtime Bytes host-arg BEFORE a scalar arg keeps distinct core slots (no width-clobber)
 pass	a runtime Bytes rope in a SUM payload compares equal to its flat twin
 pass	a runtime Bytes rope in a record field compares equal to its flat twin
 pass	a runtime Bytes rope is found as a Set element by its flat twin

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -2764,6 +2764,7 @@ pass	a runtime BigInt three-way compare reports Equal at a BEYOND-Int64 magnitud
 pass	a runtime BigInt three-way compare reports equality as Equal
 pass	a runtime BigInt-inner quantity used as a Map key hits, and a different magnitude misses
 pass	a runtime Bool-payload ctor binder threads its Bool through construction and destructure
+todo	a runtime Bytes host-arg BEFORE a scalar arg keeps distinct core slots (no width-clobber)
 pass	a runtime Bytes rope in a SUM payload compares equal to its flat twin
 pass	a runtime Bytes rope in a record field compares equal to its flat twin
 pass	a runtime Bytes rope is found as a Set element by its flat twin

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -248,6 +248,29 @@
   (host-calls (call io.sink))
   (call   main (: 0 Int64)) (output (: 57 Int64)))
 
+(case "a runtime Bytes host-arg BEFORE a scalar arg keeps distinct core slots (no width-clobber)"
+  (doc    "The multi-arg slot-threading edge of the host-ARG marshal: a RUNTIME String/Bytes arg reserves
+           i32 rope/len/pos scratch slots (at `base.max(high)`) and bumps `high`, but the emit arm formerly
+           reused the STALE `base` for the FOLLOWING arg — so a subsequent scalar's i64 checked-arith guard
+           teed into a slot the marshal had declared i32, one wasm local at two widths → an INVALID module
+           (`func failed to validate: expected i64, found i32`). Only the marshalled-arg-BEFORE-scalar order
+           tripped it; scalar-before-marshalled worked because the scalar bumped `high` first. Fixed by
+           threading a rising `arg_base` (as the ordinary call arg loop does). Here `n = k+7` is BOTH the
+           scalar arg AND re-read after the call (`10*n`), so a clobbered slot would corrupt the output, not
+           just fail to validate: send responds 5, so 5 + 10*7 = 75. (rust-async: todo pending its host-arg
+           path; wasm + rust pin the pass.)")
+  (input  (do
+            (effect io (op send (-> Bytes Int64 Int64)))
+            (def (main (: k Int64))
+              (host (io)
+                (let ((n (+ k 7)))
+                  (+ (io.send (String.to-bytes (String.concat "ab" (if (> k 100) "z" "cd"))) n)
+                     (* 10 n)))))
+            (export main)))
+  (host-responses (respond io.send (: 5 Int64)))
+  (host-calls (call io.send))
+  (call   main (: 0 Int64)) (output (: 75 Int64)))
+
 (case "one host effect with TWO ops interleaves its calls in program order"
   (doc    "The per-run response cursor over a MULTI-OP effect: geta, getb, geta consume rows 1,2,3 in
            the order made — the cursor is per-RUN, not per-op (a per-op cursor would give the second


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 9c1474020, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.