### PR TITLE
cdz-agent-host: explicit HTTP method (no body-presence inference) — operator directive

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -308,9 +308,9 @@ jobs:
           # VALID component (wasm-tools validate). This catches "source no longer produces a valid authorizer
           # component" — NOT staleness of a committed artifact (there is NO committed cedar .component.wasm:
           # it's ~3.3 MB with the Cedar engine embedded, so it's CI-built here, not checked in). Validate,
-          # not a byte-diff: guest dep versions aren't lock-pinned + CI floats toolchains → different-but-
-          # valid bytes (same rationale as reducer-guest, trunk@455dcb7e7). The lifted component's PATH is
-          # handed to the e2e via CEDAR_POLICY_COMPONENT (next step).
+          # not a byte-diff: even with the committed lock (built --locked below), CI floats the toolchain →
+          # different-but-valid bytes (same rationale as reducer-guest, trunk@455dcb7e7). The lifted
+          # component's PATH is handed to the e2e via CEDAR_POLICY_COMPONENT (next step).
           rustup target add wasm32-unknown-unknown
           # --locked: build against the COMMITTED Cargo.lock (#1522). The guest's deps are loose
           # (cedar-policy = "4", wit-bindgen = "0.45"), so without --locked CI floats to a newer

--- a/implementation/seed/crates/cdz-agent-host/src/http.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/http.rs
@@ -3,14 +3,16 @@
 //! An agent that fetches a URL emits an `Http` effect; the kernel authorizes it (the host is gated by a
 //! SEC-F1 `HostIn` capability — the SSRF/exfil guard), durably dispatches it, this executor performs the
 //! request, and the response body folds back as the result. The effect's `target` is the URL; its
-//! `payload` is the optional request body (a POST/PUT body — `None` is a GET); the response body becomes
-//! the result payload.
+//! `payload` is a `(http-request (method <name>) (body <opt>))` binary-sexpr (the kernel's
+//! [`cdz_kernel::event_ast::encode_http_request`] wire convention, §9b): the METHOD is CALLER-SPECIFIED
+//! (never inferred from body presence — a bodyless POST and a DELETE-with-body are both expressible), and
+//! the body is independent of the method. The response body becomes the result payload.
 //!
 //! **Transport seam** (identical shape to [`crate::model`]): the real request touches the network, so
 //! this executor is GENERIC over an [`HttpTransport`]. The executor owns the pure, hermetically-testable
-//! effect mapping (kind check, method/body derivation, outcome mapping); the transport owns the I/O (a
-//! real client — behind the crate's `live-net` feature). A stub transport drives the hermetic tests +
-//! the end-to-end agent-loop test.
+//! effect mapping (family check, payload DECODE, method mapping, outcome mapping); the transport owns the
+//! I/O (a real client — behind the crate's `live-net` feature). A stub transport drives the hermetic
+//! tests + the end-to-end agent-loop test.
 //!
 //! **Bytes-first** (operator perf directive): both the request body and the response body are
 //! [`Bytes`] — a fetched body is a hot-path buffer folded into the log/KV, so a ref-counted clone beats
@@ -19,20 +21,71 @@
 
 use crate::retry;
 use bytes::Bytes;
-use cdz_kernel::effect::{effect_ct, EffectKind, EffectRequest, Payload};
+use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
+use cdz_kernel::event_ast::decode_http_request;
 use cdz_kernel::executor::Executor;
 use cdz_kernel::hash::Hash;
+
+/// The HTTP method an `Http` effect carries — CALLER-SPECIFIED, never inferred from body presence (so
+/// POST vs PUT vs DELETE are distinguishable, a bodyless POST and a DELETE-with-body are both
+/// expressible). An OPEN sum: an unknown/extension method (`PROPFIND`, …) survives verbatim as
+/// [`HttpMethod::Other`] rather than being rejected — the kernel codec returns the method name as a
+/// string and does not reject unknowns (tolerant-reader posture).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Delete,
+    Patch,
+    Head,
+    Options,
+    /// Any method the codec surfaced that isn't a well-known one above — carried through verbatim.
+    Other(String),
+}
+
+impl HttpMethod {
+    /// Map a decoded method name (the kernel returns it lowercase) to the enum. Case-insensitive; an
+    /// unrecognized name is preserved as [`HttpMethod::Other`] (open sum — never rejected here).
+    pub fn from_name(name: &str) -> Self {
+        match name.to_ascii_lowercase().as_str() {
+            "get" => HttpMethod::Get,
+            "post" => HttpMethod::Post,
+            "put" => HttpMethod::Put,
+            "delete" => HttpMethod::Delete,
+            "patch" => HttpMethod::Patch,
+            "head" => HttpMethod::Head,
+            "options" => HttpMethod::Options,
+            _ => HttpMethod::Other(name.to_string()),
+        }
+    }
+
+    /// The uppercase wire name a transport puts on the request line.
+    pub fn as_str(&self) -> &str {
+        match self {
+            HttpMethod::Get => "GET",
+            HttpMethod::Post => "POST",
+            HttpMethod::Put => "PUT",
+            HttpMethod::Delete => "DELETE",
+            HttpMethod::Patch => "PATCH",
+            HttpMethod::Head => "HEAD",
+            HttpMethod::Options => "OPTIONS",
+            HttpMethod::Other(s) => s,
+        }
+    }
+}
 
 /// The I/O half of an HTTP request, factored out so the executor's logic is hermetically testable. An
 /// impl performs the real request (behind `live-net`); a stub returns canned bytes for tests. Total: it
 /// returns `Err(reason)` rather than panicking, so a transport failure folds as an observable
 /// `EffectOutcome::Err` (§9d/§17).
 ///
-/// `body` is `None` for a bodyless request (a GET) and `Some(bytes)` for a request with a body (a POST/
-/// PUT). The response body is returned as [`Bytes`] (the hot-path buffer). The `idempotency_key` lets a
-/// side-effecting transport dedup a crash-re-driven request (§16c-S1/D) — relevant for a non-idempotent
-/// method; a GET is naturally idempotent and can ignore it.
+/// `method` is the caller-specified [`HttpMethod`] (the transport puts it on the request line — no
+/// inference). `body` is `None` for a bodyless request and `Some(bytes)` for one with a body; the two are
+/// INDEPENDENT (any method may carry or omit a body). The response body is returned as [`Bytes`] (the
+/// hot-path buffer). The `idempotency_key` lets a side-effecting transport dedup a crash-re-driven request
+/// (§16c-S1/D) — relevant for a non-idempotent method.
 ///
 /// **Error classification (supervision, [`crate::retry`]):** an `Err(reason)` MUST lead with a
 /// retryability token — a transient failure (5xx, timeout, connection reset) as
@@ -43,14 +96,15 @@ use cdz_kernel::hash::Hash;
 pub trait HttpTransport {
     async fn request(
         &self,
+        method: HttpMethod,
         url: &str,
         body: Option<&[u8]>,
         idempotency_key: Hash,
     ) -> Result<Bytes, String>;
 }
 
-/// Performs `Http` effects by delegating the request to an [`HttpTransport`]. Single-KIND: a non-`Http`
-/// kind is an observable `Err` (§9d) — register it under `Http` in a
+/// Performs `Http` effects by delegating the request to an [`HttpTransport`]. Single-family: a non-`Http`
+/// family is an observable `Err` (§9d) — register it under `Http` in a
 /// [`cdz_kernel::executor::CompositeExecutor`] alongside the other real executors.
 pub struct HttpExecutor<T: HttpTransport> {
     transport: T,
@@ -65,29 +119,41 @@ impl<T: HttpTransport> HttpExecutor<T> {
 #[async_trait::async_trait(?Send)]
 impl<T: HttpTransport> Executor for HttpExecutor<T> {
     async fn perform_async(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
-        if req.kind != EffectKind::Http {
+        // Family-keyed (seq-39), not the EffectKind enum — the same decision the router + authz make.
+        if !req.content_type.matches_family(effect_ct::HTTP) {
             // Structural — PERMANENT, a supervisor must not retry it (§17: observable Err, never a panic).
             return EffectOutcome::Err(retry::permanent(format!(
-                "HttpExecutor only handles Http effects, got {:?}",
-                req.kind
+                "HttpExecutor only handles the {} family, got {}",
+                effect_ct::HTTP,
+                req.content_type.family
             )));
         }
-        // The request body: an inline payload IS the body (a POST/PUT); no payload is a bodyless request
-        // (a GET). A blob-ref body is rejected because this executor has no blob-store handle to resolve
-        // it (structural → PERMANENT; observable Err, never a panic).
-        let body: Option<&[u8]> = match &req.payload {
-            // `&bytes[..]` borrows the inline `Bytes` payload as a slice (`Bytes` derefs to `[u8]`).
-            Some(Payload::Inline(bytes)) => Some(&bytes[..]),
+        // The payload is a `(http-request (method <name>) (body <opt>))` binary-sexpr — decode the
+        // caller-specified method + body (NO body-presence heuristic). A blob-ref payload can't be decoded
+        // (no blob-store handle) and a missing/garbage payload is malformed; both are structural → PERMANENT.
+        let (method, body): (HttpMethod, Option<Vec<u8>>) = match &req.payload {
+            Some(Payload::Inline(bytes)) => match decode_http_request(bytes) {
+                Ok((method_name, body)) => (HttpMethod::from_name(&method_name), body),
+                Err(e) => {
+                    return EffectOutcome::Err(retry::permanent(format!(
+                        "HttpExecutor: malformed http-request payload: {e:?}"
+                    )));
+                }
+            },
             Some(Payload::Blob(_)) => {
                 return EffectOutcome::Err(retry::permanent(
-                    "HttpExecutor: blob-ref request body unsupported — this executor has no blob-store access; inline it",
+                    "HttpExecutor: blob-ref request payload unsupported — this executor has no blob-store access; inline the http-request",
                 ));
             }
-            None => None,
+            None => {
+                return EffectOutcome::Err(retry::permanent(
+                    "HttpExecutor: an Http effect requires an http-request payload (method + optional body)",
+                ));
+            }
         };
         match self
             .transport
-            .request(&req.target, body, idempotency_key)
+            .request(method, &req.target, body.as_deref(), idempotency_key)
             .await
         {
             // The transport's `Bytes` response body moves straight into `Payload::Inline` (ref-counted
@@ -98,7 +164,7 @@ impl<T: HttpTransport> Executor for HttpExecutor<T> {
         }
     }
 
-    /// This single-kind executor serves exactly the `Http` family — the capability-manifest mechanism
+    /// This single-family executor serves exactly the `Http` family — the capability-manifest mechanism
     /// dimension when it's used bare as a `dyn Executor` (in a `CompositeExecutor` the composite's own
     /// `by_family` override answers instead). Overrides the trait's fail-safe `false` default.
     fn handles_family(&self, family: &str) -> bool {
@@ -110,9 +176,12 @@ impl<T: HttpTransport> Executor for HttpExecutor<T> {
 mod tests {
     use super::*;
     use cdz_kernel::effect::Timeliness;
+    use cdz_kernel::event_ast::encode_http_request;
 
-    /// A stub transport that asserts what it was asked to fetch and returns a canned response body.
+    /// A stub transport that asserts the method + body it was asked to perform and returns a canned
+    /// response. It records the exact method the executor decoded + passed through.
     struct StubHttp {
+        expect_method: HttpMethod,
         expect_body: Option<Vec<u8>>,
         response: Bytes,
     }
@@ -120,32 +189,39 @@ mod tests {
     impl HttpTransport for StubHttp {
         async fn request(
             &self,
+            method: HttpMethod,
             url: &str,
             body: Option<&[u8]>,
             _key: Hash,
         ) -> Result<Bytes, String> {
             assert_eq!(url, "https://ok.host/x");
+            assert_eq!(method, self.expect_method, "method threaded through verbatim");
             assert_eq!(body.map(|b| b.to_vec()), self.expect_body);
             Ok(self.response.clone()) // Bytes clone = O(1) refcount bump, not a deep copy
         }
     }
 
-    fn http_req(payload: Option<Payload>) -> EffectRequest {
+    /// Build an Http effect whose payload is the `(http-request …)` binary-sexpr the kernel codec writes.
+    fn http_req(method: &str, body: Option<&[u8]>) -> EffectRequest {
         EffectRequest::new_with_family(
             effect_ct::HTTP,
             "https://ok.host/x".to_string(),
-            payload,
+            Some(Payload::Inline(encode_http_request(method, body).into())),
             Timeliness::Interactive,
         )
     }
 
     #[tokio::test]
-    async fn a_get_has_no_body_and_returns_the_response() {
+    async fn a_get_carries_no_body_and_returns_the_response() {
         let mut exec = HttpExecutor::new(StubHttp {
+            expect_method: HttpMethod::Get,
             expect_body: None,
             response: Bytes::from_static(b"response body"),
         });
-        match exec.perform_async(&http_req(None), Hash::of(b"k")).await {
+        match exec
+            .perform_async(&http_req("get", None), Hash::of(b"k"))
+            .await
+        {
             EffectOutcome::Ok(Some(Payload::Inline(bytes))) => {
                 assert_eq!(&bytes[..], b"response body")
             }
@@ -154,17 +230,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn an_inline_payload_is_the_request_body() {
+    async fn the_explicit_method_and_body_thread_through() {
+        // POST with a body: the caller-specified method reaches the transport, body independent of it.
         let mut exec = HttpExecutor::new(StubHttp {
+            expect_method: HttpMethod::Post,
             expect_body: Some(b"post this".to_vec()),
             response: Bytes::from_static(b"ok"),
         });
-        // The stub asserts it received exactly the inline payload as the request body.
         match exec
-            .perform_async(
-                &http_req(Some(Payload::Inline(b"post this".to_vec().into()))),
-                Hash::of(b"k"),
-            )
+            .perform_async(&http_req("post", Some(b"post this")), Hash::of(b"k"))
             .await
         {
             EffectOutcome::Ok(Some(Payload::Inline(bytes))) => assert_eq!(&bytes[..], b"ok"),
@@ -173,20 +247,70 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_blob_body_is_a_permanent_err_no_blob_store_access() {
+    async fn a_bodyless_post_and_a_delete_with_body_are_both_expressible() {
+        // The whole point of the explicit method: the two cases the body-presence heuristic couldn't do.
+        // Bodyless POST:
         let mut exec = HttpExecutor::new(StubHttp {
+            expect_method: HttpMethod::Post,
             expect_body: None,
-            response: Bytes::new(),
+            response: Bytes::from_static(b"a"),
         });
-        match exec
-            .perform_async(
-                &http_req(Some(Payload::Blob(Hash::of(b"big")))),
-                Hash::of(b"k"),
-            )
-            .await
-        {
+        assert!(matches!(
+            exec.perform_async(&http_req("post", None), Hash::of(b"k")).await,
+            EffectOutcome::Ok(_)
+        ));
+        // DELETE carrying a body:
+        let mut exec = HttpExecutor::new(StubHttp {
+            expect_method: HttpMethod::Delete,
+            expect_body: Some(b"why".to_vec()),
+            response: Bytes::from_static(b"b"),
+        });
+        assert!(matches!(
+            exec.perform_async(&http_req("delete", Some(b"why")), Hash::of(b"k"))
+                .await,
+            EffectOutcome::Ok(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_unknown_method_survives_verbatim_as_other() {
+        // Open sum: an extension method (PROPFIND) is carried through, not rejected.
+        let mut exec = HttpExecutor::new(StubHttp {
+            expect_method: HttpMethod::Other("propfind".to_string()),
+            expect_body: None,
+            response: Bytes::from_static(b"x"),
+        });
+        assert!(matches!(
+            exec.perform_async(&http_req("propfind", None), Hash::of(b"k"))
+                .await,
+            EffectOutcome::Ok(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_blob_payload_is_a_permanent_err_no_blob_store_access() {
+        struct NeverCalled;
+        #[async_trait::async_trait(?Send)]
+        impl HttpTransport for NeverCalled {
+            async fn request(
+                &self,
+                _m: HttpMethod,
+                _u: &str,
+                _b: Option<&[u8]>,
+                _k: Hash,
+            ) -> Result<Bytes, String> {
+                panic!("transport must not be called for a blob-ref payload");
+            }
+        }
+        let mut exec = HttpExecutor::new(NeverCalled);
+        let req = EffectRequest::new_with_family(
+            effect_ct::HTTP,
+            "https://ok.host/x".to_string(),
+            Some(Payload::Blob(Hash::of(b"big"))),
+            Timeliness::Interactive,
+        );
+        match exec.perform_async(&req, Hash::of(b"k")).await {
             EffectOutcome::Err(msg) => {
-                // Rejected because this executor has no blob-store access (an invariant, not a "yet").
                 assert!(msg.contains("no blob-store access"), "{msg}");
                 assert_eq!(
                     retry::classify(&msg),
@@ -194,7 +318,54 @@ mod tests {
                     "{msg}"
                 );
             }
-            other => panic!("expected Err for a blob-ref body, got {other:?}"),
+            other => panic!("expected Err for a blob-ref payload, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_missing_or_malformed_payload_is_a_permanent_err() {
+        struct NeverCalled;
+        #[async_trait::async_trait(?Send)]
+        impl HttpTransport for NeverCalled {
+            async fn request(
+                &self,
+                _m: HttpMethod,
+                _u: &str,
+                _b: Option<&[u8]>,
+                _k: Hash,
+            ) -> Result<Bytes, String> {
+                panic!("transport must not be called for a malformed request");
+            }
+        }
+        // No payload → PERMANENT (an Http effect requires an http-request payload).
+        let mut exec = HttpExecutor::new(NeverCalled);
+        let no_payload = EffectRequest::new_with_family(
+            effect_ct::HTTP,
+            "https://ok.host/x".to_string(),
+            None,
+            Timeliness::Interactive,
+        );
+        match exec.perform_async(&no_payload, Hash::of(b"k")).await {
+            EffectOutcome::Err(msg) => {
+                assert!(msg.contains("http-request payload"), "{msg}");
+                assert_eq!(retry::classify(&msg), retry::Retryability::Permanent, "{msg}");
+            }
+            other => panic!("expected Err for a missing payload, got {other:?}"),
+        }
+        // Garbage (non-http-request) inline payload → PERMANENT (malformed), never a panic (decode is total).
+        let mut exec = HttpExecutor::new(NeverCalled);
+        let garbage = EffectRequest::new_with_family(
+            effect_ct::HTTP,
+            "https://ok.host/x".to_string(),
+            Some(Payload::Inline(b"not a sexpr".to_vec().into())),
+            Timeliness::Interactive,
+        );
+        match exec.perform_async(&garbage, Hash::of(b"k")).await {
+            EffectOutcome::Err(msg) => {
+                assert!(msg.contains("malformed"), "{msg}");
+                assert_eq!(retry::classify(&msg), retry::Retryability::Permanent, "{msg}");
+            }
+            other => panic!("expected Err for a garbage payload, got {other:?}"),
         }
     }
 
@@ -207,6 +378,7 @@ mod tests {
         impl HttpTransport for FlakyHttp {
             async fn request(
                 &self,
+                _m: HttpMethod,
                 _u: &str,
                 _b: Option<&[u8]>,
                 _k: Hash,
@@ -215,7 +387,10 @@ mod tests {
             }
         }
         let mut exec = HttpExecutor::new(FlakyHttp);
-        match exec.perform_async(&http_req(None), Hash::of(b"k")).await {
+        match exec
+            .perform_async(&http_req("get", None), Hash::of(b"k"))
+            .await
+        {
             EffectOutcome::Err(msg) => {
                 assert!(msg.contains("connection refused"), "{msg}");
                 assert_eq!(
@@ -229,17 +404,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn non_http_kind_is_a_permanent_err() {
+    async fn a_non_http_family_is_a_permanent_err() {
         struct NeverCalled;
         #[async_trait::async_trait(?Send)]
         impl HttpTransport for NeverCalled {
             async fn request(
                 &self,
+                _m: HttpMethod,
                 _u: &str,
                 _b: Option<&[u8]>,
                 _k: Hash,
             ) -> Result<Bytes, String> {
-                panic!("transport must not be called for a non-Http kind");
+                panic!("transport must not be called for a non-http-family effect");
             }
         }
         let mut exec = HttpExecutor::new(NeverCalled);
@@ -251,14 +427,17 @@ mod tests {
         );
         match exec.perform_async(&req, Hash::of(b"k")).await {
             EffectOutcome::Err(msg) => {
-                assert!(msg.contains("Http"), "err names the handled kind: {msg}");
+                assert!(
+                    msg.contains(effect_ct::HTTP) && msg.contains(effect_ct::MODEL),
+                    "err names the handled (http) + rejected (model) families: {msg}"
+                );
                 assert_eq!(
                     retry::classify(&msg),
                     retry::Retryability::Permanent,
                     "{msg}"
                 );
             }
-            other => panic!("expected Err for a non-Http kind, got {other:?}"),
+            other => panic!("expected Err for a non-http-family effect, got {other:?}"),
         }
     }
 
@@ -266,6 +445,7 @@ mod tests {
     fn handles_only_the_http_family() {
         // Bare-leaf mechanism dimension: serves Http, nothing else (the trait default false otherwise).
         let exec = HttpExecutor::new(StubHttp {
+            expect_method: HttpMethod::Get,
             expect_body: None,
             response: Bytes::from_static(b""),
         });

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -49,7 +49,7 @@ pub mod status;
 pub use async_host::{AsyncAgentHost, Inbound, Inbox};
 pub use clock::ClockExecutor;
 pub use host::{AgentHost, HostedSession, SessionId};
-pub use http::{HttpExecutor, HttpTransport};
+pub use http::{HttpExecutor, HttpMethod, HttpTransport};
 pub use model::{ModelExecutor, ModelTransport};
 pub use retry::{classify, permanent, retryable, Retryability};
 pub use status::{host_session_status_json, session_status_json, DEFAULT_STALL_AFTER_MS};

--- a/implementation/seed/crates/cdz-agent-host/tests/capability_manifest_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/capability_manifest_e2e.rs
@@ -21,7 +21,9 @@
 mod common;
 
 use bytes::Bytes;
-use cdz_agent_host::{ClockExecutor, HttpExecutor, HttpTransport, ModelExecutor, ModelTransport};
+use cdz_agent_host::{
+    ClockExecutor, HttpExecutor, HttpMethod, HttpTransport, ModelExecutor, ModelTransport,
+};
 use cdz_kernel::effect::{effect_ct, project_manifest, GrantState};
 use cdz_kernel::executor::CompositeExecutor;
 use cdz_kernel::hash::Hash;
@@ -35,7 +37,13 @@ use common::policy_component_bytes;
 struct UnusedHttp;
 #[async_trait::async_trait(?Send)]
 impl HttpTransport for UnusedHttp {
-    async fn request(&self, _url: &str, _body: Option<&[u8]>, _key: Hash) -> Result<Bytes, String> {
+    async fn request(
+        &self,
+        _method: HttpMethod,
+        _url: &str,
+        _body: Option<&[u8]>,
+        _key: Hash,
+    ) -> Result<Bytes, String> {
         unreachable!("manifest projection probes policy; it never performs an effect")
     }
 }

--- a/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
@@ -5,12 +5,13 @@
 //! (here a STUB transport, so the loop is hermetically gateable), and the response body folds back and
 //! drives the agent's next step. The REAL client drops into the same wiring behind `live-net`.
 
-use cdz_agent_host::{HttpExecutor, HttpTransport};
+use cdz_agent_host::{HttpExecutor, HttpMethod, HttpTransport};
 use cdz_kernel::authz::Authorizer;
 use cdz_kernel::effect::{
     effect_ct, Capability, EffectKind, EffectRequest, Payload, ResourcePredicate, Timeliness,
 };
 use cdz_kernel::event::{ContentType, EffectOutcome, Event, EventBody};
+use cdz_kernel::event_ast::encode_http_request;
 use cdz_kernel::executor::CompositeExecutor;
 use cdz_kernel::hash::Hash;
 use cdz_kernel::kernel::Session;
@@ -18,16 +19,18 @@ use cdz_kernel::kv::Kv;
 use cdz_kernel::reducer::{FoldOutput, Reducer};
 
 /// A stub HTTP transport: returns a canned response body so the fetch loop is hermetic. The real client
-/// implements this same trait behind `live-net`.
+/// implements this same trait behind `live-net`. Asserts it got the caller-specified GET.
 struct StubHttp;
 #[async_trait::async_trait(?Send)]
 impl HttpTransport for StubHttp {
     async fn request(
         &self,
+        method: HttpMethod,
         url: &str,
         _body: Option<&[u8]>,
         _key: Hash,
     ) -> Result<bytes::Bytes, String> {
+        assert_eq!(method, HttpMethod::Get, "the reducer emitted a GET");
         Ok(format!("fetched {url}").into_bytes().into())
     }
 }
@@ -44,7 +47,8 @@ impl Reducer for FetchAgent {
                 FoldOutput::with(vec![EffectRequest::new_with_family(
                     effect_ct::HTTP,
                     "https://ok.host/data",
-                    None,
+                    // Explicit method in the http-request payload — a GET with no body.
+                    Some(Payload::Inline(encode_http_request("get", None).into())),
                     Timeliness::Interactive,
                 )])
             }
@@ -118,6 +122,7 @@ async fn a_fetch_to_an_unpermitted_host_is_denied_before_the_client() {
     impl HttpTransport for MustNotCall {
         async fn request(
             &self,
+            _m: HttpMethod,
             _u: &str,
             _b: Option<&[u8]>,
             _k: Hash,


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref da5c046db, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.