### PR TITLE
rcdzc(effects): doc-nit fix-forward on #1711 — reference emit_call_args/emit_loop_iteration by name (not a ~6330 line-anchor) + dot HostResponse.op

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
@@ -11417,7 +11417,8 @@ fn emit(
             // declines above rather than silently overwriting the first.
             let mut runtime_string_arg_seen = false;
             // Each arg is emitted above the scratch its predecessors consumed — `arg_base` rises to `*high`
-            // after every arg (as the ordinary `Core::Call` arg loop does, ~6330). WITHOUT this, a runtime
+            // after every arg (the same `arg_base = *high` threading the call/tail-call arg loops use —
+            // `emit_call_args` and `emit_loop_iteration`). WITHOUT this, a runtime
             // String/Bytes marshal reserves i32 rope/len/pos slots at `base.max(*high)` and bumps `*high`, but
             // a FOLLOWING scalar arg emitted with the stale `base` would tee its i64 checked-arith guard into
             // that same slot — one wasm local declared at two widths → an invalid module (the marshalled-arg-

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
@@ -11519,22 +11519,33 @@ fn emit(
         // (The `Core::ExternCall` emit arm was REMOVED in U4 — a peer op is now a peer-bound effect's
         // escaping `Core::HostCall`, which the `Core::HostCall` arm above emits as a `CallExternImport`
         // when the effect is peer-bound.)
-        // A SEQUENCING block — emit each statement FOR ITS EFFECT (in order), then the tail as the value.
-        // A statement is a host call whose result is `Unit` (it leaves NOTHING on the stack — a
-        // `func()`-typed import), so emitting it needs no `drop`; a value-leaving statement is not produced
-        // here yet (the `do`-fold only sequences Unit-returning host calls). The tail leaves the block's
-        // value on the stack.
+        // A SEQUENCING block — emit each non-final statement FOR ITS EFFECT (in order), then the tail as the
+        // value. The `do`-fold (`lower.rs`) puts a statement here only when SOME non-final statement reaches a
+        // host call; a statement itself is classified per the DEAD-INIT ruling (rust already does this,
+        // adv-56 — this is the wasm parity face):
+        //   • a statement that does NOT reach a host call is a DISCARDED PURE form — its value flows nowhere,
+        //     so it is UNOBSERVED and must be ELIDED (not emitted). Emitting it would (a) leave a dangling
+        //     value on the stack (imbalance) and (b) FORCE a trap that must not fire — `(do (/ 100 d) …)` at
+        //     d=0 yields the tail, the div-by-zero is dead. This is EXACTLY the predicate CDZ0307 warns on
+        //     (`collect_discarded_value_warnings` reads the same `subtree_reaches_host_call`), so no drift.
+        //   • a statement that DOES reach a host call must be EMITTED (the call crosses the boundary). A
+        //     Unit-result host call leaves nothing (a `func()`-typed import) — emit as-is. A value-leaving
+        //     host call (a discarded non-Unit result, e.g. `(io.put 1)` returning Int64) leaves its value on
+        //     the stack, so `Drop` it to keep the block balanced (the tail is the block's value).
+        //= spec/capabilities/core-semantics.md#a-sequencing-block-evaluates-its-forms-in-order
+        //# A sequencing block MUST evaluate to the value of its last form.
         Core::Seq { stmts, tail } => {
             for s in &stmts {
-                // A statement must leave nothing on the stack (a Unit host call). Guard it: a non-Unit
-                // statement would leave a dangling value (stack imbalance) — decline rather than emit it.
-                if !matches!(crate::infer::type_of(db, *s), Ty::Unit) {
-                    return Err(Reject::decline(
-                        "a sequencing statement that leaves a value is not yet emitted (only a \
-                         unit-returning host-call statement)",
-                    ));
+                // A discarded PURE statement is unobserved — elide it (its trap, if any, is dead-init).
+                if !crate::lower::subtree_reaches_host_call(db, *s) {
+                    continue;
                 }
+                // A host-reaching statement must run. Emit it; if it leaves a value (a non-Unit host-call
+                // result, discarded here), drop that value so the block stays stack-balanced.
                 emit(db, *s, slots, base, high, scratch_ty, layout, out)?;
+                if !matches!(crate::infer::type_of(db, *s), Ty::Unit) {
+                    out.push(Lir::Drop);
+                }
             }
             emit(db, tail, slots, base, high, scratch_ty, layout, out)
         }

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -66398,7 +66398,7 @@ mod stage1 {
         // guard into a slot the marshal had declared i32 — one wasm local at two widths → an INVALID module
         // (`wasm-tools validate: expected i64, found i32`). Only the marshalled-BEFORE-scalar order tripped it
         // (scalar-first worked because the scalar bumped `high` first). Fixed by threading a rising `arg_base`
-        // (as the ordinary call arg loop, ~6330, already does). `Component::from_binary` RE-VALIDATES the
+        // (the same `arg_base = *high` pattern `emit_call_args` / `emit_loop_iteration` use). `Component::from_binary` RE-VALIDATES the
         // composed component — the exact guard that failed pre-fix — and the run proves the scalar (`n`, also
         // re-read after the call as `10*n`) was NOT clobbered: send responds 5, so 5 + 10*7 = 75. The corpus
         // case pins the same shape cross-backend; this is the unit-level invalid-module guard.
@@ -66425,7 +66425,9 @@ mod stage1 {
             runtime: Some(runtime),
             runtime_cache_dir: None,
             host_responses: vec![cdz_run::HostResponse {
-                op: "send".to_string(),
+                // Dotted `E.op` per the HostResponse.op contract (effect `io`, op `send`); responses are
+                // consumed in order, so the name is for the diagnostic, but match the documented form.
+                op: "io.send".to_string(),
                 value: "5".to_string(),
             }],
         };

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -3571,6 +3571,7 @@ pass	a value definition may carry a leading doc, like a function definition
 pass	a value-eq guard on a LITERAL-probe arm drives a tail-recursive loop
 pass	a value-eq guard on a SUM-match arm drives a tail-recursive loop
 pass	a value-eq guard on a wildcard arm drives a tail-recursive loop
+pass	a value-leaving host-call statement in a do-body runs and its result is dropped (dead-init sibling)
 pass	a variadic Ast form is folded via a tail-splice rest-binder over its operands
 pass	a variant carrying a Char payload constructs, matches, and binds it
 pass	a variant carrying a RECORD payload constructs and matches
@@ -5627,7 +5628,7 @@ todo	a String host RESULT crosses the boundary and is read twice (byte-len + sca
 todo	a Symbol entry parameter compares to an interned constant
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject
 todo	a constant-try helper that fails feeds the None arm's fallback into resume
-todo	a discarded pure trapping item in a host do-body is elided beside a host call (dead-init ruling)
+pass	a discarded pure trapping item in a host do-body is elided beside a host call (dead-init ruling)
 todo	a recursive scalar-walk classifies characters across a multibyte String entry arg
 todo	a runtime bin match decodes a FINAL constant-size utf8 segment
 todo	a runtime-DISC `?` inside a stored closure applies per-call once BRICK 3b lands

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -523,6 +523,7 @@ pass	a BigInt-inner quantity scales by a bare BigInt on the bigint path
 pass	a BigInt-inner quantity stored in a List reads back through List.at
 pass	a Bool argument to a parameter used in integer addition is rejected
 pass	a Bool generator derived from the seed is reproducible (same seed, same Bool)
+pass	a Bool host arg BESIDE a scalar and a String composes in one mixed-arity op
 pass	a Bool match with its arms in either order is exhaustive
 pass	a Bool match with only the true arm is non-exhaustive
 pass	a Bool-payload ctor BINDER used as a Bool in an if computes on the compiled path
@@ -2802,6 +2803,7 @@ pass	a runtime BigInt three-way compare agrees with the boolean ordering
 pass	a runtime BigInt three-way compare reports Equal at a BEYOND-Int64 magnitude
 pass	a runtime BigInt three-way compare reports equality as Equal
 pass	a runtime BigInt-inner quantity used as a Map key hits, and a different magnitude misses
+pass	a runtime Bool host arg crosses the boundary and drives two response bindings
 pass	a runtime Bool-payload ctor binder threads its Bool through construction and destructure
 pass	a runtime Bytes host-arg BEFORE a scalar arg keeps distinct core slots (no width-clobber)
 pass	a runtime Bytes rope in a SUM payload compares equal to its flat twin

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -3594,6 +3594,7 @@ pass	a value definition may carry a leading doc, like a function definition
 pass	a value-eq guard on a LITERAL-probe arm drives a tail-recursive loop
 pass	a value-eq guard on a SUM-match arm drives a tail-recursive loop
 pass	a value-eq guard on a wildcard arm drives a tail-recursive loop
+pass	a value-leaving host-call statement in a do-body runs and its result is dropped (dead-init sibling)
 pass	a variadic Ast form is folded via a tail-splice rest-binder over its operands
 pass	a variant carrying a Char payload constructs, matches, and binds it
 pass	a variant carrying a RECORD payload constructs and matches

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -527,6 +527,7 @@ pass	a BigInt-inner quantity scales by a bare BigInt on the bigint path
 pass	a BigInt-inner quantity stored in a List reads back through List.at
 pass	a Bool argument to a parameter used in integer addition is rejected
 pass	a Bool generator derived from the seed is reproducible (same seed, same Bool)
+pass	a Bool host arg BESIDE a scalar and a String composes in one mixed-arity op
 pass	a Bool match with its arms in either order is exhaustive
 pass	a Bool match with only the true arm is non-exhaustive
 pass	a Bool-payload ctor BINDER used as a Bool in an if computes on the compiled path
@@ -2825,6 +2826,7 @@ pass	a runtime BigInt three-way compare agrees with the boolean ordering
 pass	a runtime BigInt three-way compare reports Equal at a BEYOND-Int64 magnitude
 pass	a runtime BigInt three-way compare reports equality as Equal
 pass	a runtime BigInt-inner quantity used as a Map key hits, and a different magnitude misses
+pass	a runtime Bool host arg crosses the boundary and drives two response bindings
 pass	a runtime Bool-payload ctor binder threads its Bool through construction and destructure
 pass	a runtime Bytes host-arg BEFORE a scalar arg keeps distinct core slots (no width-clobber)
 pass	a runtime Bytes rope in a SUM payload compares equal to its flat twin

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -515,6 +515,7 @@ pass	a BigInt-inner quantity scales by a bare BigInt on the bigint path
 pass	a BigInt-inner quantity stored in a List reads back through List.at
 pass	a Bool argument to a parameter used in integer addition is rejected
 pass	a Bool generator derived from the seed is reproducible (same seed, same Bool)
+todo	a Bool host arg BESIDE a scalar and a String composes in one mixed-arity op
 pass	a Bool match with its arms in either order is exhaustive
 pass	a Bool match with only the true arm is non-exhaustive
 pass	a Bool-payload ctor BINDER used as a Bool in an if computes on the compiled path
@@ -2764,6 +2765,7 @@ pass	a runtime BigInt three-way compare agrees with the boolean ordering
 pass	a runtime BigInt three-way compare reports Equal at a BEYOND-Int64 magnitude
 pass	a runtime BigInt three-way compare reports equality as Equal
 pass	a runtime BigInt-inner quantity used as a Map key hits, and a different magnitude misses
+todo	a runtime Bool host arg crosses the boundary and drives two response bindings
 pass	a runtime Bool-payload ctor binder threads its Bool through construction and destructure
 todo	a runtime Bytes host-arg BEFORE a scalar arg keeps distinct core slots (no width-clobber)
 pass	a runtime Bytes rope in a SUM payload compares equal to its flat twin

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -3529,6 +3529,7 @@ pass	a value definition may carry a leading doc, like a function definition
 pass	a value-eq guard on a LITERAL-probe arm drives a tail-recursive loop
 pass	a value-eq guard on a SUM-match arm drives a tail-recursive loop
 pass	a value-eq guard on a wildcard arm drives a tail-recursive loop
+todo	a value-leaving host-call statement in a do-body runs and its result is dropped (dead-init sibling)
 pass	a variadic Ast form is folded via a tail-splice rest-binder over its operands
 pass	a variant carrying a Char payload constructs, matches, and binds it
 pass	a variant carrying a RECORD payload constructs and matches

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -2814,8 +2814,9 @@
            recorded), not the pure discarded sibling. Pins that the Core::Seq emit ELIDES a discarded pure
            non-final statement rather than force-evaluating it (adv-56 rust miscompile — `let _ = <stmt>;`
            ran the trap). The pure-only dead-init twin (02-binding-and-control) elides the same way with no
-           host call; this is the host-call face. Rust passes (the fix landed there); wasm / rust-async
-           decline this host-delegated shape (todo).")
+           host call; this is the host-call face. Rust + wasm pass (the wasm Core::Seq emit elides a
+           non-host-reaching statement via the SAME `subtree_reaches_host_call` predicate CDZ0307 warns on);
+           rust-async declines this host-delegated shape (todo).")
   (input  (do
             (effect io (op put (-> Int64 Int64)))
             (def (main (: d Int64))
@@ -2826,6 +2827,26 @@
             (export main)))
   (host-responses (respond io.put (: 0 Int64)))
   (host-calls (call io.put))
+  (call   main (: 0 Int64)) (output (: 42 Int64)))
+
+(case "a value-leaving host-call statement in a do-body runs and its result is dropped (dead-init sibling)"
+  (doc    "The DROP face of the dead-init Core::Seq emit: `(do (io.put 1) (io.put 2) 42)` — the two non-final
+           statements are VALUE-LEAVING host calls (`io.put : Int64 -> Int64`), not Unit. Each must RUN (both
+           host calls fire, recorded in order) but its returned value is DISCARDED — the emit drops the
+           leftover so the block stays stack-balanced and yields the tail, 42. Distinct from the pure-elide
+           sibling above (which does NOT emit its statement at all): a host-reaching statement is always
+           emitted; only a non-Unit RESULT is dropped. Pins the `Lir::Drop` arm the sibling's pure-elide path
+           doesn't exercise. Rust + wasm pass; rust-async todo pending its host-delegated Seq emit.")
+  (input  (do
+            (effect io (op put (-> Int64 Int64)))
+            (def (main (: k Int64))
+              (host (io)
+                (do (io.put 1)
+                    (io.put 2)
+                    42)))
+            (export main)))
+  (host-responses (respond io.put (: 0 Int64)) (respond io.put (: 0 Int64)))
+  (host-calls (call io.put) (call io.put))
   (call   main (: 0 Int64)) (output (: 42 Int64)))
 
 (case "a RESULT-returning effect op is matched on Ok / Err — the fallible-step idiom"

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -2664,6 +2664,37 @@
             (export main)))
   (call   main (: 0 Int64)) (output (: 7 Int64)))
 
+(case "a runtime Bool host arg crosses the boundary and drives two response bindings"
+  (doc    "The Bool scalar-ARG host-boundary face (v-rust-backend #1708 closed the rust arm: a bool
+           marshals to i64 via i64::from, matching wasm's i32 rep). Two host calls each take a runtime
+           bool computed from a comparison — `io.check (> n 5)` then `io.check (< n 5)` at n=7 → true then
+           false — and each response (10, 20) sums to 30. Pins the bool arg crosses AND that two ops
+           consume their rows in order. (breaker bh1, verified past its #1708 witness.) wasm + rust pass;
+           rust-async todo pending its host-delegated op-arg path.")
+  (input  (do
+            (effect io (op check (-> Bool Int64)))
+            (def (main (: n Int64))
+              (host (io) (+ (io.check (> n 5)) (io.check (< n 5)))))
+            (export main)))
+  (host-responses (respond io.check (: 10 Int64)) (respond io.check (: 20 Int64)))
+  (host-calls (call io.check) (call io.check))
+  (call   main (: 7 Int64)) (output (: 30 Int64)))
+
+(case "a Bool host arg BESIDE a scalar and a String composes in one mixed-arity op"
+  (doc    "The mixed-arity composition face: one op `(-> Bool Int64 String Int64)` takes a bool, a
+           scalar, AND a string arg together — the Bool marshal (#1708) composing with the existing
+           scalar and String-arg arms in a single arg list (the multi-arg slot-threading the
+           host-arg-before-scalar fix hardened). `io.log (= n 3) n \"tag\"` at n=3 → host answers 42.
+           (breaker bh2, verified.) wasm + rust pass; rust-async todo.")
+  (input  (do
+            (effect io (op log (-> Bool Int64 String Int64)))
+            (def (main (: n Int64))
+              (host (io) (io.log (= n 3) n "tag")))
+            (export main)))
+  (host-responses (respond io.log (: 42 Int64)))
+  (host-calls (call io.log))
+  (call   main (: 3 Int64)) (output (: 42 Int64)))
+
 (case "a RECURSIVE-sum value of runtime depth rides a handler resume"
   (doc    "An op whose declared result is a RECURSIVE sum (`Give.get : Unit -> Nat`) resumed with a
            runtime-depth spine `(mk a)`: the resume value is an unbounded heap structure, not a scalar or


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref db51b60f5, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.