### PR TITLE
rcdzc(wasm): hoist the CDZ0406 escaping-closure scan to the emit dispatch (es1 parity)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/wasm/mod.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/mod.rs
@@ -173,6 +173,37 @@ pub fn emit(
             )));
         }
     }
+    // ESCAPING-CLOSURE guard (CDZ0406) — hoisted BEFORE every emit path, so a closure that performs an
+    // effect and crosses the host boundary declines with the CODED CDZ0406 regardless of HOW it escapes
+    // (a bare closure result, or one NESTED in a returned tuple/record/sum/collection). The individual
+    // `emit_*_resource` emitters each run this same `layout.lifted` scan, but only for the shapes they
+    // handle — a closure nested in a COMPOUND result (`(host (ask) (tuple 1 (fn (x) (+ x (ask.ask)))))`,
+    // breaker es1) routes to a compound-escape path that lacked the scan, so it fell through to `select`'s
+    // generic "not in the host-import set" decline (code None) — a diagnostic-parity gap vs the rust
+    // backend, which rejects CDZ0406 for the same program. Scanning here covers all faces uniformly.
+    // The scan targets the LIFTED CLOSURE BODIES (`layout.lifted`) — the code that runs LATER, when the
+    // host invokes `call()`, OUTSIDE the delegation frame — so a `Core::HostCall` there is a genuine escape
+    // with no home. A make-time HostCall in the EXPORT body proper (the build-time-delegated case
+    // `(host (ask) (let ((v (ask.ask))) (fn (x) (+ x v))))`, discharged while the delegation is still in
+    // dynamic scope, the closure capturing only the plain result) is NOT in a lifted body and is correctly
+    // NOT flagged. (The per-path scans remain as-is — now redundant for the shapes reached here, harmless.)
+    {
+        let mut escaping = Vec::new();
+        for l in &layout.lifted {
+            host::collect_host_imports(db, l.body, &mut escaping);
+        }
+        if let Some(h) = escaping.first() {
+            return Err(Reject::coded(
+                crate::diag::Code::ClosureEscapesEffect,
+                format!(
+                    "a closure that performs an effect ({}.{}) cannot cross the host boundary — the \
+                     closure's handler context does not travel with it, so the effect would have no home \
+                     when the host invokes it (closures escaping effects are not supported)",
+                    h.effect, h.op
+                ),
+            ));
+        }
+    }
     // The RESOURCE ESCAPE path (`DESIGN-value-heap-rcdzc.md` §3a), detected BEFORE selection: a single
     // nullary export returning a COMPOUND crosses as a component-model resource whose `encode() ->
     // list<u8>` yields the canonical binary value form. For a fully-CONSTANT compound (R1) the value is

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -88733,6 +88733,39 @@ mod closure_host_resource {
         );
     }
 
+    /// adv es1 (v-rust-backend/breaker, LOW diagnostic-parity): an escaping closure NESTED IN A TUPLE —
+    /// `(host (ask) (tuple 1 (fn (x) (+ x (ask.ask)))))` — must reject the SAME CDZ0406 as a bare escaping
+    /// closure, matching the rust backend. Before: the wasm CDZ0406 escaping-closure scan lived only inside
+    /// the individual `emit_*_resource` emitters, and a closure nested in a COMPOUND result routed to a
+    /// compound-escape path that lacked the scan, so it fell through to `select`'s generic "not in the
+    /// host-import set" decline (code None) — a parity gap (rust rejected CDZ0406, wasm declined generically;
+    /// both refuse, so it was diagnostic-only, no wrong value). Fix: hoist the escaping-closure scan to the
+    /// emit dispatch head (BEFORE routing), so every escape face — bare or compound-nested — declines CDZ0406
+    /// uniformly. Pins the tuple-nested face; the build-time-delegated companion below stays COMPILING (the
+    /// scan targets lifted closure BODIES, not a make-time host call in the export body).
+    #[test]
+    fn an_escaping_closure_nested_in_a_tuple_rejects_cdz0406_like_a_bare_one() {
+        use crate::testkit::parse;
+        let src = "(do (effect ask (op ask (-> Unit Int64))) \
+                   (def (main) (host (ask) (tuple 1 (fn ((: x Int64)) (+ x (ask.ask)))))) (export main))";
+        let err = crate::compile::compile_component(&crate::codec::encode(&parse(src)))
+            .expect_err("a closure nested in a tuple that performs an effect must REJECT CDZ0406");
+        assert_eq!(
+            err.code.as_deref(),
+            Some("CDZ0406"),
+            "a tuple-nested escaping closure must reject CDZ0406 (parity with a bare one + the rust \
+             backend), NOT fall through to a generic 'not in the host-import set' decline; got: {:?} / {}",
+            err.code,
+            err.message
+        );
+        assert!(
+            err.message.contains("ask.ask")
+                && err.message.contains("cannot cross the host boundary"),
+            "the rejection should name the escaping op, got: {}",
+            err.message
+        );
+    }
+
     /// A closure export whose BUILD-TIME code delegates a host effect — `(host (ask) (let ((v (ask.ask)))
     /// (fn (x) (+ x v))))` — now COMPILES to a VALID component (brick d: the closure-resource emit composes
     /// the host interface via `multi_closure_resource_core_module_with_host` +


### PR DESCRIPTION
Candidate PR for v-wasm-opt's merge-request (ref 74f1d72a86eddf7d67a3eefde334f769dc707d6f, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.