### PR TITLE
refactor(cdz-kernel): §4c dedup the compiler-pointer literal to NameStore::COMPILER_LATEST (liaison #1876)

### DIFF
--- a/implementation/seed/crates/cdz-kernel/src/authz.rs
+++ b/implementation/seed/crates/cdz-kernel/src/authz.rs
@@ -105,6 +105,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn family_grant_permits_a_store_family_no_capability_can() {
         use crate::effect::{effect_ct, EffectRequest};
+        use crate::name_store::NameStore;
         // §4c: store/* has NO EffectKind, so a `Capability` (keyed on kind.family()) CANNOT grant it —
         // Capability::for_family + with_family_grants is the register-by-string seam that can. A store/set
         // grant scoped to `system/` permits `store/set system/…` and denies other prefixes / other families.
@@ -122,7 +123,7 @@ mod tests {
         };
         // Permits a system/ name...
         assert!(authz
-            .authorize(&store_set("system/compiler/latest"))
+            .authorize(&store_set(NameStore::COMPILER_LATEST))
             .await
             .is_ok());
         // ...denies a name outside the granted prefix...
@@ -131,7 +132,7 @@ mod tests {
         assert!(authz
             .authorize(&EffectRequest::new_with_family(
                 effect_ct::STORE_RESOLVE,
-                "system/compiler/latest",
+                NameStore::COMPILER_LATEST,
                 None,
                 crate::effect::Timeliness::Interactive,
             ))

--- a/implementation/seed/crates/cdz-kernel/src/event_ast.rs
+++ b/implementation/seed/crates/cdz-kernel/src/event_ast.rs
@@ -1298,10 +1298,11 @@ mod tests {
     fn name_set_payload_round_trips_name_and_hash() {
         // §4c set(name, hash) log-entry payload (non-crypto half): the full name string + the content
         // hash it points at round-trip through the shared codec.
+        use crate::name_store::NameStore;
         let h = Hash::of(b"the compiler wasm bytes");
         let (name, hash) =
-            decode_name_set(&encode_name_set("system/compiler/latest", &h)).expect("round-trips");
-        assert_eq!(name, "system/compiler/latest");
+            decode_name_set(&encode_name_set(NameStore::COMPILER_LATEST, &h)).expect("round-trips");
+        assert_eq!(name, NameStore::COMPILER_LATEST);
         assert_eq!(hash, h);
 
         // A scoped name with a different prefix round-trips identically (the prefix is the resolver's

--- a/implementation/seed/crates/cdz-kernel/src/kernel.rs
+++ b/implementation/seed/crates/cdz-kernel/src/kernel.rs
@@ -2658,12 +2658,12 @@ mod store_effect_tests {
             match &event.body {
                 EventBody::Inbound { .. } => {
                     let payload = crate::event_ast::encode_name_set(
-                        "system/compiler/latest",
+                        NameStore::COMPILER_LATEST,
                         &Hash::of(b"compiler-wasm-v1"),
                     );
                     FoldOutput::with(vec![EffectRequest::new_with_family(
                         effect_ct::STORE_SET,
-                        "system/compiler/latest",
+                        NameStore::COMPILER_LATEST,
                         Some(Payload::Inline(payload.into())),
                         Timeliness::Interactive,
                     )])
@@ -2678,7 +2678,7 @@ mod store_effect_tests {
                             kv.put(b"phase".to_vec(), b"resolving".to_vec());
                             FoldOutput::with(vec![EffectRequest::new_with_family(
                                 effect_ct::STORE_RESOLVE,
-                                "system/compiler/latest",
+                                NameStore::COMPILER_LATEST,
                                 None,
                                 Timeliness::Interactive,
                             )])
@@ -2824,7 +2824,7 @@ mod store_effect_tests {
                 EventBody::Inbound { .. } => {
                     FoldOutput::with(vec![EffectRequest::new_with_family(
                         effect_ct::STORE_RESOLVE,
-                        "system/compiler/latest",
+                        NameStore::COMPILER_LATEST,
                         None,
                         Timeliness::Interactive,
                     )])
@@ -2888,7 +2888,7 @@ mod store_effect_tests {
         store
             .apply_effect(
                 effect_ct::STORE_SET,
-                "system/compiler/latest",
+                NameStore::COMPILER_LATEST,
                 Some(Hash::of(b"seeded")),
                 Hash::of(b"seed-key"),
             )

--- a/implementation/seed/crates/cdz-kernel/src/name_store.rs
+++ b/implementation/seed/crates/cdz-kernel/src/name_store.rs
@@ -305,20 +305,20 @@ mod tests {
         let mut s = NameStore::new();
         let v1 = Hash::of(b"compiler v1");
         let v2 = Hash::of(b"compiler v2");
-        s.set("system/compiler/latest", SetEntry::unsigned(v1))
+        s.set(NameStore::COMPILER_LATEST, SetEntry::unsigned(v1))
             .unwrap();
-        assert_eq!(s.resolve("system/compiler/latest").unwrap(), v1);
+        assert_eq!(s.resolve(NameStore::COMPILER_LATEST).unwrap(), v1);
         // A later set moves the pointer; resolve returns the NEW latest (value-over-time).
-        s.set("system/compiler/latest", SetEntry::unsigned(v2))
+        s.set(NameStore::COMPILER_LATEST, SetEntry::unsigned(v2))
             .unwrap();
-        assert_eq!(s.resolve("system/compiler/latest").unwrap(), v2);
+        assert_eq!(s.resolve(NameStore::COMPILER_LATEST).unwrap(), v2);
     }
 
     #[test]
     fn resolve_of_a_never_set_name_is_no_such_name() {
         let s = NameStore::new();
         assert_eq!(
-            s.resolve("system/compiler/latest"),
+            s.resolve(NameStore::COMPILER_LATEST),
             Err(NameStoreError::NoSuchName)
         );
     }
@@ -378,7 +378,7 @@ mod tests {
     #[test]
     fn authority_prefix_parse_covers_the_four_namespaces_and_fails_closed() {
         assert_eq!(
-            NameStore::authority_prefix_of("system/compiler/latest"),
+            NameStore::authority_prefix_of(NameStore::COMPILER_LATEST),
             NameAuthority::System
         );
         assert_eq!(
@@ -436,11 +436,11 @@ mod tests {
         // The store's entry payload IS what event_ast::encode_name_set serializes for a durable backend —
         // pin that the value survives the wire (slice-1 codec + slice-2 store agree).
         let h = Hash::of(b"the compiler wasm");
-        let bytes = crate::event_ast::encode_name_set("system/compiler/latest", &h);
+        let bytes = crate::event_ast::encode_name_set(NameStore::COMPILER_LATEST, &h);
         let (name, hash) = crate::event_ast::decode_name_set(&bytes).unwrap();
         let mut s = NameStore::new();
         s.set(&name, SetEntry::unsigned(hash)).unwrap();
-        assert_eq!(s.resolve("system/compiler/latest").unwrap(), h);
+        assert_eq!(s.resolve(NameStore::COMPILER_LATEST).unwrap(), h);
     }
 
     #[test]
@@ -450,16 +450,16 @@ mod tests {
         let (v1, v2) = (Hash::of(b"compiler v1"), Hash::of(b"compiler v2"));
         let sess = Hash::of(b"scratch");
         let rebuilt = NameStore::replay_set_entries([
-            ("system/compiler/latest", v1),
+            (NameStore::COMPILER_LATEST, v1),
             ("session/abc/scratch", sess),
-            ("system/compiler/latest", v2), // a later set moves the pointer
+            (NameStore::COMPILER_LATEST, v2), // a later set moves the pointer
         ])
         .expect("replay a well-formed set-event stream");
-        assert_eq!(rebuilt.resolve("system/compiler/latest").unwrap(), v2);
+        assert_eq!(rebuilt.resolve(NameStore::COMPILER_LATEST).unwrap(), v2);
         assert_eq!(rebuilt.resolve("session/abc/scratch").unwrap(), sess);
         // The full value-over-time is preserved (audit/rollback), not just the latest.
         let hist: Vec<Hash> = rebuilt
-            .history("system/compiler/latest")
+            .history(NameStore::COMPILER_LATEST)
             .iter()
             .map(|e| e.hash)
             .collect();
@@ -540,14 +540,14 @@ mod tests {
 
         // store/set with a hash → appends + echoes the set hash.
         assert_eq!(
-            s.apply_effect(effect_ct::STORE_SET, "system/compiler/latest", Some(h), k),
+            s.apply_effect(effect_ct::STORE_SET, NameStore::COMPILER_LATEST, Some(h), k),
             Ok(StoreOutcome::Set(h))
         );
         // store/resolve with no hash → the current (frozen) hash.
         assert_eq!(
             s.apply_effect(
                 effect_ct::STORE_RESOLVE,
-                "system/compiler/latest",
+                NameStore::COMPILER_LATEST,
                 None,
                 Hash::of(b"key-2")
             ),
@@ -573,7 +573,7 @@ mod tests {
         let mut s = NameStore::new();
         let h = Hash::of(b"compiler wasm v1");
         let key = Hash::of(b"dispatch-key-A");
-        let name = "system/compiler/latest";
+        let name = NameStore::COMPILER_LATEST;
 
         // First apply appends.
         assert_eq!(
@@ -613,7 +613,7 @@ mod tests {
         // and forgetting an absent key (a resolve's, or an already-forgotten one) is a harmless no-op.
         use crate::effect::effect_ct;
         let mut s = NameStore::new();
-        let name = "system/compiler/latest";
+        let name = NameStore::COMPILER_LATEST;
         let key = Hash::of(b"dispatch-key-A");
         let h = Hash::of(b"v1");
 


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 157c60855999bd2bd147e8b007fe25dcbd651ea3, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.