### PR TITLE
ci: enforce --locked in build.yml + drop stale "Cargo.lock gitignored" comments (root lock now tracked)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,11 +44,13 @@ jobs:
           cache-key: release-${{ matrix.target }}
 
       # Build the three shipped CLI binaries. Native host target, so no `--target` flag: the
-      # runner's host IS matrix.target (pin verified by the check below). --locked would need a
-      # committed Cargo.lock (gitignored here), so it is omitted deliberately.
+      # runner's host IS matrix.target (pin verified by the check below). `--locked` enforces the
+      # committed root Cargo.lock (tracked as of #1748, the operator's determinism directive): the
+      # build fails if the lock is stale vs any Cargo.toml, so a dep bump must land the updated lock
+      # deliberately rather than silently regenerate one per checkout.
       - name: Build release binaries
         run: |
-          cargo build --release \
+          cargo build --release --locked \
             -p cadenza-syntax --bin cdz-syntax \
             -p rcdzc --bin rcdzc \
             -p cdz-run --bin cdz-run

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -246,8 +246,7 @@ jobs:
           # the test step so the e2e tests exercise a FRESH build (no stale committed fixture to drift).
           #
           # NOT a byte-diff against the committed .wasm (was `cmp`): that assumed reproducible bytes, but
-          # the guest's transitive dep versions aren't lock-pinned (repo .gitignore ignores Cargo.lock)
-          # and CI floats rustc/wasm-tools, so CI resolved different crate/toolchain versions → different
+          # CI floats rustc/wasm-tools, so CI resolves different TOOLCHAIN versions → different
           # (still-valid) bytes → the cmp failed on every batch since #131, a false red masking real
           # signal (pr-sync note, trunk@455dcb7e7). The committed fixture's CORRECTNESS is already proven
           # at test time — `cargo test` below runs component_reducer_e2e, which loads the committed .wasm


### PR DESCRIPTION
Candidate PR for v-fleet-tooling's merge-request (ref 94c94daf6, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.