### PR TITLE
rcdzc(effects): strip_nominal in the Core::Seq stmt-drop Unit test — a nominal-Unit host-call stmt no longer underflows Lir::Drop (#1721 fix-forward)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
@@ -11542,9 +11542,13 @@ fn emit(
                     continue;
                 }
                 // A host-reaching statement must run. Emit it; if it leaves a value (a non-Unit host-call
-                // result, discarded here), drop that value so the block stays stack-balanced.
+                // result, discarded here), drop that value so the block stays stack-balanced. Strip nominals
+                // before the Unit test: a nominal-Unit (a newtype over `Unit`) leaves NO machine value at the
+                // boundary just like a bare `Unit` (`valtype_of` is None), so it must NOT be dropped — a
+                // `Lir::Drop` on an empty stack underflows → an invalid module. Mirrors the field-proj Unit
+                // check (~1108) and the tail-drop (~2486), both of which strip_nominal for the same reason.
                 emit(db, *s, slots, base, high, scratch_ty, layout, out)?;
-                if !matches!(crate::infer::type_of(db, *s), Ty::Unit) {
+                if !matches!(crate::infer::type_of(db, *s).strip_nominal(), Ty::Unit) {
                     out.push(Lir::Drop);
                 }
             }

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -727,6 +727,7 @@ pass	a NESTED sum-in-sum map key discriminates by the inner variant
 pass	a NESTED tuple of quantities renders every element scaled at depth
 pass	a NESTED tuple-of-tuples let pattern destructures a call's runtime result to all four leaves
 pass	a NESTED-tuple ARG composes with a NESTED-tuple RESULT
+pass	a NOMINAL-Unit-typed host-call statement in a do-body is not spuriously dropped
 pass	a NOMINAL-over-tuple ARG crosses as the underlying tuple (direct-call)
 pass	a NON-LAST handler arm whose body is a MATCH round-trips through the ML printer
 pass	a NON-TAIL host call consumes rows on the unwind, deepest frame first

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -748,6 +748,7 @@ pass	a NESTED sum-in-sum map key discriminates by the inner variant
 pass	a NESTED tuple of quantities renders every element scaled at depth
 pass	a NESTED tuple-of-tuples let pattern destructures a call's runtime result to all four leaves
 pass	a NESTED-tuple ARG composes with a NESTED-tuple RESULT
+pass	a NOMINAL-Unit-typed host-call statement in a do-body is not spuriously dropped
 pass	a NOMINAL-over-tuple ARG crosses as the underlying tuple (direct-call)
 pass	a NON-LAST handler arm whose body is a MATCH round-trips through the ML printer
 pass	a NON-TAIL host call consumes rows on the unwind, deepest frame first

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -719,6 +719,7 @@ pass	a NESTED sum-in-sum map key discriminates by the inner variant
 pass	a NESTED tuple of quantities renders every element scaled at depth
 pass	a NESTED tuple-of-tuples let pattern destructures a call's runtime result to all four leaves
 pass	a NESTED-tuple ARG composes with a NESTED-tuple RESULT
+todo	a NOMINAL-Unit-typed host-call statement in a do-body is not spuriously dropped
 pass	a NOMINAL-over-tuple ARG crosses as the underlying tuple (direct-call)
 pass	a NON-LAST handler arm whose body is a MATCH round-trips through the ML printer
 pass	a NON-TAIL recursion rebinding its rope arg to a slice-concat accumulates after each return

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -2880,6 +2880,28 @@
   (host-calls (call io.put) (call io.put))
   (call   main (: 0 Int64)) (output (: 42 Int64)))
 
+(case "a NOMINAL-Unit-typed host-call statement in a do-body is not spuriously dropped"
+  (doc    "The nominal-Unit edge of the Seq stmt-DROP arm (the sibling above): `(Done (io.fire k))` is a
+           non-final statement that REACHES a host call AND is typed `Done` — a NEWTYPE over `Unit`
+           (`(type Done (Done Unit))`). A nominal-Unit leaves NO machine value at the boundary just like a
+           bare `Unit` (`valtype_of` is None), so it must NOT be dropped. The drop test must strip nominals
+           (`type_of(..).strip_nominal() != Unit`) — WITHOUT that, `Done` ≠ `Ty::Unit` takes the drop branch
+           and `Lir::Drop` underflows the empty stack → an invalid module (`wasm-tools: expected a type but
+           nothing on stack`). io.fire still fires (recorded), the do yields io.get's response, 9. Mirrors
+           the field-proj / tail-drop Unit checks that already strip_nominal. Rust + wasm pass; rust-async
+           todo.")
+  (input  (do
+            (type Done (Done Unit))
+            (effect io (op fire (-> Int64 Unit)) (op get (-> Unit Int64)))
+            (def (main (: k Int64))
+              (host (io)
+                (do (Done (io.fire k))
+                    (io.get unit))))
+            (export main)))
+  (host-responses (respond io.fire (: 0 Int64)) (respond io.get (: 9 Int64)))
+  (host-calls (call io.fire) (call io.get))
+  (call   main (: 5 Int64)) (output (: 9 Int64)))
+
 (case "a RESULT-returning effect op is matched on Ok / Err — the fallible-step idiom"
   (doc    "The `Result` companion of the Option-result case: an operation whose declared result is a
            `(Result Int64 Int64)`, resumed with an `Ok` or `Err` chosen by the arm, and the body dispatches


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 683ee0d50, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.