### PR TITLE
cdz-agent-host: real HTTP client transport behind live-net (operator-greenlit live-net arc, slice 1)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/Cargo.toml
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.toml
@@ -23,7 +23,11 @@ publish = false
 # OFF by default so the default build/tests never make a network call or need AWS credentials, exactly
 # like cdz-kernel's `live-exec` gates the one subprocess-spawning executor. CI lints AND tests
 # `--features live-net` where a runner has egress; the default gate stays hermetic.
-live-net = []
+#
+# It enables the real transports' network deps (reqwest for the HTTP client) — kept OPTIONAL so the
+# default build never compiles them (no reqwest/hyper/rustls tree, no network types). `dep:reqwest`
+# binds the optional dependency to this feature only.
+live-net = ["dep:reqwest"]
 
 [dependencies]
 # The kernel whose Executor/Authorize traits + effect/event types we implement. Path dep across the
@@ -48,3 +52,10 @@ tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
 # (all async, single trait each). My `ModelTransport`/`HttpTransport` sub-traits + my native `impl Executor`
 # for the executors use `#[async_trait(?Send)]` (single-threaded host, non-Send transport futures — §15b).
 async-trait = "0.1"
+# reqwest — the real async HTTP client behind the `HttpTransport` seam. OPTIONAL, enabled only by
+# `live-net` (default build never compiles it — keeps the hermetic gate free of the network/TLS tree).
+# `rustls-tls` (not the platform's OpenSSL) so it builds on any runner with no system SSL dep;
+# `default-features = false` drops the default native-tls + the blocking client we don't use. The
+# single-threaded host awaits reqwest's async client directly (no `Send` bound needed — `#[cfg]`-gated
+# `ReqwestHttpTransport` is constructed on the host task).
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"], optional = true }

--- a/implementation/seed/crates/cdz-agent-host/src/http.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/http.rs
@@ -206,6 +206,104 @@ impl<T: HttpTransport> Executor for HttpExecutor<T> {
     }
 }
 
+/// The REAL HTTP client transport (behind `live-net`) — a thin adapter over [`reqwest`] filling the
+/// [`HttpTransport`] seam the [`HttpExecutor`] already routes to. Needs no credentials (an HTTP fetch),
+/// so this is the first live transport to land; the Bedrock model transport (SigV4 + creds) follows.
+///
+/// The kernel already gated the resolved URL's host (SEC-F1 SSRF/exfil guard) BEFORE dispatch, so this
+/// does NOT re-authorize — it just performs the request. It maps a completed request (any status) to
+/// `Ok(HttpResponse)` and a TRANSPORT failure to a retryability-classified `Err` (§9d/§17): a timeout or
+/// connect error is [`retry::retryable`], a builder/decode/redirect-policy failure is
+/// [`retry::permanent`]. Credentials come from the ambient environment where relevant (none needed here).
+#[cfg(feature = "live-net")]
+pub struct ReqwestHttpTransport {
+    client: reqwest::Client,
+}
+
+#[cfg(feature = "live-net")]
+impl ReqwestHttpTransport {
+    /// Build the transport with a default client. A client build failure (e.g. no TLS backend) is a
+    /// permanent host misconfiguration surfaced at construction, not per-request.
+    pub fn new() -> Result<Self, String> {
+        reqwest::Client::builder()
+            .build()
+            .map(|client| ReqwestHttpTransport { client })
+            .map_err(|e| retry::permanent(format!("failed to build the HTTP client: {e}")))
+    }
+}
+
+#[cfg(feature = "live-net")]
+#[async_trait::async_trait(?Send)]
+impl HttpTransport for ReqwestHttpTransport {
+    async fn request(
+        &self,
+        method: HttpMethod,
+        url: &str,
+        headers: &[(String, String)],
+        body: Option<&[u8]>,
+        _idempotency_key: Hash,
+    ) -> Result<HttpResponse, String> {
+        // Method + URL. reqwest parses the method string; an unparseable custom method (control chars,
+        // spaces) is a structural PERMANENT error (the request line can't be formed).
+        let reqwest_method =
+            reqwest::Method::from_bytes(method.as_str().as_bytes()).map_err(|e| {
+                retry::permanent(format!("invalid HTTP method {:?}: {e}", method.as_str()))
+            })?;
+        let mut builder = self.client.request(reqwest_method, url);
+        for (k, v) in headers {
+            builder = builder.header(k, v);
+        }
+        if let Some(b) = body {
+            builder = builder.body(b.to_vec());
+        }
+
+        // A transport-level failure (the request never completed) → classified Err. A COMPLETED request
+        // with any status (incl. 4xx/5xx) is Ok — the reducer decides what a status means, not us.
+        let resp =
+            self.client
+                .execute(builder.build().map_err(|e| {
+                    retry::permanent(format!("failed to build the HTTP request: {e}"))
+                })?)
+                .await
+                .map_err(classify_reqwest_error)?;
+
+        let status = resp.status().as_u16();
+        let resp_headers: Vec<(String, String)> = resp
+            .headers()
+            .iter()
+            .map(|(name, value)| {
+                // A header value that isn't valid UTF-8 is lossily rendered rather than dropped — a
+                // reducer reading headers gets every header, and non-text values are rare on the paths an
+                // agent fetches. (The status + body are unaffected.)
+                (
+                    name.as_str().to_string(),
+                    String::from_utf8_lossy(value.as_bytes()).into_owned(),
+                )
+            })
+            .collect();
+        // The body read can itself fail mid-stream (connection dropped) — a transport failure, classified.
+        let body = resp.bytes().await.map_err(classify_reqwest_error)?;
+
+        Ok(HttpResponse {
+            status,
+            headers: resp_headers,
+            body,
+        })
+    }
+}
+
+/// Classify a reqwest error into the supervision retryability token (§17). A timeout or a connect-level
+/// failure is transient (the endpoint may recover) → retryable; anything else (a redirect-policy or
+/// decode failure, a malformed URL that slipped the builder) is permanent by default (fail-closed).
+#[cfg(feature = "live-net")]
+fn classify_reqwest_error(e: reqwest::Error) -> String {
+    if e.is_timeout() || e.is_connect() {
+        retry::retryable(format!("HTTP transport failure: {e}"))
+    } else {
+        retry::permanent(format!("HTTP transport failure: {e}"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -49,6 +49,8 @@ pub mod status;
 pub use async_host::{AsyncAgentHost, Inbound, Inbox};
 pub use clock::ClockExecutor;
 pub use host::{AgentHost, HostedSession, SessionId};
+#[cfg(feature = "live-net")]
+pub use http::ReqwestHttpTransport;
 pub use http::{HttpExecutor, HttpMethod, HttpResponse, HttpTransport};
 pub use model::{ModelExecutor, ModelTransport};
 pub use retry::{classify, permanent, retryable, Retryability};


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 791fb44a3, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.