### PR TITLE
rcdzc: reject a closure escaping an effect on the Rust backend (CDZ0406) — cross-backend diagnostic parity

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/rust/mod.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/mod.rs
@@ -579,6 +579,47 @@ pub fn emit(db: &mut Db, layout: &Layout, mode: Mode) -> Result<Vec<u8>, Reject>
         out.push('\n');
         out.push_str(&f);
     }
+    // REJECT a closure escaping an effect (CDZ0406) — the SAME rule the wasm backend enforces
+    // (`backend/wasm/mod.rs`): a lifted-lambda body that performs a host effect carries that effect OUT to
+    // the host, to be run when the host later invokes the closure — outside the delegation's dynamic extent,
+    // where the effect has no home. A closure's handler context does not travel with it across the boundary.
+    // The RUST backend previously had NO such guard, so it tried to EMIT the escaping-effect closure and
+    // produced un-compilable Rust (an unresolved host-shim call → E0061) — graded `todo` (BadArtifact) while
+    // wasm rejected CDZ0406 (a cross-backend diagnostic differential). Scan the reached lifted bodies for a
+    // host import and reject with the same code + message, so both backends agree. (A fully intra-program-
+    // HANDLED effect leaves no `Core::HostCall` in the lifted body and is NOT caught here — only an escaping
+    // one is.) Placed before the lifted-lambda emit so the reject fires instead of the broken emit.
+    {
+        let mut escaping = Vec::new();
+        for k in 0..layout.lifted.len() {
+            // Scan a lifted body when it is REACHED (a `Core::Closure` builds it) OR ETA-PEELED into an
+            // export (`peeled_codes`): a peeled closure's body IS emitted as the export's `pub fn`, and if
+            // that body performs an effect the closure still escapes it to the host — the exact case here
+            // (`(def (main) (host (ask) (fn (x) (+ x (ask.ask)))))` peels `main` to `fn main(x)` whose body
+            // performs `ask.ask`). Scanning ONLY the non-peeled reached slots (the earlier bug) missed the
+            // peeled export, so the reject didn't fire and the broken emit slipped through.
+            let peeled = peeled_codes.contains(&k);
+            let reached = layout.lifted_reached.get(k).copied().unwrap_or(false);
+            if peeled || reached {
+                crate::backend::wasm::host::collect_host_imports(
+                    db,
+                    layout.lifted[k].body,
+                    &mut escaping,
+                );
+            }
+        }
+        if let Some(h) = escaping.first() {
+            return Err(Reject::coded(
+                crate::diag::Code::ClosureEscapesEffect,
+                format!(
+                    "a closure that performs an effect ({}.{}) cannot cross the host boundary — the \
+                     closure's handler context does not travel with it, so the effect would have no home \
+                     when the host invokes it (closures escaping effects are not supported)",
+                    h.effect, h.op
+                ),
+            ));
+        }
+    }
     // Each REACHED lambda-lifted closure (`layout.lifted[k]`, reached by a `Core::Closure` in some body)
     // becomes a private `fn __lifted_{k}(<captures…>, <params…>) -> <ret>` — the closure VALUE a
     // `Core::Closure` builds calls into it. An UNREACHED slot is skipped (no `Core::Closure` names it, so

--- a/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
@@ -7471,6 +7471,30 @@ fn rustc_host_call_bool_arg_marshals_to_i64() {
 }
 
 #[test]
+fn rustc_closure_that_escapes_an_effect_rejects_cdz0406_not_a_broken_emit() {
+    // A closure whose body performs a DELEGATED effect and CROSSES the host boundary must be REJECTED
+    // (CDZ0406 — "closures escaping effects are not supported"): the closure's handler context does not
+    // travel with it, so the effect has no home when the host later invokes it. The wasm backend enforces
+    // this (backend/wasm/mod.rs); the rust backend previously had NO such guard, so it tried to EMIT the
+    // escaping-effect closure and produced un-compilable Rust (an unresolved host-shim call → E0061),
+    // graded `todo` while wasm rejected — a cross-backend diagnostic differential. The rust emit now scans
+    // the reached AND eta-peeled lifted bodies for a host import and rejects with the SAME code + message.
+    // Here `(def (main) (host (ask) (fn (x) (+ x (ask.ask)))))` peels `main` to `fn main(x)` whose body
+    // performs `ask.ask` — the peeled-export case the first (lifted-only) scan missed.
+    let src = "(module m (effect ask (op ask (-> Unit Int64))) \
+        (def (main) (host (ask) (fn ((: x Int64)) (+ x (ask.ask))))) (export main))";
+    let err = try_compile_rust(src).expect_err(
+        "a closure escaping an effect must REJECT on rust (CDZ0406), not emit broken Rust",
+    );
+    assert!(
+        err.iter().any(
+            |d| d.contains("closures escaping effects are not supported") && d.contains("ask.ask")
+        ),
+        "the rust reject must name the escaping effect + the unsupported feature (CDZ0406):\n{err:?}"
+    );
+}
+
+#[test]
 fn rustc_host_call_float_result_reads_the_shim_f64() {
     // H4 host-call emit: a delegated FLOAT-result host op (`Param.ratio -> Unit Float64`, from an
     // `@param(widget: slider) ratio : Float64`) emits `(crate::__cdz_host_<key>() as f64)` — the runner's

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5641,7 +5641,7 @@ pass	α-equivalence handles nesting and distinguishes a bound variable from a sa
 todo	Set.of over runtime lists at two different element types declines pending the recursive-generic tie
 todo	Type is a first-class value
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject
-todo	a closure that performs a delegated effect cannot cross the host boundary
+pass	a closure that performs a delegated effect cannot cross the host boundary
 todo	a constant-try helper that fails feeds the None arm's fallback into resume
 todo	a mutually-recursive decoder returns a heap value and cursor and its heap slot is dispatched
 todo	a recursive NEWTYPE traversal recurses on its projected recursive field

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5549,7 +5549,7 @@ todo	a build-time delegated effect whose result a returned closure captures does
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject
 todo	a closure captures the result of a build-time host op called with an argument
 todo	a closure capturing a build-time host effect preserves the order of two host calls
-todo	a closure that performs a delegated effect cannot cross the host boundary
+pass	a closure that performs a delegated effect cannot cross the host boundary
 todo	a conditional performs only the taken branch's effect — else
 todo	a conditional performs only the taken branch's effect — then
 todo	a constant-try helper that fails feeds the None arm's fallback into resume


### PR DESCRIPTION
Candidate PR for v-rust-backend's merge-request (ref 898e750b1, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.