### PR TITLE
rcdzc(effects): adv-69 safe-decline floor — a block-wrapped branch perform in a let-init declines cleanly instead of a silent state-drop miscompile

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -2118,6 +2118,20 @@ pub fn reduce_handle(
     // continuation. Idempotent + cheap: a no-op (returns `body` unchanged) when the inline surfaced no
     // branch-performing conditional, so a body with no such helper is untouched.
     let body = hoist_resumptive_conditional(db, body, &ctx);
+    // adv-69 SAFE-DECLINE FLOOR (HIGH silent miscompile, breaker + corpus-bugfix 2026-08-04). The hoist above
+    // lifts a branch-performing conditional that is DIRECTLY a `let`-init to tail position (Site 4), where
+    // per-branch threading carries its state advance. But a conditional wrapped in a BLOCK (`(let ((v (let
+    // ((b true)) (if b (E.op) x)))) cont)` — inner-let/do around the `if`/`match`) is opaque to Site 4: the
+    // block's exit state reverts to block-ENTRY, so the branch perform's advance is DROPPED and a later
+    // perform in `cont` resumes the stale pre-branch state → a WRONG VALUE, no error (worst class). Until the
+    // full through-block distribution lands (a commuting conversion needing alpha-safe binder handling — a
+    // separate careful increment), DECLINE this residual shape so it grades a clean Todo, never a silent
+    // miscompile. Detects a `let`-init whose value is a block-wrapped branch-performing conditional the hoist
+    // left in place. (The direct-init case the hoist DID lift no longer matches — it's now a tail conditional,
+    // not a `let`-init block — so this never over-declines the working Site-4 path.)
+    if body_has_block_wrapped_let_init_branch_perform(db, body, &ctx) {
+        return None;
+    }
     // E5 PURE ONE-HOLE-CONTINUATION fold (general one-shot, the pure-continuation case). When the handle
     // BODY reaches EXACTLY ONE discharged perform `P` through STRICT, UNCONDITIONAL, effect-free positions
     // (`pure_hole`), its delimited continuation is the PURE one-hole context `C = body[P := □]`. Resuming
@@ -3375,6 +3389,69 @@ fn conditional_branch_performs(db: &mut Db, node: StructId, ctx: &HandlerCtx) ->
             .iter()
             .any(|&(_, body)| subtree_performs(db, body, ctx)),
         _ => false,
+    }
+}
+
+/// Whether `node` is a BLOCK (`let`/`do`) whose TAIL VALUE — through nested `let`/`do` wrappers — is a
+/// branch-performing conditional that Site 4's hoist does NOT reach. Site 4 (`conditional_branch_performs`)
+/// only lifts a conditional that is DIRECTLY the `let`-init value; a conditional wrapped in a block
+/// (`(let ((v (let ((b true)) (if b (E.op) x)))) cont)`) is opaque to it, so the block's exit state falls
+/// back to the block-ENTRY state and the branch perform's advance is DROPPED at the block boundary — a
+/// silent wrong-value (adv-69, HIGH: `+ (* 10 v) (E.op)` reads the stale pre-branch state). Detecting this
+/// residual shape (AFTER the hoist ran, so a liftable direct-init case is already in tail position) lets
+/// `reduce_handle` DECLINE cleanly (honest Todo) rather than fold a wrong value. Peels only PURE-binding
+/// block wrappers to the tail; a wrapper with a PERFORMING binding is a different (threaded) shape, not this.
+fn block_wrapped_branch_performs(db: &mut Db, node: StructId, ctx: &HandlerCtx) -> bool {
+    match resolved_of(db, node) {
+        // A `let` block: its value is the body; recurse through it. (A performing binding is threaded by
+        // the ordinary `let` arm — this drop only bites when the wrapper's BODY is the branch conditional.)
+        Resolved::Let { body, .. } => {
+            conditional_branch_performs(db, body, ctx)
+                || block_wrapped_branch_performs(db, body, ctx)
+        }
+        // A `do` block resolves to a `Ref` at its last form (its value); recurse through it.
+        Resolved::Ref { value } => {
+            conditional_branch_performs(db, value, ctx)
+                || block_wrapped_branch_performs(db, value, ctx)
+        }
+        _ => false,
+    }
+}
+
+/// Scan `node` for a `let` whose ANY binding init is a BLOCK-WRAPPED branch-performing conditional (the
+/// adv-69 shape the hoist cannot lift). Walks the whole subtree via `child_ids` — the miscompiling `let`
+/// may sit anywhere the fold would thread. Returns true iff such a `let`-init exists, so `reduce_handle`
+/// declines cleanly rather than folding the dropped-advance wrong value.
+fn body_has_block_wrapped_let_init_branch_perform(
+    db: &mut Db,
+    node: StructId,
+    ctx: &HandlerCtx,
+) -> bool {
+    // A NESTED handle's own lets belong to THAT handler's reduction — don't descend (mirrors the guard
+    // scanner); reducing this outer handle must not decline on an inner handle's still-unreduced shape.
+    if matches!(resolved_of(db, node), Resolved::Handle { .. }) {
+        return false;
+    }
+    // A `let` at THIS node: check each init for the block-wrapped branch-performing shape.
+    if let Some(parts) = db.ast.as_form(node, "let").map(<[_]>::to_vec)
+        && parts.len() == 2
+        && let Struct::List(pairs) = db.ast.get(parts[0]).clone()
+    {
+        for pair in pairs {
+            if let Struct::List(kv) = db.ast.get(pair).clone()
+                && kv.len() == 2
+                && block_wrapped_branch_performs(db, kv[1], ctx)
+            {
+                return true;
+            }
+        }
+    }
+    // Recurse structurally — the miscompiling `let` may be nested anywhere in the body.
+    match db.ast.get(node).clone() {
+        Struct::List(children) => children
+            .iter()
+            .any(|&c| body_has_block_wrapped_let_init_branch_perform(db, c, ctx)),
+        Struct::Atom(_) => false,
     }
 }
 

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -66148,6 +66148,41 @@ mod stage1 {
     }
 
     #[test]
+    fn a_block_wrapped_branch_perform_in_a_let_init_declines_not_miscompiles() {
+        // adv-69 (breaker + corpus-bugfix, HIGH cross-backend silent miscompile). A branch-performing
+        // conditional wrapped in a BLOCK inside a `let`-init — `(let ((v (let ((b true)) (if b (St.get) 99))))
+        // (+ (* 10 v) (St.get)))` — DROPPED the branch perform's state advance at the block boundary: the
+        // trailing `(St.get)` resumed the block-ENTRY state (3) instead of the branch's out-state (4), so
+        // seeded 3 it produced 33 (= 10*3 + 3) on wasm AND rust, where the correct value is 34. The hoist's
+        // Site 4 lifts a conditional that is DIRECTLY a `let`-init to tail position, but a conditional behind a
+        // `let`/`do` block wrapper is opaque to it. Until the full through-block distribution lands (alpha-safe
+        // commuting conversion), this MUST decline cleanly (→ Todo), NEVER fold the silent 33.
+        let src = "(do (effect St (op get (-> Unit Int64))) \
+                   (def (main) (handle St 3 ((get (u) s (resume s (+ s 1)))) \
+                     (let ((v (let ((b true)) (if b (St.get) 99)))) (+ (* 10 v) (St.get))))) \
+                   (export main))";
+        assert!(
+            compile_component(&crate::codec::encode(&parse(src))).is_err(),
+            "a block-wrapped branch perform in a let-init must decline, not miscompile to 33"
+        );
+        // CONTRAST — the direct-init shape (no block wrapper) the hoist DOES lift must still FOLD to 34
+        // (the safe-decline must not over-decline the working Site-4 path).
+        let direct = "(do (effect St (op get (-> Unit Int64))) \
+                   (def (main) (handle St 3 ((get (u) s (resume s (+ s 1)))) \
+                     (let ((v (if true (St.get) 99))) (+ (* 10 v) (St.get))))) \
+                   (export main))";
+        assert_eq!(
+            run_returns::<i64>(
+                &compile_component(&crate::codec::encode(&parse(direct)))
+                    .expect("a direct-init branch perform in a let-init folds"),
+                "main"
+            ),
+            34,
+            "the direct-init branch perform must still fold to 34 (no over-decline of the Site-4 hoist path)"
+        );
+    }
+
+    #[test]
     fn a_mutually_recursive_effectful_group_specializes_under_a_state_handler() {
         // E3 extended to MUTUAL recursion: `ev`/`od` call each other, and the effect (`Ctr.tick`) is reached
         // by `ev` only THROUGH its partner `od`. The fix: `body_reaches_discharged` now follows RECURSIVE

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -511,6 +511,7 @@ pass	a BARE pattern on a withheld constructor is rejected like the qualified spe
 pass	a BASE-N conversion round-trips one value through three runtime radices
 pass	a BIGINT handler state multiplies per perform and each resume reads the prior product
 pass	a BINARY SEARCH halves a lo/hi window over a sorted list read by List.at
+todo	a BLOCK-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, not a silent miscompile)
 pass	a BOOL as a Map key routes a runtime lookup to the right entry
 pass	a BOOL-field Tuple closure ARG flattens + rebuilds (box-bool imported)
 pass	a BOOL-field Tuple closure ARG, false discriminant
@@ -590,6 +591,7 @@ pass	a CURRIED closure capturing an inner-handled perform result closes over it 
 pass	a Char-payload sum value escapes across the boundary in its canonical form
 pass	a DEFERRED resume-thunk escaping to another function re-installs the handler at apply, over a re-performing do-continuation
 pass	a DERIVED-dimension (velocity) quantity used as a Map key hits by content
+pass	a DIRECT-init branch perform in a let-init threads its state advance (adv-69 control, still computes)
 pass	a DOUBLY-nested Tuple ARG (three levels deep) crosses the direct-call boundary
 pass	a DOUBLY-nested projected list, consumed then read, is unchanged (child retain through a proj chain)
 pass	a DRAINED set compares equal to the literal empty set — removal restores the canonical empty rep

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -512,6 +512,7 @@ pass	a BARE pattern on a withheld constructor is rejected like the qualified spe
 pass	a BASE-N conversion round-trips one value through three runtime radices
 pass	a BIGINT handler state multiplies per perform and each resume reads the prior product
 pass	a BINARY SEARCH halves a lo/hi window over a sorted list read by List.at
+todo	a BLOCK-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, not a silent miscompile)
 pass	a BOOL as a Map key routes a runtime lookup to the right entry
 pass	a BOOL-field Tuple closure ARG flattens + rebuilds (box-bool imported)
 pass	a BOOL-field Tuple closure ARG, false discriminant
@@ -595,6 +596,7 @@ pass	a CURRIED closure capturing an inner-handled perform result closes over it 
 pass	a Char-payload sum value escapes across the boundary in its canonical form
 pass	a DEFERRED resume-thunk escaping to another function re-installs the handler at apply, over a re-performing do-continuation
 pass	a DERIVED-dimension (velocity) quantity used as a Map key hits by content
+pass	a DIRECT-init branch perform in a let-init threads its state advance (adv-69 control, still computes)
 pass	a DOUBLY-nested Tuple ARG (three levels deep) crosses the direct-call boundary
 pass	a DOUBLY-nested projected list, consumed then read, is unchanged (child retain through a proj chain)
 pass	a DRAINED set compares equal to the literal empty set — removal restores the canonical empty rep

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -498,6 +498,7 @@ pass	a BARE pattern on a withheld constructor is rejected like the qualified spe
 pass	a BASE-N conversion round-trips one value through three runtime radices
 pass	a BIGINT handler state multiplies per perform and each resume reads the prior product
 pass	a BINARY SEARCH halves a lo/hi window over a sorted list read by List.at
+todo	a BLOCK-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, not a silent miscompile)
 pass	a BOOL as a Map key routes a runtime lookup to the right entry
 pass	a BOOL-field Tuple closure ARG flattens + rebuilds (box-bool imported)
 pass	a BOOL-field Tuple closure ARG, false discriminant
@@ -579,6 +580,7 @@ pass	a CURRIED closure capturing an inner-handled perform result closes over it 
 pass	a Char-payload sum value escapes across the boundary in its canonical form
 pass	a DEFERRED resume-thunk escaping to another function re-installs the handler at apply, over a re-performing do-continuation
 pass	a DERIVED-dimension (velocity) quantity used as a Map key hits by content
+pass	a DIRECT-init branch perform in a let-init threads its state advance (adv-69 control, still computes)
 pass	a DOUBLY-nested Tuple ARG (three levels deep) crosses the direct-call boundary
 pass	a DOUBLY-nested projected list, consumed then read, is unchanged (child retain through a proj chain)
 pass	a DRAINED set compares equal to the literal empty set — removal restores the canonical empty rep

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -3366,6 +3366,43 @@
   (call   main (: true Bool))
   (output (: 2 Int64)))
 
+(case "a BLOCK-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, not a silent miscompile)"
+  (doc    "adv-69 (HIGH, breaker+corpus-bugfix): a branch-performing conditional wrapped in a BLOCK inside a
+           `let`-init — `(let ((v (let ((b true)) (if b (St.get) 99)))) (+ (* 10 v) (St.get)))` — DROPPED the
+           branch perform's state advance at the block boundary: the trailing `(St.get)` resumed the block-
+           ENTRY state, not the branch's out-state. Seeded 3 it produced 33 (= 10*3 + 3) on wasm AND rust,
+           where the correct value is 34 (= 10*3 + 4). The hoist's Site 4 lifts a conditional that is DIRECTLY
+           a `let`-init to tail position (per-branch threading carries the advance), but a conditional behind
+           a `let`/`do` block wrapper is opaque to it. Until the full through-block distribution lands (an
+           alpha-safe commuting conversion, a separate increment), reduce_handle DECLINES this residual shape
+           → a clean Todo (honest 'not yet reducible'), NEVER the silent 33. This case grades TODO on all
+           backends (the safe floor); its 34 becomes a PASS when the full fold lands. Distinct from the FIXED
+           direct-init/connective-scrutinee cases above (those still compute — see the control below).")
+  (input  (do
+            (effect St (op get (-> Unit Int64)))
+            (def (main)
+              (handle St 3 ((get (u) s (resume s (+ s 1))))
+                (let ((v (let ((b true)) (if b (St.get) 99))))
+                  (+ (* 10 v) (St.get)))))
+            (export main)))
+  (call   main) (output (: 34 Int64)))
+
+(case "a DIRECT-init branch perform in a let-init threads its state advance (adv-69 control, still computes)"
+  (doc    "The working control for adv-69's safe-decline: the SAME body but with the branch-performing
+           conditional DIRECTLY the `let`-init (no block wrapper) — `(let ((v (if true (St.get) 99))) (+ (* 10
+           v) (St.get)))`. Hoist Site 4 lifts it to tail position, so each branch threads the perform's advance
+           through the continuation: seeded 3, v=3 (first get, state→4), trailing get reads 4 → 10*3 + 4 = 34.
+           Pins that the adv-69 safe-decline floor does NOT over-decline the direct-init path the hoist already
+           handles correctly. Computes on all backends.")
+  (input  (do
+            (effect St (op get (-> Unit Int64)))
+            (def (main)
+              (handle St 3 ((get (u) s (resume s (+ s 1))))
+                (let ((v (if true (St.get) 99)))
+                  (+ (* 10 v) (St.get)))))
+            (export main)))
+  (call   main) (output (: 34 Int64)))
+
 (case "two performs bound by nested lets thread the handler state in order"
   (doc    "Two performs on the strict spine, each BOUND by its own `let`, thread the handler state in
            evaluation order across the binds. `(let ((a (Ask.get))) (let ((b (Ask.get))) (+ a b)))` under a


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 0a93831c3, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.