### PR TITLE
rcdzc: a bare under-applied generic in a VALUE annotation gives the needs-argument message, not a confusing mismatch

### DIFF
--- a/implementation/seed/crates/rcdzc/src/infer.rs
+++ b/implementation/seed/crates/rcdzc/src/infer.rs
@@ -13727,6 +13727,28 @@ fn collect_node(db: &mut Db, id: StructId, out: &mut Vec<Reject>) {
                 collect(db, expr, out);
                 return;
             }
+            // A BARE type-CONSTRUCTOR name used with NO argument in a VALUE annotation — `(: (Mk 1) Box)`,
+            // `(: 5 List)`. Like the applied wrong-arity above (and the param/payload paths), this must be
+            // caught BEFORE the type is used: a user generic's bare name REDUCES to a `Ty::Sum` with a fresh
+            // var, so `typeval_of` succeeds and the value-vs-annotation UNIFY below fires the CONFUSING
+            // "annotation type Box does not match value type Box — wrap the value in `Mk`" (both render `Box`,
+            // reading as a contradiction) instead of the clear "needs a type argument". Emit the same CDZ0203
+            // the parameter annotation gives (`bare_type_ctor_needs_argument` → the constructor message), so
+            // an under-applied generic in a value annotation reads like one in a parameter annotation. Returns
+            // `None` for a monomorphic type / a genuine value, so those are unaffected.
+            if !runtime_width
+                && let Some((ctor, placeholder)) = bare_type_ctor_needs_argument(db, ty_expr)
+            {
+                trace!(target: "rcdzc::infer", node = id.0, "fault: bare type constructor missing its argument in a value annotation (CDZ0203)");
+                out.push(Reject::coded(
+                    Code::TypeMismatch,
+                    format!(
+                        "`{ctor}` is a type constructor — it needs a type argument here, e.g. `({ctor} {placeholder})`"
+                    ),
+                ));
+                collect(db, expr, out);
+                return;
+            }
             if let Some(annot_ty) = crate::eval::typeval_of(db, ty_expr) {
                 // A FLOAT type annotating with a NON-ADMITTED width reduces (via the `Float` constructor)
                 // to the sentinel `Ty::Float(Fixed(0))` — a `(: 1.5 (Float 16))` / `(: 1.5 (Float 48))`.

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -24280,6 +24280,65 @@ mod match_engine {
     }
 
     #[test]
+    fn a_bare_generic_ctor_in_a_value_annotation_is_the_needs_argument_message_not_a_confusing_mismatch()
+     {
+        // FIX: a BARE under-applied generic constructor in a VALUE annotation `(: (Mk 1) Box)` / `(: 5 List)`
+        // previously gave the CONFUSING "annotation type Box does not match value type Box — wrap the value
+        // in `Mk`" (both render `Box`, reading as a contradiction) — because the bare generic REDUCES to a
+        // `Ty::Sum` with a fresh var, so `typeval_of` succeeds and the value-vs-annotation UNIFY fired the
+        // mismatch. The PARAMETER annotation path already gave the clear "`Box` is a type constructor — it
+        // needs a type argument here". FIX: the `Resolved::Annot` collect arm now runs
+        // `bare_type_ctor_needs_argument` (after the applied-arity check), so a value annotation reads like a
+        // parameter annotation. A right-arity value annotation still type-checks, and a GENUINE type mismatch
+        // still gives the mismatch message (the fix fires ONLY on a bare under-applied ctor).
+        let msg = |src: &str| -> String {
+            compile_component(&crate::codec::encode(&parse(src)))
+                .expect_err("a bare generic ctor in a value annotation must reject")
+                .message
+        };
+        for (src, ctor) in [
+            (
+                "(module m (type (Box a) (Mk a)) (def (main) (match (: (Mk 1) Box) ((Mk v) v))) (export main))",
+                "Box",
+            ),
+            ("(module m (def (main) (: 5 List)) (export main))", "List"),
+        ] {
+            let m = msg(src);
+            assert!(
+                m.contains(&format!(
+                    "`{ctor}` is a type constructor — it needs a type argument"
+                )),
+                "expected the needs-argument message for {ctor}, got: {m}"
+            );
+            assert!(
+                !m.contains("does not match value type"),
+                "must NOT be the confusing mismatch message, got: {m}"
+            );
+        }
+        // CONTROL — a right-arity value annotation still type-checks + runs.
+        assert_eq!(
+            run_returns::<i64>(
+                &component(
+                    "(module m (type (Box a) (Mk a)) \
+                       (def (main) (match (: (Mk 7) (Box Int64)) ((Mk v) v))) (export main))"
+                ),
+                "main"
+            ),
+            7
+        );
+        // CONTROL — a GENUINE type mismatch (not a bare ctor) still gives the mismatch message, unchanged.
+        assert!(
+            compile_component(&crate::codec::encode(&parse(
+                "(module m (def (main) (: 5 Bool)) (export main))"
+            )))
+            .expect_err("a genuine mismatch rejects")
+            .message
+            .contains("does not match value type"),
+            "a genuine type mismatch keeps the mismatch message"
+        );
+    }
+
+    #[test]
     fn a_generic_def_monomorphizes_over_a_user_generic_at_two_element_types() {
         // Coverage-hardening for recursive-generic monomorphization when a DEF's parameter/result is a USER
         // generic sum, exercised at TWO distinct element types in one program (each call site


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref e228d471b, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.