### PR TITLE
rcdzc: reject a BARE generic ctor missing its argument in a declaration type position (CDZ0203)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/compile.rs
+++ b/implementation/seed/crates/rcdzc/src/compile.rs
@@ -1120,6 +1120,26 @@ pub(crate) fn validate_type_position(
         out.push(Reject::coded(Code::TypeMismatch, msg).at(pos));
         return;
     }
+    // A BARE type-CONSTRUCTOR name used with NO argument in this position — `(type W (Wrap Box))`, `(op emit
+    // (-> Option Int64))`. The APPLIED wrong-arity is caught above, but a bare generic ctor is not an
+    // application, so `type_ctor_arity_message` returns `None` AND `typeval_of` SUCCEEDS (a user generic's
+    // bare name reduces to a `Ty::Sum` with a fresh var; a prelude ctor fails to reduce but the "not a type"
+    // branch below would give a vaguer message) — so it slipped through. The ANNOTATION path rejects this
+    // via `bare_type_ctor_needs_argument` (infer.rs); mirror it here so a declaration position agrees:
+    // CDZ0203 naming the missing argument + the canonical spelling, checked BEFORE the `typeval_of` return.
+    // Returns `None` for a monomorphic/nullary type or a genuine value, so those are unaffected.
+    if let Some((ctor, placeholder)) = crate::infer::bare_type_ctor_needs_argument(db, pos) {
+        out.push(
+            Reject::coded(
+                Code::TypeMismatch,
+                format!(
+                    "`{ctor}` is a type constructor — it needs a type argument here, e.g. `({ctor} {placeholder})`"
+                ),
+            )
+            .at(pos),
+        );
+        return;
+    }
     if crate::eval::typeval_of(db, pos).is_some() {
         return; // denotes a real type (self/mutual/forward refs + nested generics resolve)
     }

--- a/implementation/seed/crates/rcdzc/src/infer.rs
+++ b/implementation/seed/crates/rcdzc/src/infer.rs
@@ -1798,7 +1798,10 @@ fn non_type_annotation_message(db: &mut Db, ty_expr: StructId, lead: &str) -> St
 /// (`Int64`, a `(type C (R) (G))`). Used to turn a bare `(: xs List)` from the misleading "is a value" into
 /// the accurate missing-argument message (the bare-name twin of `type_ctor_arity_message`, which handles
 /// only the APPLIED `(List)` / `(List T T)` forms).
-fn bare_type_ctor_needs_argument(db: &mut Db, ty_expr: StructId) -> Option<(String, String)> {
+pub(crate) fn bare_type_ctor_needs_argument(
+    db: &mut Db,
+    ty_expr: StructId,
+) -> Option<(String, String)> {
     let name = db.ast.as_name(ty_expr)?.to_string();
     // A PRELUDE collection/quantity constructor — identified by its `(meta apply)` prim, placeholder names
     // matching `type_ctor_arity_message_here`.

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -24232,6 +24232,54 @@ mod match_engine {
     }
 
     #[test]
+    fn a_bare_generic_ctor_missing_its_argument_in_a_declaration_type_position_is_cdz0203() {
+        // Follow-on to the applied-wrong-arity payload fix (PR #1838 review, github-liaison/Copilot): a
+        // BARE generic constructor with NO argument — `(type W (Wrap Box))`, `(op emit (-> Option Int64))`
+        // — slipped through `validate_type_position`. The applied check (`type_ctor_arity_message`) only
+        // fires on an APPLICATION, and `typeval_of` SUCCEEDS on a bare user generic (reduces to a `Ty::Sum`
+        // with a fresh var) → early-return, waved through — while the ANNOTATION path rejected it via
+        // `bare_type_ctor_needs_argument`. FIX: `validate_type_position` now also runs
+        // `bare_type_ctor_needs_argument` before the `typeval_of` return, so a declaration position agrees
+        // with an annotation: CDZ0203 "`{ctor}` is a type constructor — it needs a type argument here".
+        let bad = |src: &str, ctor: &str| {
+            let e = compile_component(&crate::codec::encode(&parse(src))).expect_err(
+                "a bare generic ctor missing its argument must reject at the declaration",
+            );
+            assert_eq!(e.code.as_deref(), Some("CDZ0203"), "got: {}", e.message);
+            assert!(
+                e.message.contains(&format!(
+                    "`{ctor}` is a type constructor — it needs a type argument"
+                )),
+                "expected the bare-ctor message naming {ctor}, got: {}",
+                e.message
+            );
+        };
+        // bare USER generic in a variant payload.
+        bad(
+            "(module m (type (Box a) (Mk a)) (type W (Wrap Box)) (def (main) 0) (export main))",
+            "Box",
+        );
+        // bare BUILT-IN generic in a variant payload.
+        bad(
+            "(module m (type W (Wrap Option)) (def (main) 0) (export main))",
+            "Option",
+        );
+        // bare user generic in an EFFECT-OP arg type (the other validate_type_position caller).
+        bad(
+            "(module m (type (Box a) (Mk a)) (effect E (op emit (-> Box Int64))) (def (main) 0) (export main))",
+            "Box",
+        );
+        // CONTROL — a monomorphic user sum (no type params) bare in a payload is VALID (stands alone).
+        assert!(
+            compile_component(&crate::codec::encode(&parse(
+                "(module m (type Color (Red) (Green)) (type W (Wrap Color)) (def (main) 0) (export main))"
+            )))
+            .is_ok(),
+            "a bare monomorphic type in a payload is valid (not a missing-argument ctor)"
+        );
+    }
+
+    #[test]
     fn a_wrong_arity_generic_in_a_variant_payload_is_cdz0203_at_the_declaration() {
         // FIX: a type constructor applied at the WRONG ARITY in a VARIANT PAYLOAD position — `(type W (Wrap
         // (Box Int64 Bool)))` where `(Box a)` takes 1, or a built-in `(Option Int64 Bool)` — was SILENTLY


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref c0a17d4d5, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.