### PR TITLE
rcdzc(wasm): de-rot two comments — reference behavior, not line-anchors/PR-tags

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/wasm/host.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/host.rs
@@ -271,6 +271,12 @@ fn is_extern_heap_type(ty: &Ty) -> bool {
 //# The compiler MUST surface a program's declared capabilities in its manifest without deciding which capabilities are permissible.
 //= spec/contracts/host-interface-binding.md#policy-over-the-manifest-belongs-to-the-runtime
 //# The compiler MUST NOT refuse a program solely because a capability it declares would be disallowed by a particular runtime's policy.
+//
+// This is a BACKEND-AGNOSTIC reachability walk of the lowered core (it only enumerates reached host ops;
+// no wasm-emit specifics), so the RUST backend deliberately REUSES it (e.g. its closure-escapes-effect
+// scan) rather than duplicating the descent. The `HostImport` it builds carries wasm-ABI shape, so a clean
+// hoist to a shared `backend::host` module would need a walk/construction split — deferred as not worth the
+// churn for a single reuse (v-rust-backend agreed); if a 2nd/3rd cross-backend reuse appears, do the split.
 pub fn collect_host_imports(db: &mut Db, id: StructId, out: &mut Vec<HostImport>) {
     // WALK-DEPTH GUARD — the same bound `collect_call_callees` / `collect_closure_codes` hold (see
     // [`crate::db::WALK_DEPTH_LIMIT`]): this walk drives `core_of` at every node, and a non-normalizing

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/mod.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/mod.rs
@@ -189,10 +189,10 @@ pub fn emit(
     // NOT flagged. (The per-path scans remain as-is — now redundant for the shapes reached here, harmless.)
     // Only scan REACHED lifted slots: `layout.lifted` also holds UNREACHED lambdas (demanded during
     // type-checking but built by no reachable `Core::Closure`), which `append_lifted_bodies` emits as inert
-    // never-called STUBS gated on `layout.lifted_reached` (:122). A HostCall in such a dead/stub body is
-    // provably unreachable — flagging it is a spurious CDZ0406 reject of a program where the effectful
-    // closure can never run (PR #1792 review, MED false-reject). Mirror the `:122` reached-gate so only a
-    // genuinely-reachable escaping closure is caught; stop at the first (a coded reject needs just one).
+    // never-called STUBS gated on `layout.lifted_reached`. A HostCall in such a dead/stub body is provably
+    // unreachable — flagging it would spuriously reject CDZ0406 a program whose effectful closure can never
+    // run. Mirror `append_lifted_bodies`' `layout.lifted_reached` gate so only a genuinely-reachable escaping
+    // closure is caught; stop at the first (a coded reject needs just one).
     {
         let mut escaping = Vec::new();
         for (code, l) in layout.lifted.iter().enumerate() {


### PR DESCRIPTION
Candidate PR for v-wasm-opt's merge-request (ref 91f3cff2265ea60d384ecb112f1af0fa09d77b61, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.