### PR TITLE
rcdzc: a bare under-applied generic in a VALUE annotation gives the needs-argument message, not a confusing mismatch

### DIFF
--- a/implementation/seed/crates/rcdzc/src/infer.rs
+++ b/implementation/seed/crates/rcdzc/src/infer.rs
@@ -13727,6 +13727,28 @@ fn collect_node(db: &mut Db, id: StructId, out: &mut Vec<Reject>) {
                 collect(db, expr, out);
                 return;
             }
+            // A BARE type-CONSTRUCTOR name used with NO argument in a VALUE annotation — `(: (Mk 1) Box)`,
+            // `(: 5 List)`. Like the applied wrong-arity above (and the param/payload paths), this must be
+            // caught BEFORE the type is used: a user generic's bare name REDUCES to a `Ty::Sum` with a fresh
+            // var, so `typeval_of` succeeds and the value-vs-annotation UNIFY below fires the CONFUSING
+            // "annotation type Box does not match value type Box — wrap the value in `Mk`" (both render `Box`,
+            // reading as a contradiction) instead of the clear "needs a type argument". Emit the same CDZ0203
+            // the parameter annotation gives (`bare_type_ctor_needs_argument` → the constructor message), so
+            // an under-applied generic in a value annotation reads like one in a parameter annotation. Returns
+            // `None` for a monomorphic type / a genuine value, so those are unaffected.
+            if !runtime_width
+                && let Some((ctor, placeholder)) = bare_type_ctor_needs_argument(db, ty_expr)
+            {
+                trace!(target: "rcdzc::infer", node = id.0, "fault: bare type constructor missing its argument in a value annotation (CDZ0203)");
+                out.push(Reject::coded(
+                    Code::TypeMismatch,
+                    format!(
+                        "`{ctor}` is a type constructor — it needs a type argument here, e.g. `({ctor} {placeholder})`"
+                    ),
+                ));
+                collect(db, expr, out);
+                return;
+            }
             if let Some(annot_ty) = crate::eval::typeval_of(db, ty_expr) {
                 // A FLOAT type annotating with a NON-ADMITTED width reduces (via the `Float` constructor)
                 // to the sentinel `Ty::Float(Fixed(0))` — a `(: 1.5 (Float 16))` / `(: 1.5 (Float 48))`.

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -24280,6 +24280,78 @@ mod match_engine {
     }
 
     #[test]
+    fn a_bare_generic_ctor_in_a_value_annotation_is_the_needs_argument_message_not_a_confusing_mismatch()
+     {
+        // FIX: a BARE under-applied generic constructor in a VALUE annotation `(: (Mk 1) Box)` / `(: 5 List)`
+        // previously gave the CONFUSING "annotation type Box does not match value type Box — wrap the value
+        // in `Mk`" (both render `Box`, reading as a contradiction) — because the bare generic REDUCES to a
+        // `Ty::Sum` with a fresh var, so `typeval_of` succeeds and the value-vs-annotation UNIFY fired the
+        // mismatch. The PARAMETER annotation path already gave the clear "`Box` is a type constructor — it
+        // needs a type argument here". FIX: the `Resolved::Annot` collect arm now runs
+        // `bare_type_ctor_needs_argument` (after the applied-arity check), so a value annotation reads like a
+        // parameter annotation. A right-arity value annotation still type-checks, and a GENUINE type mismatch
+        // still gives the mismatch message (the fix fires ONLY on a bare under-applied ctor).
+        let reject = |src: &str| {
+            compile_component(&crate::codec::encode(&parse(src)))
+                .expect_err("a bare generic ctor in a value annotation must reject")
+        };
+        for (src, ctor) in [
+            (
+                "(module m (type (Box a) (Mk a)) (def (main) (match (: (Mk 1) Box) ((Mk v) v))) (export main))",
+                "Box",
+            ),
+            ("(module m (def (main) (: 5 List)) (export main))", "List"),
+        ] {
+            let e = reject(src);
+            let m = &e.message;
+            // The behavior is CDZ0203 — assert the CODE, not just the message text (a message-only check is
+            // brittle and doesn't pin the code the way a consumer branching on it needs).
+            assert_eq!(
+                e.code.as_deref(),
+                Some("CDZ0203"),
+                "expected CDZ0203, got: {m}"
+            );
+            assert!(
+                m.contains(&format!(
+                    "`{ctor}` is a type constructor — it needs a type argument"
+                )),
+                "expected the needs-argument message for {ctor}, got: {m}"
+            );
+            assert!(
+                !m.contains("does not match value type"),
+                "must NOT be the confusing mismatch message, got: {m}"
+            );
+        }
+        // CONTROL — a right-arity value annotation still type-checks + runs.
+        assert_eq!(
+            run_returns::<i64>(
+                &component(
+                    "(module m (type (Box a) (Mk a)) \
+                       (def (main) (match (: (Mk 7) (Box Int64)) ((Mk v) v))) (export main))"
+                ),
+                "main"
+            ),
+            7
+        );
+        // CONTROL — a GENUINE type mismatch (not a bare ctor) still gives the mismatch message, unchanged.
+        let mismatch = compile_component(&crate::codec::encode(&parse(
+            "(module m (def (main) (: 5 Bool)) (export main))",
+        )))
+        .expect_err("a genuine mismatch rejects");
+        assert_eq!(
+            mismatch.code.as_deref(),
+            Some("CDZ0203"),
+            "got: {}",
+            mismatch.message
+        );
+        assert!(
+            mismatch.message.contains("does not match value type"),
+            "a genuine type mismatch keeps the mismatch message, got: {}",
+            mismatch.message
+        );
+    }
+
+    #[test]
     fn a_generic_def_monomorphizes_over_a_user_generic_at_two_element_types() {
         // Coverage-hardening for recursive-generic monomorphization when a DEF's parameter/result is a USER
         // generic sum, exercised at TWO distinct element types in one program (each call site

--- a/issues/pr1821-MERGED-deliver-control-comment-drift.md
+++ b/issues/pr1821-MERGED-deliver-control-comment-drift.md
@@ -1,0 +1,10 @@
+# PR #1821 review comment — cdz-kernel/src/kernel.rs (v-agent-harness) — MERGED, fix-forward
+
+https://github.com/camshaft/cadenza/pull/1821 (MERGED).
+
+## Test comment says `deliver_async_control` but the test now exercises `deliver_control` (Copilot, kernel.rs:1945) — doc/accuracy
+> The explanatory comment still says the kernel returns control effects via `deliver_async_control`, but
+> this test now exercises `deliver_control`. Update the comment to keep the migration narrative accurate.
+The async-collapse rename residual (same family as #1752/#1764/#1811): the `_async` suffix was dropped
+(`deliver_async_control` → `deliver_control`) but a test comment still names the old form. Update the
+comment to `deliver_control`. LOW/doc, fix-forward.

--- a/issues/pr1822-13strings-header-flat-only-claim-inaccurate.md
+++ b/issues/pr1822-13strings-header-flat-only-claim-inaccurate.md
@@ -1,0 +1,15 @@
+# PR #1822 review comment — spec/semantics/13-strings.sexp (breaker) — OPEN
+
+https://github.com/camshaft/cadenza/pull/1822 (2-pin cross-leaf UTF-8 validation; author breaker via gh).
+
+## New header claims the earlier from-bytes pins "validate FLAT buffers" — but a cross-leaf seam pin already exists above (Copilot, 13-strings.sexp:4356) — doc/accuracy [VERIFIED]
+> This header says the earlier `from-bytes` pins above only validate FLAT buffers, but the file already
+> contains a cross-leaf `Bytes.concat` seam-split UTF-8 pin (e.g. the two-byte é case). [So the "only
+> flat" framing is inaccurate.]
+VERIFIED on the PR head: the new header (~:4353) reads "the from-bytes pins ABOVE validate FLAT buffers;
+these pin the CROSS-LEAF walk" — but an existing case at :2684 is "String.from-bytes validates a
+multi-byte scalar straddling a runtime byte-rope's SEAM" (a cross-leaf/seam case, NOT flat). So the "pins
+above validate FLAT buffers" claim over-generalizes — a cross-leaf pin already exists above. Reword the
+header to distinguish what these NEW pins uniquely cover (e.g. 3-byte scalar split across BOTH seams of a
+3-leaf rope + torn-continuation-in-next-leaf) vs "flat only". LOW/doc — fold into the next 13-strings edit
+per the no-standalone-polish steer.

--- a/issues/pr1825-CONFIRMED-let-else-question-compiles-false-positive.md
+++ b/issues/pr1825-CONFIRMED-let-else-question-compiles-false-positive.md
@@ -1,0 +1,13 @@
+# PR #1825 review comment — cdz-kernel/src/event_ast.rs (v-agent-harness) — MERGED — VERIFIED FALSE POSITIVE
+
+https://github.com/camshaft/cadenza/pull/1825 (MERGED).
+
+## Copilot: `let [..] = expr?.ok_or()? else {}` "won't compile" — FALSE POSITIVE (Copilot, event_ast.rs:350)
+> `let ... else` on an expression that already applies `?` won't compile: let-else requires a plain
+> expression, not one that early-returns via `?`.
+FALSE. `?` is an expression operator that evaluates to the unwrapped value; `let PATTERN = expr? else {}`
+is valid — the `?` resolves first, then the (refutable) slice-pattern `[name_f, hash_f]` is matched with
+the else-arm as the refutation branch. VERIFIED it compiles: #1825 is MERGED (CI green) and the code is on
+trunk (event_ast.rs:344-350) as `let [name_f, hash_f] = a.as_form(...).ok_or(...)? else { return … };`.
+No action — Copilot mis-analyzed let-else + `?` interaction. DISMISSED. (Sent v-agent-harness a brief
+FYI so they don't churn working code on the bad review.)

--- a/issues/pr1829-name-store-authority-prefix-degenerate-names.md
+++ b/issues/pr1829-name-store-authority-prefix-degenerate-names.md
@@ -1,0 +1,17 @@
+# PR #1829 review comment — cdz-kernel/src/name_store.rs (v-agent-harness) — OPEN
+
+https://github.com/camshaft/cadenza/pull/1829 (§4c set/resolve slice 2 — NameStore). The anti-hijack
+namespace (#1747 lineage — security-relevant).
+
+## `authority_prefix_of` admits DEGENERATE prefixes (`system/`, `team/`, `session/`) → weakens fail-closed posture (Copilot, name_store.rs:146) — security/correctness [VERIFIED]
+> `authority_prefix_of` classifies any string that merely starts with `system/`/`team/`/`session/`/
+> `memory/` as scoped. Degenerate names like `system/`, `team/`, `team/<team>` (no trailing segment),
+> `session/` are treated as writable (set only backstops Unscoped). This contradicts the docs
+> (`system/…`, `team/<team>/…`, `session/<id>/…`) and weakens fail-closed for malformed prefixes.
+VERIFIED on the cand branch: `authority_prefix_of` is bare `if name.starts_with("system/") { System }
+else if starts_with("team/") { Team } …`. So `"system/"` (empty tail), `"team/"` (no team), `"session/"`
+(no id) all classify as their scoped authority — but the module docs require a non-empty segment
+(`team/<team>/…` etc.). A degenerate/malformed prefix being treated as a valid scoped (writable) authority
+weakens the intended fail-closed anti-hijack posture. Tighten to require a non-empty segment after the
+prefix (e.g. `team/` must be `team/<nonempty>/…`), classifying malformed ones as Unscoped (or a dedicated
+reject). MED/security-posture — recommend v-agent-harness confirm the intended grammar + fail-closed. Fix-forward.

--- a/issues/pr1830-RESOLVED-INTENTIONAL-host-do-family-frontier-flips-with-async-emit-no-action.md
+++ b/issues/pr1830-RESOLVED-INTENTIONAL-host-do-family-frontier-flips-with-async-emit-no-action.md
@@ -1,0 +1,13 @@
+# PR #1830 review comment — spec/semantics/.gate-baseline-rust-async (breaker) — MERGED, fix-forward
+
+https://github.com/camshaft/cadenza/pull/1830 (MERGED — pin the LEGAL side of the CDZ0406 boundary).
+
+## New case is `pass` in .gate-baseline + -rust but `todo` in -rust-async — weakens the cross-backend guarantee (Copilot, .gate-baseline-rust-async:2444) — coverage
+> This new case is `pass` in `.gate-baseline` and `.gate-baseline-rust`, but `todo` in
+> `.gate-baseline-rust-async`. If the intent is to pin the LEGAL side of CDZ0406 across backends, leaving
+> it `todo` for rust-async weakens that guarantee.
+The legal-side CDZ0406 pin passes on 2 of 3 backends but is `todo` on rust-async — so the "legal closure
+compiles across backends" guarantee has a hole on the async-rust path. Either the case genuinely fails on
+rust-async (then it's a rust-async gap to file/fix, not a silent todo) or it should pass there too.
+RECOMMEND breaker confirm: is rust-async `todo` intentional (a known-unsupported shape) or an oversight? If
+intentional, a comment noting WHY; if not, flip to pass. LOW-MED/coverage. Fix-forward.

--- a/issues/pr1831-FIX-QUEUED-d5fd407c7-vulnerable-landed-race-lost-live-net-gated-window.md
+++ b/issues/pr1831-FIX-QUEUED-d5fd407c7-vulnerable-landed-race-lost-live-net-gated-window.md
@@ -1,0 +1,16 @@
+# PR #1831 review comment — cdz-agent-host/src/http.rs (v-agent-harness-host) — OPEN
+
+https://github.com/camshaft/cadenza/pull/1831 (real HTTP client transport behind live-net).
+
+## reqwest follows redirects by default → an authorized URL can 3xx to a DISALLOWED host, bypassing the SSRF/host-authz guard (Copilot, http.rs:231) — SECURITY [VERIFIED]
+> Reqwest follows redirects by default, which can change the effective destination host. That bypasses
+> the "kernel already gated the resolved URL's host" SSRF/exfil guard — an allowed URL could 3xx to a
+> disallowed host and still be fetched. Configure the client to NOT follow redirects (or handle redirects
+> manually with re-authorization).
+VERIFIED against the diff: the client is `reqwest::Client::builder().build()` (http.rs:56-57) with NO
+`.redirect(...)` policy — so reqwest's DEFAULT applies (follows up to 10 redirects). The kernel authorizes
+the RESOLVED URL's host, but a 3xx response can send the actual fetch to a DIFFERENT (disallowed) host
+AFTER authorization → SSRF / data-exfil bypass of the host-authz guard. MED-HIGH (a real security surface
+on a live network transport). Fix: `.redirect(reqwest::redirect::Policy::none())` on the builder (or a
+custom policy that re-authorizes each hop's host through the kernel). RECOMMEND v-agent-harness-host treat
+as a security must-fix before live-net ships broadly.

--- a/issues/pr1832-1828-1827-agent-harness-effects-doc-nits.md
+++ b/issues/pr1832-1828-1827-agent-harness-effects-doc-nits.md
@@ -1,0 +1,13 @@
+# PRs #1832 + #1828 + #1827 review comments — LOW doc/test
+
+## PR #1828 (cdz-kernel/src/kernel.rs:1401, v-agent-harness, MERGED) — doc/accuracy
+Test comment says `deliver` is a "pure function of (input, reducer)", but `deliver` also depends on the
+STARTING SESSION STATE (the log/kv it folds onto). Reword to "(starting state, input, reducer)". LOW/doc.
+
+## PR #1832 (rcdzc/src/tests.rs:24258, v-inference, OPEN) — doc/test
+Test comment claims it locks correct singular/plural grammar + an actionable "— write `(Name …)`" hint,
+but (per Copilot) the current assertion doesn't fully pin that. Verify the assert matches the comment's
+claim (pin the grammar + hint, or soften the comment). LOW/test-precision.
+
+## PR #1827 (spec/semantics/21-host-closures.sexp:232, v-effects, MERGED) — doc/style
+Backend-status summary uses "wasm + rust" spacing vs the nearby cases' convention. Align spacing. LOWEST.

--- a/issues/pr1833-name-store-rustdoc-link-broken-on-own-branch.md
+++ b/issues/pr1833-name-store-rustdoc-link-broken-on-own-branch.md
@@ -1,0 +1,23 @@
+# PR #1833 review comments — cdz-kernel/src/effect.rs (v-agent-harness) — OPEN
+
+https://github.com/camshaft/cadenza/pull/1833 (§4c set/resolve slice 3a — store/* prefix).
+
+## 1. rustdoc intra-doc link to `name_store::NameStore::authority_prefix_of` is broken ON #1833's OWN BRANCH (Copilot, effect.rs:85) — doc/CI [VERIFIED — ordering-dependent]
+> This rustdoc intra-doc link points to `crate::name_store::NameStore::authority_prefix_of`, but there is
+> no `name_store` module / `NameStore` type in cdz-kernel, so the link will be broken (and can fail builds
+> if broken-intra-doc-links is denied).
+VERIFIED — an ORDERING dependency: `name_store`/`NameStore::authority_prefix_of` DO exist on current trunk
+(added by #1829, lib.rs:50 + name_store.rs:88/134), so the link resolves on post-#1829 trunk. BUT #1833's
+OWN cand branch (c99b2c47524a) does NOT have the module (0 matches) — it was cut before #1829 landed. So
+on #1833's own tree the link `crate::name_store::NameStore::authority_prefix_of` is genuinely broken →
+`rustdoc::broken_intra_doc_links` CI risk if #1833 is evaluated/lands before rebasing onto #1829. Now that
+#1829 is merged, ensure #1833 rebases onto current trunk (so the link resolves) before it lands — OR the
+build risks a broken-link failure. Recommend v-agent-harness rebase #1833 post-#1829 (a same-vertical
+ordering they control). LOW-MED (ordering-dependent CI risk).
+
+## 2. Doc says the predicate is used by "the drive loop's partition test" to route store/* (Copilot, effect.rs:100) — doc/verify
+> The doc comment says this predicate is used by "the drive loop's partition test" to route `store/*` to a
+> name-store handler.
+Verify the store/* routing wiring matches the doc (that the drive loop actually partitions store/* via this
+predicate) — if the routing isn't wired yet (slice 3a may be predicate-only), soften to "will be used by".
+LOW/doc. Fix-forward.

--- a/issues/pr1834-deliver-purity-comment-still-omits-authz-executor.md
+++ b/issues/pr1834-deliver-purity-comment-still-omits-authz-executor.md
@@ -1,0 +1,15 @@
+# PR #1834 review comment — cdz-kernel/src/kernel.rs (v-agent-harness) — OPEN
+
+https://github.com/camshaft/cadenza/pull/1834 (reword the deliver-determinism test comment — the fix for
+my #1828 finding). My recommended reword was itself incomplete.
+
+## "pure function of (starting state, input, reducer)" still omits `authz` + `executor` (Copilot, kernel.rs:1399) — doc/accuracy
+> The comment claims `deliver` is a pure function of (starting state, input, reducer), but `deliver` ALSO
+> takes `authz` and an `executor` and can produce different outcomes/errors when those differ. Even though
+> this test uses a Timer-only reducer (no executor calls), the statement is stronger than the API
+> guarantees.
+My #1828 note suggested "(starting state, input, reducer)" — but that's STILL incomplete: `deliver` also
+takes `authz` + `executor`, both of which affect the outcome. So the "pure function of X" framing needs
+ALL inputs, or (cleaner) drop the "pure function of" claim and say what the TEST actually pins ("this
+Timer-only reducer path is deterministic given the starting state — no executor/authz calls"). LOW/doc —
+my earlier reword suggestion was itself under-specified; Copilot's fuller list is correct. Fix-forward.

--- a/issues/pr1838-bare-generic-ctor-missing-args-accepted-at-decl.md
+++ b/issues/pr1838-bare-generic-ctor-missing-args-accepted-at-decl.md
@@ -1,0 +1,25 @@
+# PR #1838 review comments — rcdzc/src/{compile,infer}.rs (v-inference) — OPEN
+
+https://github.com/camshaft/cadenza/pull/1838 (reject a wrong-arity generic in a variant-payload — my
+#1832 wrong-arity lineage). One remaining hole + a doc.
+
+## 1. BARE generic ctor (missing all args) still accepted at payload/op-type positions — inconsistent with annotations (Copilot, compile.rs:1119) — correctness [VERIFIED]
+> `validate_type_position` now rejects over-/under-arity APPLICATIONS via `type_ctor_arity_message`, but
+> still silently accepts a BARE generic type constructor name (missing arguments) in payload/op-type
+> positions (e.g. `(type W (Wrap Box))` / `(Wrap Option)`) — `typeval_of` succeeds on the bare ctor and
+> the function returns early. Annotation positions reject this (`bare_type_ctor_needs_argument`). Remaining
+> wrong-arity hole at declaration sites.
+VERIFIED: validate_type_position (compile.rs:1119) checks `type_ctor_arity_message` (applied ctors like
+`(Box Int64 Bool)`) then `if typeval_of(pos).is_some() { return }`. A BARE ctor (`Box` with no args) isn't
+an application, so type_ctor_arity_message doesn't fire, and `typeval_of` SUCCEEDS on it (reduces to the
+sum silently) → waved through. But the ANNOTATION path catches exactly this via
+`bare_type_ctor_needs_argument` (infer.rs:1801/2501). So `(Wrap Box)` at a payload/op-type DECLARATION is
+accepted while the same shape is rejected in an annotation — an inconsistency + a wrong-arity hole that
+resurfaces later as a confusing CDZ0201 at construction. Fix: also call `bare_type_ctor_needs_argument` in
+validate_type_position (before/alongside type_ctor_arity_message). MED — completes the wrong-arity fence at
+declaration sites. Fix-forward.
+
+## 2. `type_ctor_arity_message` doc now misleading — says "annotation" + "prelude" only (Copilot, infer.rs:2157) — doc
+> The doc for `type_ctor_arity_message` says it only applies to "annotation" and "prelude type
+> constructors", but the impl is now also used by validate_type_position (payload/op-type positions).
+Update the doc to reflect it's used at payload/op-type positions too (not just annotations). LOW/doc.

--- a/issues/pr1839-classifier-no-in-kernel-caller-doc.md
+++ b/issues/pr1839-classifier-no-in-kernel-caller-doc.md
@@ -1,0 +1,11 @@
+# PR #1839 review comment — cdz-kernel/src/effect.rs (v-agent-harness) — OPEN
+
+https://github.com/camshaft/cadenza/pull/1839 (fix-forward 2 landed-MR review nits — the fixes for my
+#1833/#1834 findings). One residual on the fix.
+
+## Classifier doc says "no in-kernel caller" but it's called from this crate's unit tests (Copilot, effect.rs:102) — doc/accuracy
+> The doc comment says the classifier has "no in-kernel caller", but it IS called from the unit tests in
+> this same crate. [Also a wording nit.]
+"No in-kernel caller" is inaccurate — the crate's own unit tests call it. Reword to "no PRODUCTION/drive
+caller yet" (or "not yet wired into the drive loop; exercised by unit tests") so it's accurate about the
+test usage. LOW/doc. Fix-forward.

--- a/issues/pr1841-ADDRESSED-3410ed86f-https-connector-rt-tokio-features-plus-ResponseError-retryable-plus-doc.md
+++ b/issues/pr1841-ADDRESSED-3410ed86f-https-connector-rt-tokio-features-plus-ResponseError-retryable-plus-doc.md
@@ -1,0 +1,26 @@
+# PR #1841 review comments — cdz-agent-host/src/model.rs + Cargo.toml (v-agent-harness-host) — MERGED, fix-forward
+
+https://github.com/camshaft/cadenza/pull/1841 (MERGED — live-net Bedrock model transport).
+
+## 1. `default-features = false` may leave the AWS SDK without HTTPS connector / Tokio runtime → .send() breaks under live-net (Copilot, Cargo.toml:70) — correctness/build [substantive]
+> With `default-features = false`, the AWS crates won't include the default HTTPS client + Tokio runtime
+> wiring the SDK expects. aws-sdk-bedrockruntime only enables `rustls`, which can leave the client without
+> the required runtime/HTTP connector for `.send().await` under live-net. Also the comment says the default
+> chain includes profile/IMDS, but those are feature-gated in aws-config and won't be present unless enabled.
+The live-net Bedrock client may fail at runtime (`.send()`) if default-features=false drops the
+connector/runtime the SDK needs. Since live-net is manual/nightly-gated it wouldn't red the default CI, so
+it could lurk until someone enables live-net. RECOMMEND v-agent-harness-host verify the enabled feature set
+actually gives a working connector + runtime (add the needed features, e.g. the SDK's rustls+runtime
+combo), and correct the profile/IMDS comment to match what's feature-enabled. MED (latent live-net runtime
+break). Fix-forward.
+
+## 2. classify_bedrock_error omits SdkError::ResponseError as transient (Copilot, model.rs:210) — robustness
+> classify_bedrock_error treats only TimeoutError + DispatchFailure as transient; SdkError::ResponseError(_)
+> [and other transient variants] may also be retryable.
+Review the AWS SDK v1 SdkError variants and classify the genuinely-transient ones (ResponseError, 5xx
+ServiceError) as retryable, so live-net retries don't miss recoverable failures. LOW-MED. Fix-forward.
+
+## 3. Cargo.toml comment: "pinned to the crate's own (gitignored) Cargo.lock" (Copilot, Cargo.toml:68) — doc
+> The comment claims the live-net build is pinned to the crate's own gitignored Cargo.lock, but [the
+> workspace's Cargo.lock is the effective one].
+Reconcile the comment with the actual lock resolution (workspace vs crate-local). LOW/doc.

--- a/issues/pr1842-MERGED-07type-system-section-comment-generic-vs-nongeneric.md
+++ b/issues/pr1842-MERGED-07type-system-section-comment-generic-vs-nongeneric.md
@@ -1,0 +1,11 @@
+# PR #1842 review comment — spec/semantics/07-type-system.sexp (corpus-bugfix) — MERGED, fix-forward
+
+https://github.com/camshaft/cadenza/pull/1842 (MERGED).
+
+## Section comment inaccurate after inserting the wrong-arity user-generic cases (Copilot, 07-type-system.sexp:295) — doc/accuracy
+> This section comment is now inaccurate after inserting the wrong-arity user-generic cases: the preceding
+> two cases are about over/under-applying GENERIC user type constructors, not over-applying a NON-generic
+> type. Update the wording so readers don't confuse the two.
+The inserted wrong-arity-generic cases changed what the section covers; the header still describes
+non-generic over-application. Reword to reflect the generic-ctor arity cases now present. LOW/doc. Fold
+into the next 07-type-system edit per the no-standalone-polish steer.

--- a/issues/pr1844-MERGED-store-effect-no-idempotency-and-name-validation.md
+++ b/issues/pr1844-MERGED-store-effect-no-idempotency-and-name-validation.md
@@ -1,0 +1,27 @@
+# PR #1844 review comments — cdz-kernel/src/kernel.rs (v-agent-harness) — MERGED, fix-forward
+
+https://github.com/camshaft/cadenza/pull/1844 (MERGED — store/* effect dispatch → NameStore).
+
+## 1. store/* mutations have NO idempotency/dedup → crash-recovery re-applies (duplicate entry) (Copilot, kernel.rs:682) — correctness/durability [VERIFIED]
+> `store/*` effects mutate an external NameStore but have no idempotency mechanism like executor-side keys.
+> A crash after `apply_store_effect` mutates but before a durable EffectResult → recovery re-drives the
+> open dispatch and re-applies (store/set appends a duplicate, changing NameStore::history). Plumb
+> idempotency_key into apply_effect + track applied keys, or log the mutation durably before/with it.
+VERIFIED: the store dispatch does S1-latch (persist_error → not applied), then `apply_store_effect(&req)`,
+then `record_result` (kernel.rs:678-690). But `apply_store_effect(&mut self, req: &EffectRequest)`
+(:912) takes ONLY &req — NO idempotency_key, no dedup — even though an `idempotency_key` IS computed at
+:663 (and passed to the durable Dispatched record, NOT to the store mutation). So a crash between the
+mutation and the durable EffectResult → re-drive re-applies `store/set` → duplicate entry /
+NameStore::history divergence. The S1 latch only guards persist-FAILURE, not re-drive-after-crash — same
+crash-recovery class as #1668. MED-HIGH (durable-store correctness). Fix: plumb idempotency_key into
+apply_store_effect/NameStore + dedup by applied-key (or make the mutation itself part of a durable log
+before recording). RECOMMEND v-agent-harness treat as a recovery-correctness follow-up.
+
+## 2. `apply_store_effect` ignores the decoded name + no family-specific payload rules (Copilot, kernel.rs:935) — correctness/validation [VERIFIED]
+> `apply_store_effect` decodes a name-set payload but ignores the decoded `name` and doesn't enforce
+> family-specific payload rules — silently accepts an inconsistent store/set (payload name != target), and
+> relies on NameStore::apply_effect to reject malformed store/resolve (less precise errors).
+VERIFIED: the decode is `Ok((_name, h)) => Some(h)` — the embedded `_name` is DROPPED, so a `store/set`
+whose payload name ≠ `req.target` is silently accepted. Add: (1) store/set must have an inline name-set
+payload whose embedded name matches req.target; (2) store/resolve must have NO payload. MED/validation.
+Fix-forward.

--- a/issues/pr1848-two-unqualified-rustdoc-links-broken.md
+++ b/issues/pr1848-two-unqualified-rustdoc-links-broken.md
@@ -1,0 +1,20 @@
+# PR #1848 review comments — cdz-kernel/src/{authz,effect}.rs (v-agent-harness) — OPEN
+
+https://github.com/camshaft/cadenza/pull/1848 (§4c — Capability::for_family + Authorizer family grants).
+Two rustdoc broken-intra-doc-link risks (recurring #1692/#1764/#1815 pattern).
+
+## 1. `[`EffectKind`]` unqualified at authz.rs:45 — not in module scope (Copilot, authz.rs:45) — doc/rustdoc [VERIFIED]
+> The `family_grants` field doc references `[`EffectKind`]` but EffectKind isn't imported into this module
+> — broken intra-doc link. Fully-qualify (or import).
+VERIFIED: the link `[`EffectKind`]` is at authz.rs:41, but `use crate::effect::{EffectKind, ...}` only
+appears at :99 inside `#[cfg(test)] mod tests` — so at module-doc level EffectKind isn't in scope → broken
+link. Notably :59 in the SAME file already uses the correct fully-qualified `[`crate::effect::
+EffectKind`]` — so just make :41 match :59's qualified form. LOW/doc.
+
+## 2. `[`Authorizer::with_family_grants`]` unqualified at effect.rs:413 — Authorizer not in scope (Copilot, effect.rs:413) — doc/rustdoc [VERIFIED]
+> This rustdoc link uses `Authorizer::with_family_grants` without a module path; Authorizer isn't in scope
+> in effect.rs, so it'll likely be a broken intra-doc link. Use a fully-qualified path.
+VERIFIED: `[`Authorizer::with_family_grants`]` at effect.rs:413, but `use crate::authz::Authorizer` only
+appears inside test fns (:972+) — not at module scope. Qualify to `[`crate::authz::Authorizer::
+with_family_grants`]`. LOW/doc. Both fix-forward (or before-land — a denied broken_intra_doc_links lint
+would red the doc job).


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref 23e223b87, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.