### PR TITLE
corpus(21-host-closures): pin the LET-bound escaping-closure CDZ0406 reject cross-backend (es5)

### DIFF
--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -643,6 +643,7 @@ pass	a LAZY comparator chain (Ordering + thunk) short-circuits on decisive and f
 pass	a LEB128 final byte is the shifted remainder masked to seven bits
 pass	a LEB128 non-final byte composes mask, continuation bit, and truncation
 pass	a LET shadow of a do-def heap binding closes its scope and the do-def survives
+pass	a LET-bound escaping-effect closure returned from a host block cannot cross the host boundary
 pass	a LET-bound outer perform under an inner handle threads its state advance
 pass	a LIST OF SUMS resumed from a handler feeds an event-sourcing fold in the body
 pass	a LIST built in the handle body from perform results crosses the handle exit live

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -1171,6 +1171,7 @@ pass	a checked integer conversion of an out-of-range CONSTANT is rejected at com
 pass	a checked integer conversion that fits succeeds
 pass	a checked result is consumed by matching its Option at run time
 pass	a checked-add over a RUNTIME operand declines pending the Core::CheckedArith runtime emit
+pass	a closure NESTED IN A TUPLE that performs a delegated effect cannot cross the host boundary
 pass	a closure RETURNS its captured map and the alias plus the original both read after
 pass	a closure applied through an unbuilt sibling variant compiles and runs
 pass	a closure argument is another closure's result

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -1183,6 +1183,7 @@ pass	a checked integer conversion of an out-of-range CONSTANT is rejected at com
 pass	a checked integer conversion that fits succeeds
 pass	a checked result is consumed by matching its Option at run time
 pass	a checked-add over a RUNTIME operand declines pending the Core::CheckedArith runtime emit
+pass	a closure NESTED IN A TUPLE that performs a delegated effect cannot cross the host boundary
 pass	a closure RETURNS its captured map and the alias plus the original both read after
 pass	a closure applied through an unbuilt sibling variant compiles and runs
 pass	a closure argument is another closure's result

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -648,6 +648,7 @@ pass	a LAZY comparator chain (Ordering + thunk) short-circuits on decisive and f
 pass	a LEB128 final byte is the shifted remainder masked to seven bits
 pass	a LEB128 non-final byte composes mask, continuation bit, and truncation
 pass	a LET shadow of a do-def heap binding closes its scope and the do-def survives
+pass	a LET-bound escaping-effect closure returned from a host block cannot cross the host boundary
 pass	a LET-bound outer perform under an inner handle threads its state advance
 pass	a LIST OF SUMS resumed from a handler feeds an event-sourcing fold in the body
 pass	a LIST built in the handle body from perform results crosses the handle exit live

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -632,6 +632,7 @@ pass	a LAZY comparator chain (Ordering + thunk) short-circuits on decisive and f
 pass	a LEB128 final byte is the shifted remainder masked to seven bits
 pass	a LEB128 non-final byte composes mask, continuation bit, and truncation
 pass	a LET shadow of a do-def heap binding closes its scope and the do-def survives
+pass	a LET-bound escaping-effect closure returned from a host block cannot cross the host boundary
 pass	a LET-bound outer perform under an inner handle threads its state advance
 pass	a LIST OF SUMS resumed from a handler feeds an event-sourcing fold in the body
 pass	a LIST built in the handle body from perform results crosses the handle exit live

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -1160,6 +1160,7 @@ pass	a checked integer conversion of an out-of-range CONSTANT is rejected at com
 pass	a checked integer conversion that fits succeeds
 pass	a checked result is consumed by matching its Option at run time
 pass	a checked-add over a RUNTIME operand declines pending the Core::CheckedArith runtime emit
+pass	a closure NESTED IN A TUPLE that performs a delegated effect cannot cross the host boundary
 pass	a closure RETURNS its captured map and the alias plus the original both read after
 pass	a closure applied through an unbuilt sibling variant compiles and runs
 pass	a closure argument is another closure's result

--- a/spec/semantics/21-host-closures.sexp
+++ b/spec/semantics/21-host-closures.sexp
@@ -177,6 +177,21 @@
                 (fn ((: x Int64)) (+ x (ask.ask))))) (export main)))
   (error  CDZ0406))
 
+(case "a closure NESTED IN A TUPLE that performs a delegated effect cannot cross the host boundary"
+  (doc    "The compound-nested face of the escaping-closure fence above: the performing closure is not the
+           bare export value but is WRAPPED IN A TUPLE — `(host (ask) (tuple 1 (fn (x) (+ x (ask.ask)))))`.
+           The tuple crosses the host boundary carrying the closure, whose body still performs the delegated
+           `ask.ask` outside the delegation's dynamic extent → rejected CDZ0406, exactly as the bare closure
+           is. Pins that the escaping-closure scan reaches a closure nested in a compound, not just a
+           top-level one. Was a generic 'not in the host-import set' decline on wasm before es1 (#1792 hoisted
+           the CDZ0406 scan to the emit dispatch); now wasm rejects CDZ0406 matching rust + rust-async.")
+  (input  (do
+            (effect ask (op ask (-> Unit Int64)))
+            (def (main)
+              (host (ask)
+                (tuple 1 (fn ((: x Int64)) (+ x (ask.ask)))))) (export main)))
+  (error  CDZ0406))
+
 ; --- An exported closure's BODY is type-checked, like an ordinary def / an in-guest-applied lambda ------
 ; A `(def (a) (fn …))` exported as a host closure crosses the boundary and is NEVER applied in-guest, so
 ; its body is never β-reduced. An ill-typed body must still be a compile-time rejection — the same CDZ0203

--- a/spec/semantics/21-host-closures.sexp
+++ b/spec/semantics/21-host-closures.sexp
@@ -192,6 +192,20 @@
                 (tuple 1 (fn ((: x Int64)) (+ x (ask.ask)))))) (export main)))
   (error  CDZ0406))
 
+(case "a LET-bound escaping-effect closure returned from a host block cannot cross the host boundary"
+  (doc    "The let-indirection face of the escaping-closure fence: the performing closure is not returned
+           directly but LET-BOUND first — `(host (ask) (let ((f (fn (x) (+ x (ask.ask))))) f))` — then the
+           bound `f` is the host block's value. The escaping-closure scan must see through the `let` to the
+           returned closure whose body performs `ask.ask` outside the delegation's extent → rejected CDZ0406,
+           same as the bare and tuple-nested faces. Pins that a `let`-binding indirection does not smuggle an
+           escaping-effect closure past the fence. (breaker es5.) wasm+rust+rust-async all CDZ0406.")
+  (input  (do
+            (effect ask (op ask (-> Unit Int64)))
+            (def (main)
+              (host (ask)
+                (let ((f (fn ((: x Int64)) (+ x (ask.ask))))) f))) (export main)))
+  (error  CDZ0406))
+
 ; --- An exported closure's BODY is type-checked, like an ordinary def / an in-guest-applied lambda ------
 ; A `(def (a) (fn …))` exported as a host closure crosses the boundary and is NEVER applied in-guest, so
 ; its body is never β-reduced. An ill-typed body must still be a compile-time rejection — the same CDZ0203


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref f22b4ddd8, lane baseline). Auto-merge armed; pr-sync's schedule-pass reaps on green.