### PR TITLE
refactor(cdz-kernel): trait-rename beat T3 — DROP the _async trait methods; fold/perform/authorize are now required (+ reword stale beat-tags)

### DIFF
--- a/implementation/seed/crates/cdz-kernel/src/authz.rs
+++ b/implementation/seed/crates/cdz-kernel/src/authz.rs
@@ -27,27 +27,9 @@ use crate::effect::{Capability, EffectRequest};
 pub trait Authorize {
     /// Is this request permitted? `Ok(())` to proceed to dispatch; `Err(reason)` to deny — the denied
     /// request never reaches an executor and the reason is recorded. Total + pure; may `.await` a wasm
-    /// policy evaluation internally.
-    /// Authorize `req` — the un-suffixed name (the trait is `async`; `_async` is redundant, operator
-    /// cleanup). This is the TARGET name. During the trait-rename window BOTH `authorize` and
-    /// `authorize_async` carry mutually-forwarding defaults, so an impl provides EXACTLY ONE and the other
-    /// forwards to it — a zero-red migration (no flag-day, no coordinated red window): existing impls keep
-    /// defining `authorize_async`; new/migrated impls define `authorize`; callers always use `authorize`.
-    /// Once ALL impls (kernel + cdz-agent-host) define `authorize`, `authorize_async` is dropped and
-    /// `authorize` becomes required (beat T3).
-    ///
-    /// TRANSITIONAL-WINDOW INVARIANT: every impl must define exactly one of the two. An impl that defines
-    /// NEITHER compiles but infinite-recurses at first call — a known, temporary hazard, guarded by the impl
-    /// set being fixed and enumerated. Do not add a new Authorize impl without defining one method.
-    async fn authorize(&self, req: &EffectRequest) -> Result<(), String> {
-        self.authorize_async(req).await
-    }
-
-    /// Legacy suffixed name — TRANSITIONAL default forwarding to [`authorize`]. Existing impls still define
-    /// this directly; dropped once every impl has migrated to `authorize` (see the window invariant above).
-    async fn authorize_async(&self, req: &EffectRequest) -> Result<(), String> {
-        self.authorize(req).await
-    }
+    /// policy evaluation internally. The un-suffixed name (the trait is `async`, so an `_async` suffix
+    /// would be redundant).
+    async fn authorize(&self, req: &EffectRequest) -> Result<(), String>;
 }
 
 /// Decides whether a requested effect may be performed. The result is logged either way (§10): a
@@ -76,7 +58,6 @@ impl Authorizer {
 impl Authorize for Authorizer {
     /// SEC-F1: permission requires a capability whose predicate admits the *resolved target*. Native async
     /// (no `.await` — a flat capability-set check does no I/O).
-    /// Defines the TARGET unsuffixed `authorize` (trait-rename beat T2, kernel-side).
     async fn authorize(&self, req: &EffectRequest) -> Result<(), String> {
         if self.caps.iter().any(|c| c.permits(req)) {
             Ok(())
@@ -105,11 +86,11 @@ mod tests {
             predicate: ResourcePredicate::HostIn(vec!["ok.host".into()]),
         }]);
         assert!(authz
-            .authorize_async(&req(EffectKind::Http, "https://ok.host/x"))
+            .authorize(&req(EffectKind::Http, "https://ok.host/x"))
             .await
             .is_ok());
         assert!(authz
-            .authorize_async(&req(EffectKind::Http, "https://evil.host/x"))
+            .authorize(&req(EffectKind::Http, "https://evil.host/x"))
             .await
             .is_err());
     }
@@ -132,18 +113,15 @@ mod tests {
         let mut r = req(EffectKind::Http, "x");
         r.content_type.family = EffectKind::Model.family().into();
         // The Http grant's family ("http") no longer matches the request's family ("model") → denied...
-        assert!(http_grant.authorize_async(&r).await.is_err());
+        assert!(http_grant.authorize(&r).await.is_err());
         // ...and the Model grant's family ("model") matches → permitted, despite kind == Http.
-        assert!(model_grant.authorize_async(&r).await.is_ok());
+        assert!(model_grant.authorize(&r).await.is_ok());
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn deny_all_denies_everything() {
         let authz = Authorizer::deny_all();
-        assert!(authz
-            .authorize_async(&req(EffectKind::Now, ""))
-            .await
-            .is_err());
+        assert!(authz.authorize(&req(EffectKind::Now, "")).await.is_err());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -153,7 +131,7 @@ mod tests {
         struct OnlyNow;
         #[async_trait::async_trait(?Send)]
         impl Authorize for OnlyNow {
-            async fn authorize_async(&self, req: &EffectRequest) -> Result<(), String> {
+            async fn authorize(&self, req: &EffectRequest) -> Result<(), String> {
                 if req.kind == EffectKind::Now {
                     Ok(())
                 } else {
@@ -162,12 +140,9 @@ mod tests {
             }
         }
         let authz: &dyn Authorize = &OnlyNow;
+        assert!(authz.authorize(&req(EffectKind::Now, "")).await.is_ok());
         assert!(authz
-            .authorize_async(&req(EffectKind::Now, ""))
-            .await
-            .is_ok());
-        assert!(authz
-            .authorize_async(&req(EffectKind::Http, "https://ok.host/x"))
+            .authorize(&req(EffectKind::Http, "https://ok.host/x"))
             .await
             .is_err());
     }

--- a/implementation/seed/crates/cdz-kernel/src/executor.rs
+++ b/implementation/seed/crates/cdz-kernel/src/executor.rs
@@ -26,28 +26,10 @@ use std::collections::HashMap;
 /// cross threads.
 #[async_trait::async_trait(?Send)]
 pub trait Executor {
-    /// Perform `req`. `idempotency_key` lets a side-effecting executor dedup a re-driven dispatch after a
+    /// Perform `req` — the un-suffixed name (the whole trait is `async`, so an `_async` suffix would be
+    /// redundant). `idempotency_key` lets a side-effecting executor dedup a re-driven dispatch after a
     /// crash. Returns the outcome the kernel folds back as an `EffectResult`. May `.await` real I/O.
-    /// Perform `req` — the un-suffixed name (the whole trait is `async`, so the `_async` suffix is
-    /// redundant; operator cleanup). This is the TARGET name. During the trait-rename window BOTH `perform`
-    /// and `perform_async` carry mutually-forwarding defaults, so an impl provides EXACTLY ONE and the other
-    /// forwards to it — a zero-red migration (no flag-day, no coordinated red window): existing impls keep
-    /// defining `perform_async`; new/migrated impls define `perform`; callers always use `perform`. Once ALL
-    /// impls (kernel + cdz-agent-host) define `perform`, `perform_async` is dropped and `perform` becomes
-    /// required (beat T3).
-    ///
-    /// TRANSITIONAL-WINDOW INVARIANT: every impl must define exactly one of the two. An impl that defines
-    /// NEITHER compiles but infinite-recurses at first call — a known, temporary hazard, guarded by the impl
-    /// set being fixed and enumerated. Do not add a new Executor impl without defining one method.
-    async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
-        self.perform_async(req, idempotency_key).await
-    }
-
-    /// Legacy suffixed name — TRANSITIONAL default forwarding to [`perform`]. Existing impls still define
-    /// this directly; dropped once every impl has migrated to `perform` (see the window invariant above).
-    async fn perform_async(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
-        self.perform(req, idempotency_key).await
-    }
+    async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome;
 
     /// Does this executor serve effect `family`? The MECHANISM dimension the capability-manifest
     /// projection ([`crate::effect::project_manifest`]) probes over the canonical family set — "does the
@@ -64,7 +46,7 @@ pub trait Executor {
 }
 
 /// The by-kind effect router (§2 "the kernel routes, doesn't distinguish"): holds `Box<dyn Executor>`
-/// per kind and routes `perform_async` to the registered executor, awaiting it. A session that emits more
+/// per kind and routes `perform` to the registered executor, awaiting it. A session that emits more
 /// than one effect kind (an agent doing both `Http` and `Model`) wires one of these; a native-async
 /// executor (a real Bedrock/HTTP one that awaits its transport) registers directly.
 ///
@@ -115,7 +97,6 @@ impl CompositeExecutor {
 
 #[async_trait::async_trait(?Send)]
 impl Executor for CompositeExecutor {
-    // Defines the TARGET unsuffixed `perform` (trait-rename beat T2, kernel-side).
     async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
         // Route by the request's content-type FAMILY (seq-39): a request whose family has no registered
         // executor is an OBSERVABLE Err (§9d anti-stuck), never a panic/drop.
@@ -200,7 +181,6 @@ pub struct ShellExecutor;
 #[cfg(all(feature = "live-exec", unix))]
 #[async_trait::async_trait(?Send)]
 impl Executor for ShellExecutor {
-    // Defines the TARGET unsuffixed `perform` (trait-rename beat T2, kernel-side).
     async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash) -> EffectOutcome {
         use crate::effect::EffectKind;
         if req.kind != EffectKind::Shell {
@@ -244,7 +224,7 @@ mod tests {
     struct TagExecutor(&'static [u8]);
     #[async_trait::async_trait(?Send)]
     impl Executor for TagExecutor {
-        async fn perform_async(&mut self, _req: &EffectRequest, _key: Hash) -> EffectOutcome {
+        async fn perform(&mut self, _req: &EffectRequest, _key: Hash) -> EffectOutcome {
             EffectOutcome::Ok(Some(Payload::Inline(self.0.to_vec().into())))
         }
     }
@@ -255,7 +235,7 @@ mod tests {
         let mut tagged = TagExecutor(b"async-ran");
         let dyn_exec: &mut dyn Executor = &mut tagged;
         let out = dyn_exec
-            .perform_async(&req(EffectKind::Http, "https://ok/x"), Hash::of(b"k"))
+            .perform(&req(EffectKind::Http, "https://ok/x"), Hash::of(b"k"))
             .await;
         assert_eq!(
             out,
@@ -279,12 +259,12 @@ mod tests {
 
         // Each kind reaches its own executor — the multi-kind session a single executor couldn't serve.
         assert_eq!(
-            exec.perform_async(&req(EffectKind::Http, "https://ok/x"), Hash::of(b"k"))
+            exec.perform(&req(EffectKind::Http, "https://ok/x"), Hash::of(b"k"))
                 .await,
             EffectOutcome::Ok(Some(Payload::Inline(b"http-ran".to_vec().into())))
         );
         assert_eq!(
-            exec.perform_async(&req(EffectKind::Shell, "echo hi"), Hash::of(b"k"))
+            exec.perform(&req(EffectKind::Shell, "echo hi"), Hash::of(b"k"))
                 .await,
             EffectOutcome::Ok(Some(Payload::Inline(b"shell-ran".to_vec().into())))
         );
@@ -298,7 +278,7 @@ mod tests {
             .with_effect(crate::effect::effect_ct::HTTP, Box::new(TagExecutor(b"h")));
         assert!(!exec.handles(&EffectKind::Model));
         match exec
-            .perform_async(&req(EffectKind::Model, "gpt"), Hash::of(b"k"))
+            .perform(&req(EffectKind::Model, "gpt"), Hash::of(b"k"))
             .await
         {
             EffectOutcome::Err(msg) => {
@@ -330,7 +310,7 @@ mod tests {
         let mut ext = req(EffectKind::Http, "x");
         ext.content_type.family = "embedding".into();
         assert_eq!(
-            exec.perform_async(&ext, Hash::of(b"k")).await,
+            exec.perform(&ext, Hash::of(b"k")).await,
             EffectOutcome::Ok(Some(Payload::Inline(b"embed-e".to_vec().into())))
         );
         // with(EffectKind) delegates to with_effect(kind.family(), ..) — same registration.
@@ -339,7 +319,7 @@ mod tests {
         assert!(viaenum.handles_family(crate::effect::effect_ct::HTTP));
         assert_eq!(
             viaenum
-                .perform_async(&req(EffectKind::Http, "x"), Hash::of(b"k"))
+                .perform(&req(EffectKind::Http, "x"), Hash::of(b"k"))
                 .await,
             EffectOutcome::Ok(Some(Payload::Inline(b"h".to_vec().into())))
         );
@@ -358,7 +338,7 @@ mod tests {
                 Box::new(TagExecutor(b"second")),
             );
         assert_eq!(
-            exec.perform_async(&req(EffectKind::Http, "x"), Hash::of(b"k"))
+            exec.perform(&req(EffectKind::Http, "x"), Hash::of(b"k"))
                 .await,
             EffectOutcome::Ok(Some(Payload::Inline(b"second".to_vec().into())))
         );
@@ -371,7 +351,7 @@ mod tests {
         struct KeyEcho;
         #[async_trait::async_trait(?Send)]
         impl Executor for KeyEcho {
-            async fn perform_async(&mut self, _req: &EffectRequest, key: Hash) -> EffectOutcome {
+            async fn perform(&mut self, _req: &EffectRequest, key: Hash) -> EffectOutcome {
                 EffectOutcome::Ok(Some(Payload::Inline(key.as_bytes().to_vec().into())))
             }
         }
@@ -379,7 +359,7 @@ mod tests {
             CompositeExecutor::new().with_effect(crate::effect::effect_ct::HTTP, Box::new(KeyEcho));
         let key = Hash::of(b"the-key");
         assert_eq!(
-            exec.perform_async(&req(EffectKind::Http, "x"), key).await,
+            exec.perform(&req(EffectKind::Http, "x"), key).await,
             EffectOutcome::Ok(Some(Payload::Inline(key.as_bytes().to_vec().into())))
         );
     }
@@ -419,14 +399,14 @@ mod tests {
         r.content_type.family = EffectKind::Model.family().into();
         // Routed by family ("model") to the MODEL executor, despite kind == Http.
         assert_eq!(
-            exec.perform_async(&r, Hash::of(b"k")).await,
+            exec.perform(&r, Hash::of(b"k")).await,
             EffectOutcome::Ok(Some(Payload::Inline(b"model-executor".to_vec().into())))
         );
         // And a family with NO registered executor (and no EffectKind variant) is an observable Err naming
         // that family — the fail-closed seam the register-by-string slice hardens to retry::permanent.
         let mut ext = req(EffectKind::Http, "x");
         ext.content_type.family = "embedding".into();
-        match exec.perform_async(&ext, Hash::of(b"k")).await {
+        match exec.perform(&ext, Hash::of(b"k")).await {
             EffectOutcome::Err(msg) => assert!(
                 msg.contains("embedding"),
                 "unroutable extension family named in the err: {msg}"

--- a/implementation/seed/crates/cdz-kernel/src/kernel.rs
+++ b/implementation/seed/crates/cdz-kernel/src/kernel.rs
@@ -1255,7 +1255,7 @@ mod status_snapshot_tests {
     struct StatusReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for StatusReducer {
-        async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 EventBody::Inbound { .. } => {
                     kv.put(b"public/status".to_vec(), b"investigating auth".to_vec());
@@ -1282,7 +1282,7 @@ mod status_snapshot_tests {
     struct ReportingReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for ReportingReducer {
-        async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 EventBody::Inbound { content_type, .. } if content_type.is_report() => {
                     // Summarize from local KV alone — read the goal it recorded, describe progress.
@@ -1471,7 +1471,7 @@ mod status_snapshot_tests {
     struct TimerThenPublishReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for TimerThenPublishReducer {
-        async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 EventBody::Inbound { .. } => {
                     FoldOutput::with_effects(vec![crate::reducer::Effect {
@@ -1712,7 +1712,7 @@ mod monotonic_now_tests {
     struct NowReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for NowReducer {
-        async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 EventBody::Inbound { .. } | EventBody::EffectResult { .. } => {
                     // On a Now result, stash it; then (up to 3 total) ask again to build a sequence.
@@ -1747,7 +1747,7 @@ mod monotonic_now_tests {
     struct StuckClock(u64);
     #[async_trait::async_trait(?Send)]
     impl Executor for StuckClock {
-        async fn perform_async(&mut self, req: &EffectRequest, _key: Hash) -> EffectOutcome {
+        async fn perform(&mut self, req: &EffectRequest, _key: Hash) -> EffectOutcome {
             assert_eq!(req.kind, EffectKind::Now);
             EffectOutcome::Ok(Some(Payload::Inline(self.0.to_le_bytes().to_vec().into())))
         }
@@ -1849,7 +1849,7 @@ mod monotonic_now_tests {
     struct SummaryEmitReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for SummaryEmitReducer {
-        async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 EventBody::Inbound { .. } => {
                     let mut request = EffectRequest::new(
@@ -1934,7 +1934,7 @@ mod monotonic_now_tests {
     struct MixedEmitReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for MixedEmitReducer {
-        async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 EventBody::Inbound { .. } => {
                     // (1) a control/summary effect — must surface, authz-exempt, unrouted.
@@ -2028,7 +2028,7 @@ mod monotonic_now_tests {
     struct CapabilitiesQueryReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for CapabilitiesQueryReducer {
-        async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 EventBody::Inbound { .. } => {
                     let mut request =
@@ -2144,7 +2144,7 @@ mod monotonic_now_tests {
     struct InertReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for InertReducer {
-        async fn fold_async(&self, _event: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, _event: &Event, _kv: &mut Kv) -> FoldOutput {
             FoldOutput::none()
         }
     }
@@ -2400,7 +2400,7 @@ mod monotonic_now_tests {
     struct TimerByFamilyReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for TimerByFamilyReducer {
-        async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 EventBody::Inbound { .. } => {
                     let mut request =

--- a/implementation/seed/crates/cdz-kernel/src/reducer.rs
+++ b/implementation/seed/crates/cdz-kernel/src/reducer.rs
@@ -102,7 +102,7 @@ impl FoldOutput {
 
 /// The reducer interface — a pure ASYNC fold (see module docs). There is ONE reducer trait, and it is
 /// async (operator ruling: "one async trait only; no reason to use sync at all"). A reducer that does no
-/// I/O simply writes an `async fn fold_async` with no `.await` (the empty-await is accepted); a wasm
+/// I/O simply writes an `async fn fold` with no `.await` (the empty-await is accepted); a wasm
 /// reducer ([`crate::wasm_host::ComponentReducer`]/[`crate::wasm_host::AsyncComponentReducer`]) awaits its
 /// fuel-yielding component call so a long fold cooperatively YIELDS (wasmtime `fuel_async_yield_interval`)
 /// instead of blocking the single-threaded host loop.
@@ -115,31 +115,14 @@ impl FoldOutput {
 #[async_trait::async_trait(?Send)]
 pub trait Reducer {
     /// Fold one event into the KV, returning requested effects. Called once per event, in log order, on a
-    /// fresh conceptual instance (no cross-call state outside `kv`).
+    /// fresh conceptual instance (no cross-call state outside `kv`). The un-suffixed name (the trait is
+    /// `async`, so an `_async` suffix would be redundant); a reducer that does no I/O simply writes it with
+    /// no `.await`.
     ///
     /// Totality (§17 "can't-brick"): this must not panic for any input — a reducer that sees an event it
     /// doesn't understand returns [`FoldOutput::none`], not a crash. A long-running implementation (a wasm
     /// fold) may `.await` internally so the host loop can interleave other sessions while it yields on fuel.
-    /// Fold one event — the un-suffixed name (the trait is `async`; `_async` is redundant, operator
-    /// cleanup). This is the TARGET name. During the trait-rename window BOTH `fold` and `fold_async`
-    /// carry mutually-forwarding defaults, so an impl provides EXACTLY ONE and the other forwards to it —
-    /// a zero-red migration (no flag-day, no coordinated red window): existing impls keep defining
-    /// `fold_async`; new/migrated impls define `fold`; callers always use `fold`. Once ALL impls (kernel +
-    /// cdz-agent-host) define `fold`, `fold_async` is dropped and `fold` becomes required (beat T3).
-    ///
-    /// TRANSITIONAL-WINDOW INVARIANT: every impl must define exactly one of the two. An impl that defines
-    /// NEITHER compiles but infinite-recurses at first call — this is a known, temporary hazard of the
-    /// window, guarded by the fact that the impl set is fixed and enumerated (no new neither-impls land
-    /// during the rename). Do not add a new Reducer impl without defining one method.
-    async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
-        self.fold_async(event, kv).await
-    }
-
-    /// Legacy suffixed name — TRANSITIONAL default forwarding to [`fold`]. Existing impls still define this
-    /// directly; it is dropped once every impl has migrated to `fold` (see the window invariant above).
-    async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
-        self.fold(event, kv).await
-    }
+    async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput;
 }
 
 /// A trivial reducer used by kernel-loop tests: it ignores everything and emits nothing. Real reducers
@@ -149,9 +132,6 @@ pub struct InertReducer;
 
 #[async_trait::async_trait(?Send)]
 impl Reducer for InertReducer {
-    // Defines the TARGET unsuffixed `fold` (trait-rename beat T2, kernel-side): the `fold_async` default
-    // now forwards here. The mutual-default bridge stays until every impl (incl. cdz-agent-host's) migrates
-    // and beat T3 drops `fold_async`.
     async fn fold(&self, _event: &Event, _kv: &mut Kv) -> FoldOutput {
         FoldOutput::none()
     }
@@ -200,11 +180,11 @@ mod tests {
         };
         let mut kv = Kv::new();
         let dyn_reducer: &dyn Reducer = &reducer;
-        let out = poll_ready(dyn_reducer.fold_async(&event, &mut kv));
+        let out = poll_ready(dyn_reducer.fold(&event, &mut kv));
         assert_eq!(out, FoldOutput::none());
     }
 
-    // Poll an IMMEDIATELY-READY future once with a no-op waker (the adapter's `fold_async` wraps a sync
+    // Poll an IMMEDIATELY-READY future once with a no-op waker (the adapter's `fold` wraps a sync
     // fold, so it never returns Pending). Fail-fast on Pending rather than spin — this helper is only for
     // known-ready futures; a Pending here is a bug, not something to busy-wait on.
     fn poll_ready<F: std::future::Future>(fut: F) -> F::Output {

--- a/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
+++ b/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
@@ -718,7 +718,6 @@ impl crate::reducer::Reducer for ComponentReducer {
     /// async wasm path is [`AsyncComponentReducer`]. `ComponentReducer` remains because it is the only
     /// dep-CAPABLE wasm reducer today (§23 dep-compose; `AsyncComponentReducer` declines deps pending async
     /// dep-compose). Once async dep-compose lands, `ComponentReducer` collapses into `AsyncComponentReducer`.
-    /// Defines the TARGET unsuffixed `fold` (trait-rename beat T2, kernel-side).
     async fn fold(&self, event: &Event, kv: &mut Kv) -> crate::reducer::FoldOutput {
         // Map the kernel event → the guest's (content_type, payload, resumes) inputs.
         let (content_type, payload, resumes) = event_to_guest_inputs(&event.body);
@@ -775,7 +774,7 @@ impl crate::reducer::Reducer for ComponentReducer {
 /// counterpart of [`ComponentReducer`]. Its engine is configured with `async_support(true)` and
 /// `fuel_async_yield_interval`, so a long `fold.apply` YIELDS at fuel intervals (letting the single-
 /// threaded host loop interleave other sessions) instead of blocking, while the per-fold fuel BUDGET still
-/// traps a true runaway. It implements [`crate::reducer::Reducer`] natively (its `fold_async` awaits
+/// traps a true runaway. It implements [`crate::reducer::Reducer`] natively (its `fold` awaits
 /// the guest's async `call_apply_async`) — the single async `Reducer` trait (the all-async arc removed
 /// the sync twin + its adapter), so a pure-Rust and a wasm reducer both `impl Reducer` directly.
 ///
@@ -819,7 +818,7 @@ impl AsyncComponentReducer {
         let mut config = wasmtime::Config::new();
         config.consume_fuel(true);
         // The all-async engine: a long fold cooperatively yields (fuel_async_yield_interval, set per-store
-        // in fold_async) instead of blocking; sync calls would panic on this engine (per-engine flag).
+        // in fold) instead of blocking; sync calls would panic on this engine (per-engine flag).
         config.async_support(true);
         let engine = wasmtime::Engine::new(&config)
             .map_err(|e| ComponentError::Instantiate(e.to_string()))?;
@@ -945,7 +944,6 @@ impl AsyncComponentReducer {
 
 #[async_trait::async_trait(?Send)]
 impl crate::reducer::Reducer for AsyncComponentReducer {
-    // Defines the TARGET unsuffixed `fold` (trait-rename beat T2, kernel-side).
     async fn fold(&self, event: &Event, kv: &mut Kv) -> crate::reducer::FoldOutput {
         let (content_type, payload, resumes) = event_to_guest_inputs(&event.body);
         let taken = std::mem::take(kv);
@@ -1055,7 +1053,6 @@ impl crate::authz::Authorize for ComponentAuthorizer {
     /// legitimate decision. Native `Authorize` — the policy instantiate/call is a SYNC wasm engine
     /// call today (no `.await`); a fuel-yielding async policy eval is a later refinement (the trait is
     /// async so it drops in without a signature change).
-    /// Defines the TARGET unsuffixed `authorize` (trait-rename beat T2, kernel-side).
     async fn authorize(&self, req: &crate::effect::EffectRequest) -> Result<(), String> {
         let mut store = wasmtime::Store::new(&self.engine, ());
         if store.set_fuel(DEFAULT_FOLD_FUEL).is_err() {
@@ -1310,7 +1307,7 @@ mod tests {
         }
         // (A ComponentAuthorizer over a real policy denies fail-closed on a policy trap — exercised e2e
         // once the Cedar policy guest exists; the trait impl's Err arms encode the fail-closed contract.)
-        let _ = <ComponentAuthorizer as Authorize>::authorize_async; // name-check the impl exists
+        let _ = <ComponentAuthorizer as Authorize>::authorize; // name-check the impl exists
     }
 
     #[test]

--- a/implementation/seed/crates/cdz-kernel/tests/async_component_reducer_e2e.rs
+++ b/implementation/seed/crates/cdz-kernel/tests/async_component_reducer_e2e.rs
@@ -61,7 +61,7 @@ async fn real_guest_folds_through_async_apply_end_to_end() {
 async fn async_reducer_drives_via_the_async_reducer_trait() {
     // Drive through the `Reducer` trait (what the async kernel loop will call) via a `&dyn` reference
     // — proving the native `impl Reducer for AsyncComponentReducer` is object-safe + folds a real
-    // Inbound event, mutating the passed-in KV (the fold_async contract).
+    // Inbound event, mutating the passed-in KV (the fold contract).
     let Some(guest) = guest_bytes() else {
         eprintln!(
             "SKIP async_reducer_drives_via_the_async_reducer_trait: REDUCER_GUEST_COMPONENT unset"
@@ -84,10 +84,10 @@ async fn async_reducer_drives_via_the_async_reducer_trait() {
         },
     };
     let mut kv = Kv::new();
-    let out = dyn_reducer.fold_async(&event, &mut kv).await;
+    let out = dyn_reducer.fold(&event, &mut kv).await;
 
     // The fold succeeded (no failure), emitted the guest's one Http effect, and mutated the KV in place.
-    // `fold_async` yields KERNEL effect types (crate::effect), not the guest-wire `wasm_host::EffectKind`.
+    // `fold` yields KERNEL effect types (crate::effect), not the guest-wire `wasm_host::EffectKind`.
     assert!(
         out.failure.is_none(),
         "fold should not fail: {:?}",

--- a/implementation/seed/crates/cdz-kernel/tests/component_reducer_e2e.rs
+++ b/implementation/seed/crates/cdz-kernel/tests/component_reducer_e2e.rs
@@ -253,7 +253,7 @@ async fn fold_commits_on_success_and_leaves_the_kv_intact_on_failure() {
     // trips the borrow checker; an `async fn` scopes the borrow to its own await cleanly).
     async fn inbound(kv: &mut Kv, reducer: &ComponentReducer) -> cdz_kernel::reducer::FoldOutput {
         reducer
-            .fold_async(
+            .fold(
                 &cdz_kernel::event::Event {
                     seq: 1,
                     cause: None,

--- a/implementation/seed/crates/cdz-kernel/tests/loop_and_recovery.rs
+++ b/implementation/seed/crates/cdz-kernel/tests/loop_and_recovery.rs
@@ -25,7 +25,7 @@ struct TwoStepReducer;
 
 #[async_trait::async_trait(?Send)]
 impl Reducer for TwoStepReducer {
-    async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+    async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
         match &event.body {
             EventBody::Inbound { .. } => {
                 kv.put(b"phase".to_vec(), b"fetching".to_vec());
@@ -170,7 +170,7 @@ async fn denied_effect_is_logged_and_never_executed() {
     struct Exfil;
     #[async_trait::async_trait(?Send)]
     impl Reducer for Exfil {
-        async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             if matches!(event.body, EventBody::Inbound { .. }) {
                 FoldOutput::with(vec![EffectRequest::new(
                     EffectKind::Http,
@@ -266,7 +266,7 @@ async fn timeout_cancels_so_a_late_result_is_dropped() {
     struct CountResumes;
     #[async_trait::async_trait(?Send)]
     impl Reducer for CountResumes {
-        async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             if matches!(event.body, EventBody::Inbound { .. }) {
                 return FoldOutput::with(vec![EffectRequest::new(
                     EffectKind::Http,
@@ -291,7 +291,7 @@ async fn timeout_cancels_so_a_late_result_is_dropped() {
     struct TimeoutExecutor;
     #[async_trait::async_trait(?Send)]
     impl Executor for TimeoutExecutor {
-        async fn perform_async(&mut self, _req: &EffectRequest, _key: Hash) -> EffectOutcome {
+        async fn perform(&mut self, _req: &EffectRequest, _key: Hash) -> EffectOutcome {
             EffectOutcome::TimedOut
         }
     }
@@ -322,7 +322,7 @@ async fn time_out_effect_settles_an_open_dispatch_and_resumes_the_reducer() {
     struct GiveUpOnTimeout;
     #[async_trait::async_trait(?Send)]
     impl Reducer for GiveUpOnTimeout {
-        async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new(
                     EffectKind::Http,
@@ -514,7 +514,7 @@ async fn a_reducers_continuation_token_is_recorded_in_the_dispatched_frame() {
     struct TokenReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for TokenReducer {
-        async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             if matches!(event.body, EventBody::Inbound { .. }) {
                 FoldOutput::with_effects(vec![Effect {
                     request: EffectRequest::new(
@@ -590,7 +590,7 @@ async fn a_continuation_token_rides_timer_fired_and_authz_denied_events() {
     struct TokenTimerAndDenyReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for TokenTimerAndDenyReducer {
-        async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 // Inbound: arm a timer WITH a continuation token.
                 EventBody::Inbound { .. } => FoldOutput::with_effects(vec![Effect {
@@ -653,7 +653,7 @@ async fn a_continuation_token_rides_timer_fired_and_authz_denied_events() {
     struct DenyTokenReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for DenyTokenReducer {
-        async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             if matches!(event.body, EventBody::Inbound { .. }) {
                 FoldOutput::with_effects(vec![Effect {
                     request: EffectRequest::new(
@@ -716,7 +716,7 @@ async fn s1_route_guard_does_not_perform_an_effect_whose_dispatch_failed_to_pers
     struct OneShot;
     #[async_trait::async_trait(?Send)]
     impl Reducer for OneShot {
-        async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             if matches!(event.body, EventBody::Inbound { .. }) {
                 FoldOutput::with(vec![EffectRequest::new(
                     EffectKind::Http,
@@ -972,7 +972,7 @@ struct TimerReducer {
 }
 #[async_trait::async_trait(?Send)]
 impl Reducer for TimerReducer {
-    async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+    async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
         match &event.body {
             EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new(
                 EffectKind::Timer,
@@ -1103,7 +1103,7 @@ async fn malformed_timer_deadline_is_rejected_not_panicked() {
     struct BadTimer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for BadTimer {
-        async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             if matches!(event.body, EventBody::Inbound { .. }) {
                 FoldOutput::with(vec![EffectRequest::new(
                     EffectKind::Timer,
@@ -1143,7 +1143,7 @@ async fn live_shell_executor_runs_a_real_command_end_to_end() {
     struct ShellReducer;
     #[async_trait::async_trait(?Send)]
     impl Reducer for ShellReducer {
-        async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new(
                     EffectKind::Shell,
@@ -1201,7 +1201,7 @@ async fn live_shell_denied_command_never_executes() {
     struct DeniedShell(String);
     #[async_trait::async_trait(?Send)]
     impl Reducer for DeniedShell {
-        async fn fold_async(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
             if matches!(event.body, EventBody::Inbound { .. }) {
                 // Harmless command (PR#992 #3: no `rm -rf` in tests). Outside the `echo ` grant →
                 // denied at the gate anyway; the marker would only appear if the gate FAILED.
@@ -1262,7 +1262,7 @@ async fn live_shell_no_injection_via_metacharacters() {
     struct Injector(String);
     #[async_trait::async_trait(?Send)]
     impl Reducer for Injector {
-        async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 // Passes `starts_with("echo ")` but embeds an injection attempt.
                 EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new(
@@ -1316,7 +1316,7 @@ async fn authz_denied_is_folded_live_so_replay_matches() {
     struct DenialCounter;
     #[async_trait::async_trait(?Send)]
     impl Reducer for DenialCounter {
-        async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
             match &event.body {
                 // Target outside the capability → denied.
                 EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new(
@@ -1371,7 +1371,7 @@ async fn replay_rejects_a_genesis_less_log_loudly() {
     struct Inert;
     #[async_trait::async_trait(?Send)]
     impl Reducer for Inert {
-        async fn fold_async(&self, _e: &Event, _kv: &mut Kv) -> FoldOutput {
+        async fn fold(&self, _e: &Event, _kv: &mut Kv) -> FoldOutput {
             FoldOutput::none()
         }
     }

--- a/implementation/seed/crates/cdz-kernel/tests/replay_determinism.rs
+++ b/implementation/seed/crates/cdz-kernel/tests/replay_determinism.rs
@@ -30,7 +30,7 @@ struct BusyReducer;
 
 #[async_trait::async_trait(?Send)]
 impl Reducer for BusyReducer {
-    async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+    async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
         match &event.body {
             EventBody::Inbound { payload, .. } => {
                 let byte = match payload {
@@ -201,7 +201,7 @@ async fn different_sequences_generally_produce_different_roots() {
 struct ScanOrderReducer;
 #[async_trait::async_trait(?Send)]
 impl Reducer for ScanOrderReducer {
-    async fn fold_async(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+    async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
         if let EventBody::Inbound { payload, .. } = &event.body {
             let byte = match payload {
                 Payload::Inline(b) if !b.is_empty() => b[0],


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 8906c67e260013f542060bb01bd284bc0af0c174, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.