### PR TITLE
fix(cdz-kernel): new_with_family preserves Cow zero-alloc for well-known families + restore dense SeqNo in the round-trip fixture (PRs #1722/#1717 review)

### DIFF
--- a/implementation/seed/crates/cdz-kernel/src/effect.rs
+++ b/implementation/seed/crates/cdz-kernel/src/effect.rs
@@ -243,12 +243,21 @@ impl EffectRequest {
         timeliness: Timeliness,
     ) -> Self {
         let family: std::sync::Arc<str> = family.into();
-        let kind = EffectKind::from_family(&family).unwrap_or(EffectKind::Emit);
+        // Canonicalize a well-known family to its `&'static str` const → `Cow::Borrowed`, ZERO alloc (the
+        // same zero-alloc invariant `new` holds via `kind.family()`; #1563 Cow work). Only a genuine
+        // register-by-string EXTENSION family (no built-in kind) owns its string.
+        let (kind, family) = match EffectKind::from_family(&family) {
+            Some(k) => {
+                let borrowed = std::borrow::Cow::Borrowed(k.family());
+                (k, borrowed)
+            }
+            None => (
+                EffectKind::Emit,
+                std::borrow::Cow::Owned(family.to_string()),
+            ),
+        };
         EffectRequest {
-            content_type: ContentType {
-                family: std::borrow::Cow::Owned(family.to_string()),
-                version: 1,
-            },
+            content_type: ContentType { family, version: 1 },
             kind,
             target: target.into(),
             payload,

--- a/implementation/seed/crates/cdz-kernel/src/event_ast.rs
+++ b/implementation/seed/crates/cdz-kernel/src/event_ast.rs
@@ -690,10 +690,9 @@ mod tests {
                     token: None,
                 },
             },
-            // A CONTROL / register-by-string dispatch: the family DIVERGES from kind.family() — kind is the
-            // `Emit` placeholder, the authoritative family is `control/capabilities` (the shape the I5 seed +
-            // the inline-answer arm produce). Pins that the codec preserves BOTH the placeholder kind AND the
-            // real family across a round-trip (the durability-fix field is not collapsed back onto the kind).
+            // A dispatch whose family DIVERGES from kind.family(): kind is the `Emit` placeholder, the
+            // family is `control/capabilities`. Pins that the codec preserves BOTH the kind AND the
+            // separately-recorded family across a round-trip (the family field is not collapsed onto kind).
             Event {
                 seq: 5,
                 cause: Some(h),
@@ -708,7 +707,7 @@ mod tests {
                 },
             },
             Event {
-                seq: 5,
+                seq: 6,
                 cause: None,
                 body: EventBody::EffectResult {
                     id: EffectId(7),
@@ -717,7 +716,7 @@ mod tests {
                 },
             },
             Event {
-                seq: 6,
+                seq: 7,
                 cause: None,
                 body: EventBody::EffectResult {
                     id: EffectId(8),
@@ -726,7 +725,7 @@ mod tests {
                 },
             },
             Event {
-                seq: 7,
+                seq: 8,
                 cause: None,
                 body: EventBody::EffectResult {
                     id: EffectId(9),
@@ -735,7 +734,7 @@ mod tests {
                 },
             },
             Event {
-                seq: 8,
+                seq: 9,
                 cause: None,
                 body: EventBody::EffectResult {
                     id: EffectId(9),
@@ -744,7 +743,7 @@ mod tests {
                 },
             },
             Event {
-                seq: 9,
+                seq: 10,
                 cause: None,
                 body: EventBody::TimerArmed {
                     id: EffectId(10),
@@ -753,7 +752,7 @@ mod tests {
                 },
             },
             Event {
-                seq: 10,
+                seq: 11,
                 cause: None,
                 body: EventBody::TimerFired {
                     id: EffectId(10),
@@ -762,7 +761,7 @@ mod tests {
                 },
             },
             Event {
-                seq: 11,
+                seq: 12,
                 cause: None,
                 body: EventBody::AuthzDenied {
                     id: EffectId(11),
@@ -771,14 +770,14 @@ mod tests {
                 },
             },
             Event {
-                seq: 12,
+                seq: 13,
                 cause: None,
                 body: EventBody::Closed {
                     outcome: Payload::Inline(vec![].into()),
                 },
             },
             Event {
-                seq: 13,
+                seq: 14,
                 cause: None,
                 body: EventBody::FoldFailed {
                     reason: "wasm reducer trapped: unreachable".to_string(),


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 18e01e7cd, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.