### PR TITLE
rcdzc: ground a mutual-recursion accumulator's sum element by re-typing the partner call from its body (fix (List Any) freeze)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/db.rs
+++ b/implementation/seed/crates/rcdzc/src/db.rs
@@ -1536,6 +1536,13 @@ pub struct Db {
     /// mid-solve returns without recomputing. Holds the def indices whose solve is on the stack.
     pub(crate) solving_params: crate::fxhash::FxHashSet<usize>,
 
+    /// Guard against infinite recursion when re-typing a MUTUAL-RECURSION PARTNER's call result from its
+    /// BODY (the SCC-freeze fix in `arg_ty_in_env`'s `SumPayload` arm): typing partner `dn`'s body demands
+    /// `dac`'s body (the mutual edge), whose `child`-off-`dn` payload would re-demand `dn`'s body — this
+    /// set holds the callee def indices whose body is being result-typed so the re-entry bottoms out at
+    /// `Any` (the same `Any` the deferred scheme gives) instead of looping. Cleared as the stack unwinds.
+    pub(crate) scc_result_typing: crate::fxhash::FxHashSet<usize>,
+
     /// The def indices whose SCHEME solve is currently on the stack — the re-entry backstop for
     /// `def_scheme` (a self-call demanding the scheme mid-compute reads `None`, typing as `Any`, the
     /// same behavior the base case absorbs). Distinct from a cached `None` in `def_schemes`: a genuine
@@ -2709,6 +2716,7 @@ impl Db {
             scheme_rigid_vars: None,
             arrow_lambdas_in_progress: crate::fxhash::FxHashSet::default(),
             solving_params: crate::fxhash::FxHashSet::default(),
+            scc_result_typing: crate::fxhash::FxHashSet::default(),
             solving_schemes: crate::fxhash::FxHashSet::default(),
             seed_transitive: crate::fxhash::FxHashSet::default(),
             reduction_root: None,

--- a/implementation/seed/crates/rcdzc/src/infer.rs
+++ b/implementation/seed/crates/rcdzc/src/infer.rs
@@ -4323,8 +4323,33 @@ fn arg_ty_in_env(
                 // binder read directly off a parameter sum; this covers one read off a call's result sum.
                 _ => Some(arg_ty_in_env(db, scrutinee, env, subst, fresh)),
             };
-            if let Some(root) = root {
-                return walk_payload_ty(db, subst.apply(&root), &steps, &heads, subst);
+            if let Some(mut root) = root {
+                root = subst.apply(&root);
+                // MUTUAL-RECURSION PARTNER RESULT (SCC freeze fix). When the scrutinee is a call to a MUTUAL
+                // PARTNER — `(match (dn b i) ((tuple child nx) …))` where `dn` and the def whose params are
+                // being solved (`dac`) are in the SAME recursive SCC (both in `solving_params`) — the call
+                // types to `Any` mid-solve: `dn`'s scheme is deferred under the in-flight solve, so its whole
+                // result collapses. A payload binder read off it (`child`) then types `Any` and FREEZES into
+                // `db.param_types` for the accumulator it is pushed onto (`acc` → `(List Any)`), which the
+                // rust backend cannot represent though a clean re-solve grounds it to the real sum. STANDALONE
+                // `type_of(dn's body)` DOES resolve the concrete result (its constructors fix the shape). So
+                // when the partner-call result is an undetermined `Any`, RE-TYPE it from the callee's BODY,
+                // which reads the concrete ctors. Guarded by a visited-set (`scc_result_typing`) so co-solving
+                // the SCC does not recurse forever (dn's body calls dac, whose child would re-demand dn's body).
+                if matches!(root, Ty::Any)
+                    && let Resolved::Apply { head, .. } = resolved_of(db, scrutinee)
+                    && let Some(callee) = callee_def_index_for_infer(db, head)
+                    && !db.scc_result_typing.contains(&callee)
+                    && let Some(callee_body) = db.defs[callee].body
+                {
+                    db.scc_result_typing.insert(callee);
+                    let body_ty = type_of(db, callee_body);
+                    db.scc_result_typing.remove(&callee);
+                    if !matches!(body_ty, Ty::Any) {
+                        root = subst.apply(&body_ty);
+                    }
+                }
+                return walk_payload_ty(db, root, &steps, &heads, subst);
             }
         }
         _ => {}

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -42273,6 +42273,47 @@ mod match_engine {
     }
 
     #[test]
+    fn an_unannotated_mutrec_accumulator_grounds_its_sum_element_and_emits_on_rust() {
+        // THE FIX for the mutual-recursion `(List Any)` freeze (v-rust-backend ask, breaker mx5). An
+        // UNANNOTATED accumulator `acc` in a mutually-recursive decoder — `dac`'s `acc` seeds as an empty
+        // `(list)` and is only ever `(List.push acc child)` where `child : Ast` is bound by `(match (dn b i)
+        // ((tuple child nx) …))`, `dn`/`dac` a mutual SCC. Its element SHOULD ground to `Ast`. It DID on
+        // wasm (heap-erased) but FROZE to `(List Any)` on the rust path: during the connected param-solve,
+        // `child`'s type reads through `arg_ty_in_env`'s SumPayload arm off the partner call `(dn b i)`,
+        // which types `Any` mid-solve (dn's scheme deferred under the in-flight SCC) → `child : Any` → froze
+        // `acc = (List Any)` in `db.param_types` → rust "parameter type (List Any) has no native
+        // representation". FIX (infer.rs SumPayload arm): when the partner-call result is an undetermined
+        // `Any`, RE-TYPE it from the callee's BODY (whose constructors fix the concrete `(Tuple Ast Int64)`),
+        // guarded by `db.scc_result_typing` against the mutual-edge recursion. `acc` now grounds to `(List
+        // Ast)` and BOTH backends emit. Prior to the fix the unannotated form declined rust while the
+        // annotated workaround (the pin above) was the only rust-buildable spelling.
+        let src = "(module m \
+          (type Ast (AInt Int64) ALeaf (AList (List Ast))) \
+          (def (dn b i) \
+            (if (= i 0) \
+                (tuple (AInt (Option.expect (List.at b 0) \"in range\")) (+ i 1)) \
+                (tuple (AList (dac b i (- i 1) (list))) (+ i 1)))) \
+          (def (dac b i n acc) \
+            (if (< n 1) acc \
+                (match (dn b i) ((tuple child nx) (dac b nx (- n 1) (List.push acc child)))))) \
+          (def (top b) (match (dn b 0) ((tuple ast pos) ast))) \
+          (def (main) (match (top (list 42 7)) ((AInt n) n) (_ -1))) (export main))";
+        // WASM (always emitted).
+        let mut dbw = crate::db::Db::load(parse(src));
+        let layw =
+            crate::layout::compute(&mut dbw).expect("unannotated mutrec decoder lays out (wasm)");
+        crate::backend::emit(crate::backend::Target::Wasm, &mut dbw, &layw, None, None)
+            .expect("unannotated mutrec decoder must emit wasm");
+        // RUST (the regressed side — must now EMIT, not decline on a frozen (List Any) accumulator).
+        let mut dbr = crate::db::Db::load(parse(src));
+        let layr =
+            crate::layout::compute(&mut dbr).expect("unannotated mutrec decoder lays out (rust)");
+        crate::backend::emit(crate::backend::Target::Rust, &mut dbr, &layr, None, None).expect(
+            "unannotated mutrec accumulator grounds its element to Ast (not frozen (List Any)) and emits rust",
+        );
+    }
+
+    #[test]
     fn an_annotated_accumulator_lets_a_mutually_recursive_decoder_emit_on_both_backends() {
         // PERIMETER pin for the (List Any) mutual-recursion freeze (v-rust-backend ask + breaker mx2):
         // the UNANNOTATED accumulator `acc` of `dac` freezes to `(List Any)` and DECLINES on rust — its


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref 3c4b8f2a9, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.