### PR TITLE
corpus(07-type-system): pin cyclic-subst crash-guard — bare under-applied generic nested as a type-arg declines, not stack-overflows (2 faces) — #1903

### DIFF
--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -1033,6 +1033,7 @@ pass	a bare nullary constructor is the nullary sum value
 pass	a bare number on the left scales the quantity and keeps its dimension
 pass	a bare prelude-colliding variant name matches as the local variant
 pass	a bare type-name-colliding variant name constructs as the local variant
+pass	a bare under-applied generic nested as a type argument declines, does not stack-overflow the compiler
 pass	a bare user constructor is passed as a first-class function to a higher-order function
 pass	a bare user generic ctor in a VALUE annotation needs a type argument
 pass	a bare variant reusing a prelude DATA-constructor name constructs and matches as the local variant
@@ -3618,6 +3619,7 @@ pass	a utf8 bin segment binds a decoded string when the bytes are well-formed
 pass	a utf8 bin segment is a non-match on ill-formed bytes, forcing the catch-all
 pass	a utf8 segment sized by a CONSTANT LITERAL decodes a fixed-width string
 pass	a utf8-decoding bin match with no catch-all is non-exhaustive
+pass	a valid deeply-nested generic type argument still resolves and runs (the crash-guard control)
 pass	a value declaration in a do block is in scope for the following forms
 pass	a value definition may carry a leading doc, like a function definition
 pass	a value-eq guard on a LITERAL-probe arm drives a tail-recursive loop

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -1045,6 +1045,7 @@ pass	a bare nullary constructor is the nullary sum value
 pass	a bare number on the left scales the quantity and keeps its dimension
 pass	a bare prelude-colliding variant name matches as the local variant
 pass	a bare type-name-colliding variant name constructs as the local variant
+pass	a bare under-applied generic nested as a type argument declines, does not stack-overflow the compiler
 pass	a bare user constructor is passed as a first-class function to a higher-order function
 pass	a bare user generic ctor in a VALUE annotation needs a type argument
 pass	a bare variant reusing a prelude DATA-constructor name constructs and matches as the local variant
@@ -3629,6 +3630,7 @@ pass	a utf8 bin segment binds a decoded string when the bytes are well-formed
 pass	a utf8 bin segment is a non-match on ill-formed bytes, forcing the catch-all
 pass	a utf8 segment sized by a CONSTANT LITERAL decodes a fixed-width string
 pass	a utf8-decoding bin match with no catch-all is non-exhaustive
+pass	a valid deeply-nested generic type argument still resolves and runs (the crash-guard control)
 pass	a value declaration in a do block is in scope for the following forms
 pass	a value definition may carry a leading doc, like a function definition
 pass	a value-eq guard on a LITERAL-probe arm drives a tail-recursive loop

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -1020,6 +1020,7 @@ pass	a bare nullary constructor is the nullary sum value
 pass	a bare number on the left scales the quantity and keeps its dimension
 pass	a bare prelude-colliding variant name matches as the local variant
 pass	a bare type-name-colliding variant name constructs as the local variant
+pass	a bare under-applied generic nested as a type argument declines, does not stack-overflow the compiler
 pass	a bare user constructor is passed as a first-class function to a higher-order function
 pass	a bare user generic ctor in a VALUE annotation needs a type argument
 pass	a bare variant reusing a prelude DATA-constructor name constructs and matches as the local variant
@@ -3569,6 +3570,7 @@ pass	a utf8 bin segment binds a decoded string when the bytes are well-formed
 pass	a utf8 bin segment is a non-match on ill-formed bytes, forcing the catch-all
 pass	a utf8 segment sized by a CONSTANT LITERAL decodes a fixed-width string
 pass	a utf8-decoding bin match with no catch-all is non-exhaustive
+pass	a valid deeply-nested generic type argument still resolves and runs (the crash-guard control)
 pass	a value declaration in a do block is in scope for the following forms
 pass	a value definition may carry a leading doc, like a function definition
 pass	a value-eq guard on a LITERAL-probe arm drives a tail-recursive loop

--- a/spec/semantics/07-type-system.sexp
+++ b/spec/semantics/07-type-system.sexp
@@ -318,6 +318,43 @@
   (input  (do (type (Pair a b) (Both a b)) (def (f (: x (Pair Int64))) 0) (def (main) 0) (export main)))
   (error  CDZ0203))
 
+; A bare under-applied generic NESTED as another generic's type argument — `(: x (Option Box))` where
+; `(Box a)` needs an arg — is a harder sibling of the flat under-application above: it bound a CYCLIC
+; substitution `?v := (Option ?v)` that bypassed unify's occurs-check, and the universal type-read then
+; chased the cycle forever and CRASHED the compiler (stack overflow, not a catchable decline) when the
+; annotated value was consumed. It must reject CDZ0203 cleanly. The two cases below pin the clean reject +
+; a valid deeply-nested control (a resolved cycle would break the valid case too).
+
+(case "a bare under-applied generic nested as a type argument declines, does not stack-overflow the compiler"
+  (doc    "`(: x (Option Box))` annotates a CONSUMED parameter with the built-in `Option` whose type argument
+           is the BARE under-applied user generic `Box` (`(type (Box a) (Mk a))` needs one arg). This bound a
+           cyclic substitution `?v := (Option ?v)` bypassing the occurs-check; `Subst::apply` (every type
+           read funnels through it) then chased the cycle and STACK-OVERFLOWED rcdzc — a compiler crash, the
+           worst class (not even a catchable panic), triggered when `x` is matched + the fn called. The fix
+           caps the apply var-chain/descent so a cycle breaks to `Ty::Any` and the fault walk reports a clean
+           CDZ0203. Pins that a nested under-applied generic DECLINES, never crashes the compiler — the
+           nested (cycle-inducing) sibling of the flat `(: b Container)` bare-under-application above.")
+  (input  (do
+            (type (Box a) (Mk a))
+            (def (f (: x (Option Box))) (match x ((Some b) (match b ((Mk v) v))) ((None) 0)))
+            (def (main) (f (Some (Mk 5))))
+            (export main)))
+  (error  CDZ0203))
+
+(case "a valid deeply-nested generic type argument still resolves and runs (the crash-guard control)"
+  (doc    "The passing control for the cyclic-substitution guard above: the SAME shape but the nested generic
+           is FULLY applied — `(: x (Option (Box Int64)))` — so no cycle forms and the annotation resolves
+           normally. `(f (Some (Mk 9)))` peels the `Option` then the `Box` to recover 9. Pins that the
+           apply-depth cap (which breaks a genuine cycle to `Ty::Any`) does NOT over-decline a well-formed
+           deeply-nested generic — a real program never approaches the limit.")
+  (input  (do
+            (type (Box a) (Mk a))
+            (def (f (: x (Option (Box Int64)))) (match x ((Some b) (match b ((Mk v) v))) ((None) 0)))
+            (def (main) (f (Some (Mk 9))))
+            (export main)))
+  (call   main)
+  (output (: 9 Int64)))
+
 ; The arity rejects above (a non-generic type over-applied, and a generic type over-/under-supplied) are
 ; about the NUMBER of type arguments. The dual slip is a legitimately GENERIC type constructor — one that
 ; DOES take a type parameter — applied to a VALUE where a type belongs: `(Option 5)`, `(List 5)`. Here the


### PR DESCRIPTION
Candidate PR for corpus-bugfix's merge-request (ref a39a58e50, lane baseline). Auto-merge armed; pr-sync's schedule-pass reaps on green.