### PR TITLE
cdz-agent-host: migrate all callers off the _async Session methods (beat T4)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/async_host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/async_host.rs
@@ -14,7 +14,7 @@
 //! `Send`; sessions never cross a thread.
 //!
 //! **The kernel-async seam:** `AgentHost::deliver`/`fire_due_timers` are ASYNC (they drive the kernel's
-//! `Session::deliver_async`/`fire_due_timers_async`, folding through an [`cdz_kernel::reducer::Reducer`]
+//! `Session::deliver`/`fire_due_timers`, folding through an [`cdz_kernel::reducer::Reducer`]
 //! with `Store::fuel_async_yield_interval`), so a long fold cooperatively YIELDS and this loop interleaves
 //! other sessions while it awaits — SAME loop, no reshape, no `Send` (still one task). The in-place
 //! `host.deliver(..).await` here is exactly that seam.

--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -36,7 +36,7 @@ use std::collections::HashMap;
 /// derefs to `&str`, so every read/compare is unchanged, and `new` takes `impl Into<Arc<str>>` so
 /// `&str`/`String` call sites are unaffected.
 //
-// The host drives sessions through the kernel's ASYNC loop (`Session::deliver_async`) so a long fold can
+// The host drives sessions through the kernel's ASYNC loop (`Session::deliver`) so a long fold can
 // cooperatively yield and sessions interleave (§15b). A reducer is therefore held as a `Box<dyn
 // Reducer>` — the SINGLE reducer trait (operator "one async trait only"): a pure-Rust reducer writes
 // a native `impl Reducer` (its `fold` runs to completion with no await point), and a wasm
@@ -96,7 +96,7 @@ impl HostedSession {
     /// emits none, so most callers ignore the return.
     pub async fn seed_capabilities(&mut self) -> Vec<cdz_kernel::effect::ControlEffect> {
         self.session
-            .seed_capabilities_async(&*self.reducer, &*self.authz, &mut self.executor)
+            .seed_capabilities(&*self.reducer, &*self.authz, &mut self.executor)
             .await
     }
 
@@ -109,7 +109,7 @@ impl HostedSession {
         cause: Option<Hash>,
     ) -> Result<(), KernelError> {
         self.session
-            .deliver_async(
+            .deliver(
                 body,
                 cause,
                 &*self.reducer,
@@ -123,7 +123,7 @@ impl HostedSession {
     /// scheduler calls this on a tick; returns how many fired.
     pub async fn fire_due_timers(&mut self, now_ms: u64) -> usize {
         self.session
-            .fire_due_timers_async(now_ms, &*self.reducer, &*self.authz, &mut self.executor)
+            .fire_due_timers(now_ms, &*self.reducer, &*self.authz, &mut self.executor)
             .await
     }
 
@@ -154,7 +154,7 @@ impl HostedSession {
     ///
     /// The summary rides the CONTROL-PLANE return channel (register-by-string beat 3): the reducer emits a
     /// `control/summary` effect (family [`effect_ct::SUMMARY`]) whose `request.payload` carries the summary
-    /// bytes; `deliver_async_control` returns those authz-exempt, non-routed control effects. We scan the
+    /// bytes; `deliver_control` returns those authz-exempt, non-routed control effects. We scan the
     /// returned `Vec<ControlEffect>` for the `control/summary` entry (FILTERING by family, not taking the
     /// first — `control/capabilities` also rides this channel until it becomes kernel-answered inline) and
     /// read its inline payload. This replaces the earlier `public/summary` KV convention.
@@ -179,7 +179,7 @@ impl HostedSession {
             payload: cdz_kernel::effect::Payload::Inline(Vec::new().into()),
         };
         let controls = fork
-            .deliver_async_control(body, None, reducer, authz, executor)
+            .deliver_control(body, None, reducer, authz, executor)
             .await
             .ok()?;
         // The summary the reducer emitted for observers (§4b tier-1), read off the control-plane channel

--- a/implementation/seed/crates/cdz-agent-host/tests/agent_runs_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/agent_runs_e2e.rs
@@ -89,7 +89,7 @@ async fn agent_loop_runs_end_to_end_through_the_real_clock_executor() {
     let mut session = Session::genesis(Hash::of(b"clock-agent-v1"));
 
     session
-        .deliver_async(inbound_go(), None, &reducer, &authz, &mut exec)
+        .deliver(inbound_go(), None, &reducer, &authz, &mut exec)
         .await
         .unwrap();
 
@@ -118,7 +118,7 @@ async fn the_recorded_instant_makes_the_run_replayable() {
     // §9c/§16c-S3: the clock read is non-deterministic, but its OUTCOME is recorded — so replaying the
     // log reconstructs the identical KV without ever touching the clock again. This is why a
     // world-touching executor doesn't break event-sourcing's replay-equivalence.
-    // Both the live drive and the replay go through the async path: `deliver_async` for the run, and
+    // Both the live drive and the replay go through the async path: `deliver` for the run, and
     // `Session::replay` for the replay (it re-folds the recorded log through the Reducer, runs
     // no executor). The reducer is a native `Reducer` (the single reducer trait, ruling (b)).
     let reducer = ClockAgent;
@@ -126,7 +126,7 @@ async fn the_recorded_instant_makes_the_run_replayable() {
         CompositeExecutor::new().with_effect(effect_ct::NOW, Box::new(ClockExecutor::new()));
     let mut session = Session::genesis(Hash::of(b"clock-agent-v1"));
     session
-        .deliver_async(inbound_go(), None, &ClockAgent, &now_cap(), &mut exec)
+        .deliver(inbound_go(), None, &ClockAgent, &now_cap(), &mut exec)
         .await
         .unwrap();
 
@@ -156,7 +156,7 @@ async fn a_now_effect_outside_the_grant_is_denied_never_reaching_the_clock() {
         CompositeExecutor::new().with_effect(effect_ct::NOW, Box::new(ClockExecutor::new()));
     let mut session = Session::genesis(Hash::of(b"clock-agent-v1"));
     session
-        .deliver_async(inbound_go(), None, &reducer, &deny, &mut exec)
+        .deliver(inbound_go(), None, &reducer, &deny, &mut exec)
         .await
         .unwrap();
 

--- a/implementation/seed/crates/cdz-agent-host/tests/cedar_authz_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/cedar_authz_e2e.rs
@@ -112,7 +112,7 @@ async fn a_real_agent_is_gated_by_a_real_cedar_decision() {
             .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(StubModel)));
         let mut session = Session::genesis(Hash::of(b"cedar-permit-v1"));
         session
-            .deliver_async(inbound("model-ok"), None, &reducer, &authz, &mut exec)
+            .deliver(inbound("model-ok"), None, &reducer, &authz, &mut exec)
             .await
             .unwrap();
         assert_eq!(
@@ -138,7 +138,7 @@ async fn a_real_agent_is_gated_by_a_real_cedar_decision() {
             .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(StubModel)));
         let mut session = Session::genesis(Hash::of(b"cedar-deny-v1"));
         session
-            .deliver_async(inbound("http-imds"), None, &reducer, &authz, &mut exec)
+            .deliver(inbound("http-imds"), None, &reducer, &authz, &mut exec)
             .await
             .unwrap();
         assert_ne!(

--- a/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
@@ -101,7 +101,7 @@ async fn agent_loop_runs_end_to_end_through_the_http_executor() {
     let mut session = Session::genesis(Hash::of(b"fetch-agent-v1"));
 
     session
-        .deliver_async(inbound_go(), None, &FetchAgent, &host_cap(), &mut exec)
+        .deliver(inbound_go(), None, &FetchAgent, &host_cap(), &mut exec)
         .await
         .unwrap();
 
@@ -161,7 +161,7 @@ async fn a_fetch_to_an_unpermitted_host_is_denied_before_the_client() {
         .with_effect(effect_ct::HTTP, Box::new(HttpExecutor::new(MustNotCall)));
     let mut session = Session::genesis(Hash::of(b"exfil-agent-v1"));
     session
-        .deliver_async(inbound_go(), None, &ExfilAgent, &host_cap(), &mut exec)
+        .deliver(inbound_go(), None, &ExfilAgent, &host_cap(), &mut exec)
         .await
         .unwrap();
 

--- a/implementation/seed/crates/cdz-agent-host/tests/model_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/model_agent_e2e.rs
@@ -99,7 +99,7 @@ async fn agent_loop_runs_end_to_end_through_the_model_executor() {
     let mut session = Session::genesis(Hash::of(b"model-agent-v1"));
 
     session
-        .deliver_async(inbound_go(), None, &ModelAgent, &model_cap(), &mut exec)
+        .deliver(inbound_go(), None, &ModelAgent, &model_cap(), &mut exec)
         .await
         .unwrap();
 
@@ -189,7 +189,7 @@ async fn one_composite_routes_both_now_and_model_for_one_agent() {
     let mut session = Session::genesis(Hash::of(b"clock-then-model-v1"));
 
     session
-        .deliver_async(inbound_go(), None, &ClockThenModel, &authz, &mut exec)
+        .deliver(inbound_go(), None, &ClockThenModel, &authz, &mut exec)
         .await
         .unwrap();
 
@@ -236,7 +236,7 @@ async fn a_model_call_to_an_unpermitted_id_is_denied_before_the_transport() {
         .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(MustNotCall)));
     let mut session = Session::genesis(Hash::of(b"wrong-model-v1"));
     session
-        .deliver_async(
+        .deliver(
             inbound_go(),
             None,
             &WrongModelAgent,


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 9a11bab77, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.