### PR TITLE
rcdzc: render in-range Set-element/Map-value literals at the collection width (fix adv-68 E0308)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
@@ -1734,11 +1734,39 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
                     "a Map with a non-Ord key (a float-carrying key, or a Bytes key whose order the spec does not bless) has no BTreeMap rep on the Rust backend",
                 ));
             }
+            // The map's SETTLED key/value widths — a bare in-range literal entry key/value defaults its own
+            // `type_of` to Int64 (`Nu64 as i64`), but the map is `BTreeMap<kw, vw>`, so an unannotated entry
+            // renders at the wrong width (a chained `Map.insert` folds to this `MapNew`, so `(30)` into a
+            // `BTreeMap<i64, u8>` value slot rendered `(30u64 as i64)` → E0308). Ground each entry key/value
+            // to the map's key/value type (`emit_grounded` renders a bare literal at that width, no-op when
+            // already width-carrying) — the Map twin of the Set-element / list-element sibling-width render
+            // (adv-68, v-inference: the emit half of #1780's CDZ0302 range check).
+            let (key_it, val_it): (Option<IntTy>, Option<IntTy>) =
+                match type_of(db, id).strip_nominal() {
+                    Ty::Map(mk, mv) => {
+                        let ki = match mk.strip_nominal() {
+                            Ty::Int(it) => Some(*it),
+                            _ => None,
+                        };
+                        let vi = match mv.strip_nominal() {
+                            Ty::Int(it) => Some(*it),
+                            _ => None,
+                        };
+                        (ki, vi)
+                    }
+                    _ => (None, None),
+                };
             let mut lines = String::new();
             for (k, v) in &entries {
-                let ke = emit(db, *k, env, ctx)?;
+                let ke = match key_it {
+                    Some(it) => emit_grounded(db, *k, it, env, ctx)?,
+                    None => emit(db, *k, env, ctx)?,
+                };
                 let ke = wrap_ord_key(ke, &type_of(db, *k));
-                let ve = emit(db, *v, env, ctx)?;
+                let ve = match val_it {
+                    Some(it) => emit_grounded(db, *v, it, env, ctx)?,
+                    None => emit(db, *v, env, ctx)?,
+                };
                 lines.push_str(&format!("__m.insert({ke}, {ve}); "));
             }
             // ANNOTATE `__m` with the node's `BTreeMap<K,V>` type. When the node maps concretely, spell it
@@ -1803,9 +1831,36 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
             let mut map_ctx = ctx.clone();
             map_ctx.map_typed_by_enclosing_insert = true;
             let m = emit(db, map, env, &map_ctx)?;
-            let k = emit(db, key, env, ctx)?;
+            // The map's SETTLED key/value widths — a bare in-range literal key/value defaults its own
+            // `type_of` to Int64 (`Nu64 as i64`), but the map is `BTreeMap<kw, vw>`, so an unannotated
+            // key/value renders at the wrong width (`__m.insert((2u64 as i64), (30u64 as i64))` into
+            // `BTreeMap<i64, u8>` → the `u8` value slot gets an `i64` → E0308). Ground each to the map's
+            // key/value type (`emit_grounded` renders a bare literal at that width, no-op when already
+            // width-carrying) — the Map twin of the Set-element / list-element sibling-width render (adv-68).
+            let (key_it, val_it): (Option<IntTy>, Option<IntTy>) =
+                match type_of(db, id).strip_nominal() {
+                    Ty::Map(mk, mv) => {
+                        let ki = match mk.strip_nominal() {
+                            Ty::Int(it) => Some(*it),
+                            _ => None,
+                        };
+                        let vi = match mv.strip_nominal() {
+                            Ty::Int(it) => Some(*it),
+                            _ => None,
+                        };
+                        (ki, vi)
+                    }
+                    _ => (None, None),
+                };
+            let k = match key_it {
+                Some(it) => emit_grounded(db, key, it, env, ctx)?,
+                None => emit(db, key, env, ctx)?,
+            };
             let k = wrap_ord_key(k, &kt);
-            let v = emit(db, val, env, ctx)?;
+            let v = match val_it {
+                Some(it) => emit_grounded(db, val, it, env, ctx)?,
+                None => emit(db, val, env, ctx)?,
+            };
             Ok(format!(
                 "{{ let mut __m = {m}; __m.insert({k}, {v}); __m }}"
             ))
@@ -1905,9 +1960,25 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
                     "a Set with a non-Ord element (a float-carrying element, or a Bytes element whose order the spec does not bless) has no BTreeSet rep on the Rust backend",
                 ));
             }
+            // The set's SETTLED element type — a bare in-range literal element defaults its OWN `type_of`
+            // to Int64 (`Nu64 as i64`), but the set is `BTreeSet<elem_width>`, so an unannotated element
+            // renders at the wrong width (`__s.insert((41u64 as i64))` into `BTreeSet<u64>` → E0308). Ground
+            // each element to the set's element type (`emit_grounded` renders a bare literal at that width and
+            // is a no-op when the element already carries the width) — the Set twin of the list-element
+            // sibling-width render (#1766) and the compound-slot literal grounding above (adv-68, v-inference).
+            let set_elem_ty: Option<IntTy> = match type_of(db, id).strip_nominal() {
+                Ty::Set(elem) => match elem.strip_nominal() {
+                    Ty::Int(it) => Some(*it),
+                    _ => None,
+                },
+                _ => None,
+            };
             let mut lines = String::new();
             for e in &elems {
-                let ee = emit(db, *e, env, ctx)?;
+                let ee = match set_elem_ty {
+                    Some(it) => emit_grounded(db, *e, it, env, ctx)?,
+                    None => emit(db, *e, env, ctx)?,
+                };
                 // Wrap a bare-float element in `CdzF64::new` (the set's element type is `CdzF64`).
                 let ee = wrap_ord_key(ee, &type_of(db, *e));
                 lines.push_str(&format!("__s.insert({ee}); "));

--- a/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
@@ -7650,3 +7650,47 @@ fn rustc_host_call_unit_arg_evaluates_for_effect_then_passes_unit() {
         "the unit arg is passed to the shim, reaching the String-result marshal:\n{rs}"
     );
 }
+
+#[test]
+fn adv68_inrange_sibling_typed_set_element_and_map_value_render_at_the_collection_width() {
+    // adv-68 (v-inference ROUTED, emit-side): an IN-RANGE bare literal in a Set element / Map key/value
+    // position defaults its OWN `type_of` to Int64, so the rust emitter rendered it `Nu64 as i64` —
+    // dropping an `i64` into a `BTreeSet<u64>` / a `BTreeMap<_, u8>` value slot → rustc E0308 (wasm just
+    // wraps the literal to the element width and runs). The emit half of #1780's CDZ0302 sibling-width
+    // range check: the literal must render at the COLLECTION's settled element/value width, via
+    // `emit_grounded` (the Set/Map twin of the list-element render #1766). Witnesses that it now BUILDS
+    // and computes the right value under rustc (a witness that merely compiled the container type but
+    // never ran would not prove the element render is right).
+    //
+    // Set over a sibling-typed element: `(: 1 UInt64)` pins the set's element type to UInt64; the bare
+    // in-range `41` must render `41u64` (not `41u64 as i64`) into the `BTreeSet<u64>`.
+    let set = "(module m \
+        (def (run) (Set.len (Set.of (list (: 1 UInt64) 41)))) \
+        (export run))";
+    assert!(
+        try_compile_rust(set).is_ok(),
+        "a sibling-UInt64 Set element must render at the set width, not `as i64`: {:?}",
+        try_compile_rust(set).err()
+    );
+    if let Some(out) = rustc_run(&compile_rust(set), "run()") {
+        assert_eq!(
+            out, "2",
+            "the two distinct u64 elements {{1, 41}} count as 2"
+        );
+    }
+    // Map with a sibling-typed VALUE: the first entry's `(: 5 UInt8)` pins the value type to UInt8; the
+    // second entry's bare in-range `30` must render `30u8` (not `30u64 as i64`) into the `BTreeMap<_, u8>`
+    // value slot. A chained `Map.insert(Map.insert Map.empty …)` folds to `Core::MapNew`, so the fix lives
+    // in the MapNew entry render (and the MapInsert arm for the un-folded single-insert shape).
+    let map = "(module m \
+        (def (run) (Map.len (Map.insert (Map.insert (Map.empty) 1 (: 5 UInt8)) 2 30))) \
+        (export run))";
+    assert!(
+        try_compile_rust(map).is_ok(),
+        "a sibling-UInt8 Map value must render at the value width, not `as i64`: {:?}",
+        try_compile_rust(map).err()
+    );
+    if let Some(out) = rustc_run(&compile_rust(map), "run()") {
+        assert_eq!(out, "2", "the two distinct keys {{1, 2}} count as 2");
+    }
+}


### PR DESCRIPTION
Candidate PR for v-rust-backend's merge-request (ref 4477c6524, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.