### PR TITLE
rcdzc: reject a wrong-arity generic in a variant-payload position at the declaration (CDZ0203)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/compile.rs
+++ b/implementation/seed/crates/rcdzc/src/compile.rs
@@ -1107,6 +1107,19 @@ pub(crate) fn validate_type_position(
         out.push(Reject::coded(Code::IntOutOfRange, msg).at(node));
         return;
     }
+    // A TYPE CONSTRUCTOR applied at the WRONG ARITY in this payload/op-type position — a user generic sum
+    // `(Box Int64 Bool)` (Box takes 1) or a prelude `(Option Int64 Bool)`. Like the annotation path
+    // (`infer.rs` — `type_ctor_arity_message`), this MUST be checked BEFORE the `typeval_of` early-return
+    // below: a user generic REDUCES to a `Ty::Sum` silently ignoring the extra arg (so `typeval_of`
+    // succeeds and the position is waved through), yet the extra/missing arg is ill-formed. Without this,
+    // a mis-arity payload slipped `cdz check` at the DECLARATION and surfaced only LATER as a confusing
+    // CDZ0201 at a construction site ("payload has declared type Box, but a value of type Box was applied"
+    // — the two render identically because the extra arg was dropped). Emit the SAME CDZ0203 the annotation
+    // path gives, anchored at the offending type expression, so a payload position reads like an annotation.
+    if let Some(msg) = crate::infer::type_ctor_arity_message(db, pos) {
+        out.push(Reject::coded(Code::TypeMismatch, msg).at(pos));
+        return;
+    }
     if crate::eval::typeval_of(db, pos).is_some() {
         return; // denotes a real type (self/mutual/forward refs + nested generics resolve)
     }

--- a/implementation/seed/crates/rcdzc/src/infer.rs
+++ b/implementation/seed/crates/rcdzc/src/infer.rs
@@ -2154,7 +2154,7 @@ fn enrich_nested_lowercase_type_vars(
 /// argument count differs — every other non-type keeps the generic message. Reads the head's ctor
 /// identity via `meta_apply_of` (GENERIC — the prim carries the arity, no hard-coded name match on the
 /// source spelling).
-fn type_ctor_arity_message(db: &mut Db, ty_expr: StructId) -> Option<String> {
+pub(crate) fn type_ctor_arity_message(db: &mut Db, ty_expr: StructId) -> Option<String> {
     // Check THIS node's head first; if it is well-formed, RECURSE into its argument positions so a NESTED
     // wrong-arity ctor is caught too — `(List (Box Int64 Bool))`, `(Tuple Int64 (Map Int64))`, a record
     // field's `(Box Int64 Bool)`. The type-argument positions are the list's children after the head (each

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -24232,6 +24232,56 @@ mod match_engine {
     }
 
     #[test]
+    fn a_wrong_arity_generic_in_a_variant_payload_is_cdz0203_at_the_declaration() {
+        // FIX: a type constructor applied at the WRONG ARITY in a VARIANT PAYLOAD position — `(type W (Wrap
+        // (Box Int64 Bool)))` where `(Box a)` takes 1, or a built-in `(Option Int64 Bool)` — was SILENTLY
+        // ACCEPTED at the declaration (a user generic REDUCES to a `Ty::Sum` dropping the extra arg, so
+        // `validate_type_position`'s `typeval_of` early-return waved it through). The mis-arity surfaced only
+        // LATER as a confusing CDZ0201 at a construction site ("payload has declared type Box, but a value of
+        // type Box was applied" — identical renders because the extra arg was dropped). Now
+        // `validate_type_position` runs `type_ctor_arity_message` BEFORE the `typeval_of` return — same as the
+        // annotation path — so the payload rejects CDZ0203 at the DECLARATION with the actionable message.
+        let bad = |src: &str, name: &str| {
+            let e = compile_component(&crate::codec::encode(&parse(src))).expect_err(
+                "a wrong-arity generic in a variant payload must reject at the declaration",
+            );
+            assert_eq!(e.code.as_deref(), Some("CDZ0203"), "got: {}", e.message);
+            assert!(
+                e.message.contains(&format!("`{name}` takes")) && e.message.contains("supplied"),
+                "expected the arity message naming {name}, got: {}",
+                e.message
+            );
+        };
+        // user generic (Box a) given 2 args in a payload.
+        bad(
+            "(module m (type (Box a) (Mk a)) (type W (Wrap (Box Int64 Bool))) (def (main) 0) (export main))",
+            "Box",
+        );
+        // built-in Option given 2 args in a payload.
+        bad(
+            "(module m (type W (Wrap (Option Int64 Bool))) (def (main) 0) (export main))",
+            "Option",
+        );
+        // CONTROLS — a RIGHT-arity payload compiles, AND a PARAM-parameterized payload `(Box a)` (where `a`
+        // is the enclosing type's param) is valid, not a false wrong-arity.
+        assert!(
+            compile_component(&crate::codec::encode(&parse(
+                "(module m (type (Box a) (Mk a)) (type W (Wrap (Box Int64))) \
+                   (def (main) (match (Wrap (Mk 5)) ((Wrap b) (match b ((Mk v) v))))) (export main))"
+            )))
+            .is_ok(),
+            "a right-arity payload constructs + matches"
+        );
+        assert!(
+            compile_component(&crate::codec::encode(&parse(
+                "(module m (type (Box a) (Mk a)) (type (Pair a) (P (Box a))) (def (main) 0) (export main))"
+            )))
+            .is_ok(),
+            "a param-parameterized payload `(Box a)` inside another generic is valid, not wrong-arity"
+        );
+    }
+
+    #[test]
     fn a_wrong_arity_generic_type_application_in_an_annotation_is_cdz0203_for_user_and_builtin() {
         // Coverage-hardening for the applied-generic-ctor arity check in a TYPE-ANNOTATION position (the
         // #1683 user-generic-by-name path + the built-in generics). A generic type applied with the WRONG


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref 1a8b942c3, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.