### PR TITLE
cdz-agent-host: align the aws-config Cargo.toml comment with the real default cred chain (fix-forward #1874)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/Cargo.toml
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.toml
@@ -69,9 +69,12 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 # and the async RUNTIME (`rt-tokio`) that `.send().await` needs at runtime — so we MUST re-enable those
 # explicitly or a live-net call would fail with no connector/runtime (PR #1841 review, verified). So the
 # enabled set is: rustls (TLS backend) + default-https-client (the hyper connector) + rt-tokio (the tokio
-# sleep/timeout runtime). aws-config additionally keeps `behavior-version-latest`. We do NOT enable the
-# profile/SSO/IMDS credential-source features (`sso`, `credentials-process`) — env-var credentials
-# (AWS_ACCESS_KEY_ID / _SECRET_ACCESS_KEY / _SESSION_TOKEN + region) are the supported source per the
-# operator's environment-creds directive; a deployment needing profile/IMDS adds those features.
+# sleep/timeout runtime). aws-config additionally keeps `behavior-version-latest`. This enabled set gives
+# the DEFAULT credential chain — env vars (AWS_ACCESS_KEY_ID / _SECRET_ACCESS_KEY / _SESSION_TOKEN +
+# region), the shared config/credentials PROFILE, and IMDS — all constructed unconditionally by
+# aws-config's default_provider (verified: only the SSO leg is `#[cfg(feature = "sso")]`). The one
+# credential source we do NOT compile in is SSO (the `sso` feature) — and `credentials-process` — which we
+# leave off. Env-var creds are the operator's directed source (no broker, no Membrain); profile + IMDS
+# also work out of the box, SSO would need `sso` added.
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rustls", "default-https-client", "rt-tokio"], optional = true }
 aws-sdk-bedrockruntime = { version = "1", default-features = false, features = ["rustls", "default-https-client", "rt-tokio"], optional = true }


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref c2aacad07, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.