### PR TITLE
refactor(cdz-kernel): trait-rename T2 kernel-side — migrate the kernel's OWN impls to the unsuffixed fold/perform/authorize

### DIFF
--- a/implementation/seed/crates/cdz-kernel/src/authz.rs
+++ b/implementation/seed/crates/cdz-kernel/src/authz.rs
@@ -76,7 +76,8 @@ impl Authorizer {
 impl Authorize for Authorizer {
     /// SEC-F1: permission requires a capability whose predicate admits the *resolved target*. Native async
     /// (no `.await` — a flat capability-set check does no I/O).
-    async fn authorize_async(&self, req: &EffectRequest) -> Result<(), String> {
+    /// Defines the TARGET unsuffixed `authorize` (trait-rename beat T2, kernel-side).
+    async fn authorize(&self, req: &EffectRequest) -> Result<(), String> {
         if self.caps.iter().any(|c| c.permits(req)) {
             Ok(())
         } else {

--- a/implementation/seed/crates/cdz-kernel/src/effect.rs
+++ b/implementation/seed/crates/cdz-kernel/src/effect.rs
@@ -459,7 +459,7 @@ pub async fn project_manifest(
             let mut probe =
                 EffectRequest::new(kind, probe_target(family), None, Timeliness::Interactive);
             probe.content_type.family = family.to_string().into();
-            match authorizer.authorize_async(&probe).await {
+            match authorizer.authorize(&probe).await {
                 Ok(()) => GrantState::Granted,
                 Err(_) => GrantState::Denied,
             }

--- a/implementation/seed/crates/cdz-kernel/src/executor.rs
+++ b/implementation/seed/crates/cdz-kernel/src/executor.rs
@@ -115,11 +115,12 @@ impl CompositeExecutor {
 
 #[async_trait::async_trait(?Send)]
 impl Executor for CompositeExecutor {
-    async fn perform_async(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
+    // Defines the TARGET unsuffixed `perform` (trait-rename beat T2, kernel-side).
+    async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
         // Route by the request's content-type FAMILY (seq-39): a request whose family has no registered
         // executor is an OBSERVABLE Err (§9d anti-stuck), never a panic/drop.
         match self.by_family.get_mut(req.content_type.family.as_ref()) {
-            Some(inner) => inner.perform_async(req, idempotency_key).await,
+            Some(inner) => inner.perform(req, idempotency_key).await,
             None => EffectOutcome::Err(format!(
                 "no executor registered for effect family {:?} (target {:?})",
                 req.content_type.family, req.target
@@ -159,7 +160,7 @@ impl RecordingExecutor {
 
 #[async_trait::async_trait(?Send)]
 impl Executor for RecordingExecutor {
-    async fn perform_async(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
         self.seen.push((req.clone(), idempotency_key));
         EffectOutcome::Ok(Some(Payload::Inline(b"ok".to_vec().into())))
     }
@@ -199,11 +200,8 @@ pub struct ShellExecutor;
 #[cfg(all(feature = "live-exec", unix))]
 #[async_trait::async_trait(?Send)]
 impl Executor for ShellExecutor {
-    async fn perform_async(
-        &mut self,
-        req: &EffectRequest,
-        _idempotency_key: Hash,
-    ) -> EffectOutcome {
+    // Defines the TARGET unsuffixed `perform` (trait-rename beat T2, kernel-side).
+    async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash) -> EffectOutcome {
         use crate::effect::EffectKind;
         if req.kind != EffectKind::Shell {
             return EffectOutcome::Err(format!(

--- a/implementation/seed/crates/cdz-kernel/src/reducer.rs
+++ b/implementation/seed/crates/cdz-kernel/src/reducer.rs
@@ -149,7 +149,10 @@ pub struct InertReducer;
 
 #[async_trait::async_trait(?Send)]
 impl Reducer for InertReducer {
-    async fn fold_async(&self, _event: &Event, _kv: &mut Kv) -> FoldOutput {
+    // Defines the TARGET unsuffixed `fold` (trait-rename beat T2, kernel-side): the `fold_async` default
+    // now forwards here. The mutual-default bridge stays until every impl (incl. cdz-agent-host's) migrates
+    // and beat T3 drops `fold_async`.
+    async fn fold(&self, _event: &Event, _kv: &mut Kv) -> FoldOutput {
         FoldOutput::none()
     }
 }

--- a/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
+++ b/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
@@ -713,12 +713,13 @@ impl ComponentReducer {
 /// fails safe by emitting nothing so a broken reducer can't brick the loop.)
 #[async_trait::async_trait(?Send)]
 impl crate::reducer::Reducer for ComponentReducer {
-    /// Native `Reducer` — but NOTE: `ComponentReducer` runs a SYNC wasm engine, so `fold_async` calls
+    /// Native `Reducer` — but NOTE: `ComponentReducer` runs a SYNC wasm engine, so `fold` calls
     /// the sync `apply` with no `.await` (it does not cooperatively yield mid-fold). The fuel-yielding
     /// async wasm path is [`AsyncComponentReducer`]. `ComponentReducer` remains because it is the only
     /// dep-CAPABLE wasm reducer today (§23 dep-compose; `AsyncComponentReducer` declines deps pending async
     /// dep-compose). Once async dep-compose lands, `ComponentReducer` collapses into `AsyncComponentReducer`.
-    async fn fold_async(&self, event: &Event, kv: &mut Kv) -> crate::reducer::FoldOutput {
+    /// Defines the TARGET unsuffixed `fold` (trait-rename beat T2, kernel-side).
+    async fn fold(&self, event: &Event, kv: &mut Kv) -> crate::reducer::FoldOutput {
         // Map the kernel event → the guest's (content_type, payload, resumes) inputs.
         let (content_type, payload, resumes) = event_to_guest_inputs(&event.body);
 
@@ -944,7 +945,8 @@ impl AsyncComponentReducer {
 
 #[async_trait::async_trait(?Send)]
 impl crate::reducer::Reducer for AsyncComponentReducer {
-    async fn fold_async(&self, event: &Event, kv: &mut Kv) -> crate::reducer::FoldOutput {
+    // Defines the TARGET unsuffixed `fold` (trait-rename beat T2, kernel-side).
+    async fn fold(&self, event: &Event, kv: &mut Kv) -> crate::reducer::FoldOutput {
         let (content_type, payload, resumes) = event_to_guest_inputs(&event.body);
         let taken = std::mem::take(kv);
         match self.apply(taken, content_type, payload, resumes).await {
@@ -1053,7 +1055,8 @@ impl crate::authz::Authorize for ComponentAuthorizer {
     /// legitimate decision. Native `Authorize` — the policy instantiate/call is a SYNC wasm engine
     /// call today (no `.await`); a fuel-yielding async policy eval is a later refinement (the trait is
     /// async so it drops in without a signature change).
-    async fn authorize_async(&self, req: &crate::effect::EffectRequest) -> Result<(), String> {
+    /// Defines the TARGET unsuffixed `authorize` (trait-rename beat T2, kernel-side).
+    async fn authorize(&self, req: &crate::effect::EffectRequest) -> Result<(), String> {
         let mut store = wasmtime::Store::new(&self.engine, ());
         if store.set_fuel(DEFAULT_FOLD_FUEL).is_err() {
             return Err("authz: fuel init failed (fail-closed deny)".to_string());


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 2427e0c44c1f131280c28dfc5efa30a1260c1d46, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.