### PR TITLE
rcdzc: two doc-nits from PR #1713/#1737 review — structural reason in top_item_defined_name (drop non-existent as_name pseudo-call) + test name resolve→resolves

### DIFF
--- a/implementation/seed/crates/rcdzc/src/link.rs
+++ b/implementation/seed/crates/rcdzc/src/link.rs
@@ -773,10 +773,11 @@ fn top_item_defined_name(ast: &Arenas, item: StructId) -> Option<String> {
         };
     }
     // A `(type …)` decl's name is decoded via the shared helper: a bare atom `(type Box …)` OR a
-    // parenthesized generic head `(type (Box a) …)` (the head atom is the name). Without the helper, a bare
-    // `tail.first().as_name()` returned `None` for a `(List)` head, so a parenthesized-head generic type had no
-    // defined-name here and was invisible to the export/import name resolution that reads this fn — treated
-    // un-exported/absent.
+    // parenthesized generic head `(type (Box a) …)` (the head atom is the name). Without the helper, reading
+    // a bare name off the first tail element missed the parenthesized case — a generic head `(type (Name a)
+    // …)` has a LIST as its first tail element, not an atom, so a name-only read yields nothing. That gave a
+    // parenthesized-head generic type no defined-name here, making it invisible to the export/import name
+    // resolution that reads this fn — treated un-exported/absent.
     if let Some(tail) = ast.as_form(item, "type") {
         return tail
             .first()

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -22290,7 +22290,7 @@ mod match_engine {
     }
 
     #[test]
-    fn a_multi_param_and_nested_user_generic_resolve_by_name_in_a_type_annotation() {
+    fn a_multi_param_and_nested_user_generic_resolves_by_name_in_a_type_annotation() {
         // Coverage-hardening for the parenthesized-head user-generic-by-name resolve (#1683/#1700): the
         // pinned case `a_parenthesized_head_generic_sum_resolves_by_name_in_a_type_annotation` covered a
         // SINGLE-param `(Container a)` in a flat annotation. Three untested faces of the SAME resolve path,


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref cdb26b619, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.