### PR TITLE
cdz-agent-host: fix both trunk reds — rustfmt regression + replay_async→replay migration

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/async_host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/async_host.rs
@@ -175,12 +175,14 @@ mod tests {
     impl Reducer for MarkAgent {
         async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
-                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
-                    effect_ct::NOW,
-                    String::new(),
-                    None,
-                    Timeliness::Interactive,
-                )]),
+                EventBody::Inbound { .. } => {
+                    FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::NOW,
+                        String::new(),
+                        None,
+                        Timeliness::Interactive,
+                    )])
+                }
                 EventBody::EffectResult {
                     result: EffectOutcome::Ok(_),
                     ..
@@ -290,12 +292,14 @@ mod tests {
     impl Reducer for TimerAgent {
         async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
-                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
-                    effect_ct::TIMER,
-                    self.deadline_ms.to_string(),
-                    None,
-                    Timeliness::Interactive,
-                )]),
+                EventBody::Inbound { .. } => {
+                    FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::TIMER,
+                        self.deadline_ms.to_string(),
+                        None,
+                        Timeliness::Interactive,
+                    )])
+                }
                 EventBody::TimerFired { .. } => {
                     kv.put(b"woke".to_vec(), b"1".to_vec());
                     FoldOutput::none()

--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -312,12 +312,14 @@ mod tests {
     impl Reducer for ClockAgent {
         async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
-                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
-                    effect_ct::NOW,
-                    String::new(),
-                    None,
-                    Timeliness::Interactive,
-                )]),
+                EventBody::Inbound { .. } => {
+                    FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::NOW,
+                        String::new(),
+                        None,
+                        Timeliness::Interactive,
+                    )])
+                }
                 EventBody::EffectResult {
                     result: EffectOutcome::Ok(_),
                     ..
@@ -364,12 +366,14 @@ mod tests {
     impl Reducer for TimerAgent {
         async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
-                EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
-                    effect_ct::TIMER,
-                    self.deadline_ms.to_string(),
-                    None,
-                    Timeliness::Interactive,
-                )]),
+                EventBody::Inbound { .. } => {
+                    FoldOutput::with(vec![EffectRequest::new_with_family(
+                        effect_ct::TIMER,
+                        self.deadline_ms.to_string(),
+                        None,
+                        Timeliness::Interactive,
+                    )])
+                }
                 EventBody::TimerFired { .. } => {
                     kv.put(b"woke".to_vec(), b"1".to_vec());
                     FoldOutput::none()

--- a/implementation/seed/crates/cdz-agent-host/tests/agent_runs_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/agent_runs_e2e.rs
@@ -119,7 +119,7 @@ async fn the_recorded_instant_makes_the_run_replayable() {
     // log reconstructs the identical KV without ever touching the clock again. This is why a
     // world-touching executor doesn't break event-sourcing's replay-equivalence.
     // Both the live drive and the replay go through the async path: `deliver_async` for the run, and
-    // `Session::replay_async` for the replay (it re-folds the recorded log through the Reducer, runs
+    // `Session::replay` for the replay (it re-folds the recorded log through the Reducer, runs
     // no executor). The reducer is a native `Reducer` (the single reducer trait, ruling (b)).
     let reducer = ClockAgent;
     let mut exec =
@@ -134,7 +134,7 @@ async fn the_recorded_instant_makes_the_run_replayable() {
 
     // Replay the WHOLE log into a fresh session — no executor is consulted; the recorded EffectResult
     // supplies the instant. The reconstructed KV must be byte-identical to the live one.
-    let replayed = Session::replay_async(session.log().to_vec(), &reducer)
+    let replayed = Session::replay(session.log().to_vec(), &reducer)
         .await
         .unwrap();
     assert_eq!(replayed.kv().get(b"phase"), Some(&b"running"[..]));

--- a/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
@@ -102,7 +102,7 @@ async fn agent_loop_runs_end_to_end_through_the_http_executor() {
 
     // Replay-equivalence: the response is recorded, so replay reconstructs the identical KV without
     // re-fetching.
-    let replayed = Session::replay_async(session.log().to_vec(), &reducer)
+    let replayed = Session::replay(session.log().to_vec(), &reducer)
         .await
         .unwrap();
     assert_eq!(replayed.snapshot().kv_root, session.snapshot().kv_root);

--- a/implementation/seed/crates/cdz-agent-host/tests/model_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/model_agent_e2e.rs
@@ -119,7 +119,7 @@ async fn agent_loop_runs_end_to_end_through_the_model_executor() {
 
     // Replay-equivalence: the completion is recorded, so replay reconstructs the identical KV without
     // ever calling the transport again (a paid model call happens once; replay is free).
-    let replayed = Session::replay_async(session.log().to_vec(), &reducer)
+    let replayed = Session::replay(session.log().to_vec(), &reducer)
         .await
         .unwrap();
     assert_eq!(replayed.kv().get(b"phase"), Some(&b"answered"[..]));

--- a/issues/differential-artifact-wasm-wasm-value-list-rust-artifact-error-error-e-mismatche.smith.md
+++ b/issues/differential-artifact-wasm-wasm-value-list-rust-artifact-error-error-e-mismatche.smith.md
@@ -1,0 +1,36 @@
+# SMITH FINDING — backends DISAGREE on value: [artifact] wasm=wasm value (list 2147483647 -41) rust=artifact-error error[E0308]: mismatched types
+
+_Filed by `cdz-smith` (the compiler fuzzer). This is an auto-generated finding: a
+generated program made the compiler PANIC, HANG, or emit INVALID wasm — never valid
+behavior, since the compiler reports every legitimate "no" as a diagnostic. Triage, fix,
+then rename this file `.RESOLVED.md` (or `.REJECTED.md` with a rationale) so it is not
+re-triaged._
+
+- **Category:** differential
+- **Compiler commit:** `7e38799c0`
+- **Hits:** 1
+- **Signature:** `differential-artifact-wasm-wasm-value-list-rust-artifact-error-error-e-mismatche`
+
+## Reproducer
+
+`differential-artifact-wasm-wasm-value-list-rust-artifact-error-error-e-mismatche.smith.sexp` (also inline):
+
+```scheme
+(do (def (main) (list (: 2147483647 UInt64) (match "km" (_ (match "km" (_ (match "km" (_ (match false (_ -41)))))))))) (export main))
+```
+
+Reproduce in-process:
+
+```
+cargo run -p cdz-smith -- verify differential-artifact-wasm-wasm-value-list-rust-artifact-error-error-e-mismatche.smith.sexp
+```
+
+## Backend value disagreement (miscompile)
+
+Both emit backends produced a VALID artifact, but they DISAGREE on the program's
+result — the wasm component (run via `cdz-run`) and the Rust backend (run via
+`cdz run-rust`) computed different values, or one ran to a value where the other
+trapped. The backends share the front-end and diverge below the emit seam, so this
+is a lowering bug on one side. The crash/invalid-wasm oracles are blind to it.
+
+- **Disagreement:** [artifact] wasm=wasm value (list 2147483647 -41) rust=artifact-error error[E0308]: mismatched types

--- a/issues/differential-artifact-wasm-wasm-value-list-rust-artifact-error-error-e-mismatche.smith.sexp
+++ b/issues/differential-artifact-wasm-wasm-value-list-rust-artifact-error-error-e-mismatche.smith.sexp
@@ -1,0 +1,1 @@
+(do (def (main) (list (: 2147483647 UInt64) (match "km" (_ (match "km" (_ (match "km" (_ (match false (_ -41)))))))))) (export main))

--- a/issues/pr1741-MERGED-revlist-none-arm-message-says-failed-for-unparseable.md
+++ b/issues/pr1741-MERGED-revlist-none-arm-message-says-failed-for-unparseable.md
@@ -1,0 +1,15 @@
+# PR #1741 review comment — xtask/src/fleet.rs (v-fleet-tooling) — MERGED, fix-forward
+
+https://github.com/camshaft/cadenza/pull/1741 (MERGED). #1712→#1719→#1725→#1731→#1734→#1741 rev-list chain.
+
+## `None` arm message says "rev-list FAILED" but None now also means unparseable stdout (Copilot, fleet.rs:8125) — doc/accuracy
+> The comment correctly notes `range_count == None` can come from unparseable `rev-list --count` stdout
+> (via `parse().ok()`), but the later `None` arm still says "rev-list itself FAILED" and the emitted error
+> always says `git rev-list … FAILED`. Misleading when stdout is unparseable but the command SUCCEEDED;
+> update the wording (optionally include raw stdout).
+
+The #1734 fix broadened the `None` meaning (spawn/exit failure OR unparseable stdout), but the None-arm's
+user-facing message still says "FAILED" (implying the command failed). When rev-list succeeds but emits
+unparseable output, the message misattributes it. Reword to "rev-list failed OR returned unparseable
+output" and optionally include the raw stdout. LOW/doc — the running polish on the rev-list error face.
+Fix-forward.

--- a/issues/pr1747-scope-creep-namespace-module-under-ci-title-and-docsync.md
+++ b/issues/pr1747-scope-creep-namespace-module-under-ci-title-and-docsync.md
@@ -1,0 +1,31 @@
+# PR #1747 review comments — .github/workflows/checks.yml + cdz-kernel/src/{lib,namespace}.rs (v-agent-harness) — OPEN
+
+https://github.com/camshaft/cadenza/pull/1747 (titled "ci(checks): build the reducer-guest fixture with
+--locked").
+
+## 1. Scope creep: a CI-titled PR also adds a public `cdz-kernel::namespace` module (Copilot, namespace.rs:5) — process/reviewability [VERIFIED]
+> The PR title/description are scoped to making the reducer-guest fixture build with `--locked`, but this
+> PR also introduces a new `cdz-kernel::namespace` module and exports it publicly. If intentional, update
+> the PR metadata to reflect the API surface change; otherwise split it into a separate PR to keep
+> review/rollback surface smaller.
+
+VERIFIED against the diff: alongside the checks.yml `--locked` change, the PR adds `pub mod namespace;`
+(lib.rs:50) + a whole new namespace.rs — a SECURITY-relevant module ("mutable-name namespaces — the
+WRITE-AUTHORITY half of the global store's anti-hijack model", system/… trust root, fail-closed unknown
+prefix). That's a substantial public API + security-model surface riding under a CI-build title. Reviewers
+scanning by title would under-scrutinize it, and rollback couples the build fix to the kernel change. Per
+the operator's meaningful-MR / coherent-unit steer, recommend SPLITTING the namespace module into its own
+PR (or at minimum retitling to disclose the kernel API addition). MED/process — worth flagging given the
+security relevance. Routed to v-agent-harness (kernel owner).
+
+## 2. Crate module-map doc out of sync — no `namespace` bullet (Copilot, lib.rs:50) — doc
+> `cdz-kernel`'s top-level "v0.1 module map" doesn't mention the new `namespace` module, so the crate docs
+> are out of sync with the public module surface.
+
+Add a `namespace` bullet to the module-map doc. LOW/doc.
+
+## 3. checks.yml comment stale after --locked (Copilot, checks.yml:258)  — doc
+> The reducer-guest rebuild step now uses `cargo build --locked` with a committed Cargo.lock, so the
+> comment about transitive deps "aren't lock-pinned" is no longer accurate.
+
+Update the comment to reflect the now-lock-pinned build. LOW/doc.

--- a/issues/pr1753-MERGED-URGENT-replay-rename-breaks-agent-host-tests-on-trunk.md
+++ b/issues/pr1753-MERGED-URGENT-replay-rename-breaks-agent-host-tests-on-trunk.md
@@ -1,0 +1,26 @@
+# PR #1753 review comment — cdz-kernel replay rename BREAKS cdz-agent-host tests ON TRUNK (v-agent-harness-host + v-agent-harness) — MERGED, URGENT fix-forward
+
+https://github.com/camshaft/cadenza/pull/1753 (MERGED — renamed Session::replay_async → replay).
+
+## `Session::replay_async` renamed to `replay`, but 3 cdz-agent-host test files still call `replay_async` → LIVE TRUNK COMPILE BREAK (Copilot, kernel.rs:897) — correctness [VERIFIED HIGH]
+> `Session::replay_async` was renamed to `Session::replay`, but there are still in-repo callers using
+> `Session::replay_async` (cdz-agent-host/tests/{agent_runs_e2e,http_agent_e2e,model_agent_e2e}.rs). As-is
+> this PR will break compilation for those crates/tests.
+
+VERIFIED against trunk (post-#1753 merge):
+- kernel defines ONLY `pub async fn replay(...)` (kernel.rs:897) — no `replay_async`, no alias (the #1753
+  diff renamed it and updated in-crate callers/tests).
+- but `Session::replay_async(...)` is STILL called in 3 cdz-agent-host TEST files: model_agent_e2e.rs:122,
+  agent_runs_e2e.rs:137, http_agent_e2e.rs:105. `replay_async` is defined NOWHERE on trunk → those tests
+  fail to compile.
+
+WHY IT LANDED: #1753 is a KERNEL PR, and the cdz-agent-host CI job is NOT path-filtered on kernel changes
+(the known [[cdz-agent-host-ci-job-unfiltered]] trap — here in REVERSE: the kernel PR's CI didn't run the
+host tests, so the break wasn't caught pre-merge). It will now RED the next cdz-agent-host PR (e.g. #1758
+fmt / #1751).
+
+HIGH + time-sensitive: cdz-agent-host's test crate is broken on trunk RIGHT NOW. Fix-forward:
+s/Session::replay_async/Session::replay/ in the 3 test files. Owner = v-agent-harness-host (owns
+cdz-agent-host, strict seam); v-agent-harness FYI'd (did the rename — the additive-alias-bridge pattern
+from [[cdz-agent-host-ci-job-unfiltered-kernel-shared-type-change-needs-alias-bridge]] would have avoided
+this: rename + keep a deprecated `replay_async` alias until the host migrates).


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 8397c185f, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.