### PR TITLE
cdz-agent-host: cargo fmt — fix trunk rustfmt regression reding the unfiltered CI job fleet-wide

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/async_host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/async_host.rs
@@ -175,12 +175,14 @@ mod tests {
     impl Reducer for MarkAgent {
         async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
-                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
-                    effect_ct::NOW,
-                    String::new(),
-                    None,
-                    Timeliness::Interactive,
-                )]),
+                EventBody::Inbound { .. } => {
+                    FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::NOW,
+                        String::new(),
+                        None,
+                        Timeliness::Interactive,
+                    )])
+                }
                 EventBody::EffectResult {
                     result: EffectOutcome::Ok(_),
                     ..
@@ -290,12 +292,14 @@ mod tests {
     impl Reducer for TimerAgent {
         async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
-                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
-                    effect_ct::TIMER,
-                    self.deadline_ms.to_string(),
-                    None,
-                    Timeliness::Interactive,
-                )]),
+                EventBody::Inbound { .. } => {
+                    FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::TIMER,
+                        self.deadline_ms.to_string(),
+                        None,
+                        Timeliness::Interactive,
+                    )])
+                }
                 EventBody::TimerFired { .. } => {
                     kv.put(b"woke".to_vec(), b"1".to_vec());
                     FoldOutput::none()

--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -312,12 +312,14 @@ mod tests {
     impl Reducer for ClockAgent {
         async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
-                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
-                    effect_ct::NOW,
-                    String::new(),
-                    None,
-                    Timeliness::Interactive,
-                )]),
+                EventBody::Inbound { .. } => {
+                    FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::NOW,
+                        String::new(),
+                        None,
+                        Timeliness::Interactive,
+                    )])
+                }
                 EventBody::EffectResult {
                     result: EffectOutcome::Ok(_),
                     ..
@@ -364,12 +366,14 @@ mod tests {
     impl Reducer for TimerAgent {
         async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
-                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
-                    effect_ct::TIMER,
-                    self.deadline_ms.to_string(),
-                    None,
-                    Timeliness::Interactive,
-                )]),
+                EventBody::Inbound { .. } => {
+                    FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::TIMER,
+                        self.deadline_ms.to_string(),
+                        None,
+                        Timeliness::Interactive,
+                    )])
+                }
                 EventBody::TimerFired { .. } => {
                     kv.put(b"woke".to_vec(), b"1".to_vec());
                     FoldOutput::none()


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref a8f45f100, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.