### PR TITLE
rcdzc: extend sibling-inferred-width CDZ0302 check to Set.of elements + Map.insert values

### DIFF
--- a/implementation/seed/crates/rcdzc/src/infer.rs
+++ b/implementation/seed/crates/rcdzc/src/infer.rs
@@ -9987,6 +9987,19 @@ fn check_application(
             }
             return;
         }
+        // The key/value AGREE with the map's types — but a bare inserted literal whose width is fixed by the
+        // map's key/value type (from a SIBLING insert in the chain, e.g. `(Map.insert (Map.insert m 1 (: 5
+        // UInt8)) 2 300)` where the inner `(: 5 UInt8)` pins the value type UInt8) must still be RANGE-checked
+        // against that width. `agrees_with` only tests kind/shape agreement (a deferred `Int64` agrees with
+        // `UInt8`), not fit — so `300` slipped CDZ0302 → wasm wrapped, rust E0308 (breaker's Map face of the
+        // sibling-width skip). Range-check the inserted key against `kt` and value against `vt` via the same
+        // `width_fault_against_ty` the annotation path uses. (The operand map's own inserts are checked when
+        // `collect` recurses into `args[0]` below.)
+        if let Some(reject) = width_fault_against_ty(db, args[1], &kt)
+            .or_else(|| width_fault_against_ty(db, args[2], &vt))
+        {
+            out.push(reject);
+        }
     }
     // `Set.of list` — the set is HOMOGENEOUS: its elements (the list's) must share one type
     // (collections-and-text.md §A Set Is A Collection Of Unique Elements — elements of ONE type). A
@@ -10048,6 +10061,25 @@ fn check_application(
                 collect(db, el, out);
             }
             return;
+        }
+        // HOMOGENEOUS set (no clash) — RANGE-CHECK each element against the SETTLED element type. A bare
+        // out-of-range element whose width is fixed by an annotated SIBLING (`(Set.of (list (: 1 UInt64)
+        // -41))`) must reject CDZ0302, exactly like the list-literal sibling-width fix — else wasm wraps +
+        // rust E0308 (breaker's Set face of the sibling-unification skip). The `Set.of` path walks its
+        // elements HERE, bypassing the list-literal fault arm, so the check must live at this seam too. The
+        // settled type is the JOIN of the element types (takes the fixed width regardless of position).
+        if let Some((first, first_ty)) = first_pair {
+            let settled = elems
+                .iter()
+                .skip(1)
+                .fold(first_ty, |acc, &e| acc.join(&type_of(db, e)));
+            let _ = first;
+            if let Some(reject) = elems
+                .iter()
+                .find_map(|&e| width_fault_against_ty(db, e, &settled))
+            {
+                out.push(reject);
+            }
         }
     }
     // A LIST constructor (`list` alias) applied — its arguments are its ELEMENTS, and a list is
@@ -13606,6 +13638,9 @@ fn collect_node(db: &mut Db, id: StructId, out: &mut Vec<Reject>) {
                         Vec::new()
                     }
                 };
+                // (The sibling-width CDZ0302 range-check for `Set.of` elements runs in `check_application`'s
+                // `Set.of` arm — the homogeneous-set path — which sees the settled element type; this
+                // `collect` arm only descends into each element for its OWN nested faults.)
                 for &e in &elems {
                     collect(db, e, out);
                 }

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -42125,6 +42125,44 @@ mod match_engine {
     }
 
     #[test]
+    fn a_set_or_map_literal_out_of_range_for_a_sibling_inferred_width_is_cdz0302() {
+        // Follow-up to the list-element sibling-width fix (#1766): breaker found the SAME CDZ0302
+        // sibling-unification skip through `Set.of` ELEMENT unification and `Map.insert` VALUE unification
+        // across an insert CHAIN — the element/value width is fixed by an annotated SIBLING (a set element,
+        // an earlier insert's value), not the literal's own annotation, so the bare out-of-range literal
+        // skipped the range check → wasm silently WRAPPED it, rust emitted an invalid init (E0308) — the
+        // Set/Map faces of the same backend-divergent miscompile. FIX (infer.rs): range-check each element
+        // against the settled (JOIN'd) element type in `Set.of`'s homogeneous-set arm, and each inserted
+        // key/value against the map's `kt`/`vt` in the `Map.insert` arm (once they AGREE — `agrees_with`
+        // tests shape, not fit). CDZ0302 now fires on both backends for both.
+        let bad = |src: &str| {
+            let e = compile_component(&crate::codec::encode(&parse(src)))
+                .expect_err("an out-of-range Set/Map element for the sibling-inferred width must reject");
+            assert_eq!(e.code.as_deref(), Some("CDZ0302"), "got: {}", e.message);
+        };
+        // Set.of: the annotated sibling `(: 1 UInt64)` fixes the element type; the bare `-41` must reject.
+        bad("(module m (def (main) (Set.of (list (: 1 UInt64) -41))) (export main))");
+        // Map.insert chain: the inner insert's `(: 5 UInt8)` value fixes the value type; the outer insert's
+        // bare `300` (over-max for UInt8) must reject.
+        bad("(module m (def (main) (Map.insert (Map.insert Map.empty 1 (: 5 UInt8)) 2 300)) (export main))");
+        // CONTROLS — in-range elements/values under a sibling-inferred width still COMPILE.
+        assert!(
+            compile_component(&crate::codec::encode(&parse(
+                "(module m (def (main) (Set.of (list (: 1 UInt64) 41))) (export main))"
+            )))
+            .is_ok(),
+            "an in-range set element under a sibling-inferred width must still compile"
+        );
+        assert!(
+            compile_component(&crate::codec::encode(&parse(
+                "(module m (def (main) (Map.insert (Map.insert Map.empty 1 (: 5 UInt8)) 2 200)) (export main))"
+            )))
+            .is_ok(),
+            "an in-range map value under a sibling-inferred width must still compile"
+        );
+    }
+
+    #[test]
     fn a_list_element_literal_out_of_range_for_a_sibling_inferred_width_is_cdz0302() {
         // Fuzzer/corpus-bugfix differential: an integer-literal list element whose element TYPE is fixed by
         // a SIBLING (not the element's own annotation) skipped the CDZ0302 range check → wasm SILENTLY


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref 85a8c5134, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.