### PR TITLE
cdz-agent-host: AgentHost canonical shared NameStore — live cross-session visibility (§4c v0.3)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -273,19 +273,66 @@ impl HostedSession {
 #[derive(Default)]
 pub struct AgentHost {
     sessions: HashMap<SessionId, HostedSession>,
+    /// The §4c v0.3 canonical shared name store, if this host is share-backed (see
+    /// [`AgentHost::with_canonical_store`]). `None` = share-less host. Held BY VALUE: each session gets a
+    /// replay-copy at spawn and folds its appends back after each turn — no shared handle. (Type:
+    /// [`cdz_kernel::name_store::NameStore`].)
+    canonical: Option<cdz_kernel::name_store::NameStore>,
+}
+
+/// A by-value copy of a canonical [`NameStore`](cdz_kernel::name_store::NameStore) for a freshly-spawned session — replays the canonical
+/// store's full set-event stream into a fresh store (§4c v0.3 spawn step). `to_set_entries` +
+/// `replay_set_entries` are total over a valid store (single-writer-per-name → no `Unscoped` name in the
+/// stream), so this can't fail in practice; a defensive `expect` documents that invariant rather than
+/// threading a Result through spawn (which the caller can't meaningfully recover from).
+fn replay_of(canonical: &cdz_kernel::name_store::NameStore) -> cdz_kernel::name_store::NameStore {
+    let entries = canonical.to_set_entries();
+    cdz_kernel::name_store::NameStore::replay_set_entries(
+        entries.iter().map(|(n, h)| (n.as_str(), *h)),
+    )
+    .expect("a canonical store holds only scoped names, so its replay is total")
 }
 
 impl AgentHost {
     pub fn new() -> Self {
         AgentHost {
             sessions: HashMap::new(),
+            canonical: None,
+        }
+    }
+
+    /// Enable the §4c v0.3 SHARED name store — a single host-owned canonical [`NameStore`](cdz_kernel::name_store::NameStore) that gives LIVE
+    /// cross-session visibility of published pointers, replacing the per-hand-off export/replay bridge.
+    /// Opt-in: a host built with [`new`](Self::new) stays share-less and every session keeps whatever store
+    /// (or none) it was spawned with.
+    ///
+    /// Lifecycle (single-writer-per-name, conflict-free): the host holds ONE canonical store; on
+    /// [`spawn`](Self::spawn) a session gets a by-VALUE copy of it (a replay of `canonical.to_set_entries()`),
+    /// so it's born seeing everyone's published pointers; after each [`deliver`](Self::deliver) turn the host
+    /// folds that session's new writes back with `canonical.merge_appends_from(session.name_store())`. No
+    /// shared handle / interior mutability — by-value copies + a reconcile, composing with the per-session
+    /// [`HostedSession::with_name_store`] seam.
+    pub fn with_canonical_store(canonical: cdz_kernel::name_store::NameStore) -> Self {
+        AgentHost {
+            sessions: HashMap::new(),
+            canonical: Some(canonical),
         }
     }
 
     /// Register a new running session under `id`. Returns the id back for convenience. If `id` already
     /// exists it is REPLACED (the caller chose to restart it) — the old session is dropped; a caller that
     /// wants collision-detection checks [`AgentHost::contains`] first.
+    ///
+    /// When the host has a canonical shared store (see [`with_canonical_store`](Self::with_canonical_store)),
+    /// the session is born with a by-value replay of it — so a freshly-spawned agent already sees every
+    /// pointer other sessions have published (and the host folds this session's new writes back after each
+    /// turn). A session spawned with its OWN store keeps it (the canonical replay is only attached when the
+    /// host is canonical-backed).
     pub fn spawn(&mut self, id: SessionId, session: HostedSession) -> SessionId {
+        let session = match &self.canonical {
+            Some(canonical) => session.with_name_store(replay_of(canonical)),
+            None => session,
+        };
         self.sessions.insert(id.clone(), session);
         id
     }
@@ -305,10 +352,18 @@ impl AgentHost {
         body: EventBody,
         cause: Option<Hash>,
     ) -> Option<Result<(), KernelError>> {
-        match self.sessions.get_mut(id) {
-            Some(s) => Some(s.deliver(body, cause).await),
-            None => None,
+        let s = self.sessions.get_mut(id)?;
+        let outcome = s.deliver(body, cause).await;
+        // §4c v0.3 merge-back: after the turn, fold this session's new name-store writes into the canonical
+        // shared store so the next-spawned (or next-reconciled) session sees them. Idempotent — a turn that
+        // wrote nothing re-merges as a no-op (the session's log is already a prefix of what it was handed).
+        // Only when the host is canonical-backed AND the session actually has a store attached.
+        if let Some(canonical) = &mut self.canonical {
+            if let Some(session_store) = s.session().name_store() {
+                canonical.merge_appends_from(session_store);
+            }
         }
+        Some(outcome)
     }
 
     /// Read-only access to a hosted session (for a status query / inspection). `None` = unknown id.

--- a/implementation/seed/crates/cdz-agent-host/tests/shared_store_host_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/shared_store_host_e2e.rs
@@ -1,0 +1,191 @@
+//! End-to-end: the §4c v0.3 SHARED name store — an [`AgentHost`] with a canonical store gives LIVE
+//! cross-session visibility, so a LATER-spawned consumer resolves what an earlier publisher set WITHOUT
+//! the explicit export/replay bridge the two-agent e2e used.
+//!
+//! Lifecycle proven here (single-host-owned, conflict-free under single-writer-per-name):
+//!   - `AgentHost::with_canonical_store` holds ONE canonical `NameStore`.
+//!   - Spawn a PUBLISHER: it's born with a by-value replay of canonical; it `store/set`s a pointer; on
+//!     `AgentHost::deliver` returning, the host folds its new write back into canonical (merge_appends_from).
+//!   - Spawn a CONSUMER LATER: it's born with a replay of the NOW-updated canonical, so it already sees the
+//!     publisher's pointer — a `store/resolve` returns the published hash with no host-side bridge wiring.
+//!
+//! This is hermetic (no wasm artifact / network) — it exercises the store lifecycle only, so it runs in the
+//! default gate (unlike name_store_two_agent_e2e, which runs a real reducer component behind an env gate).
+
+use cdz_agent_host::{AgentHost, HostedSession, SessionId};
+use cdz_kernel::authz::Authorizer;
+use cdz_kernel::effect::{
+    effect_ct, Capability, EffectRequest, Payload, ResourcePredicate, Timeliness,
+};
+use cdz_kernel::event::{ContentType, EffectOutcome, Event, EventBody};
+use cdz_kernel::event_ast::{decode_name_set, encode_name_set};
+use cdz_kernel::executor::CompositeExecutor;
+use cdz_kernel::hash::Hash;
+use cdz_kernel::kv::Kv;
+use cdz_kernel::name_store::NameStore;
+use cdz_kernel::reducer::{FoldOutput, Reducer};
+
+const POINTER: &str = NameStore::COMPILER_LATEST;
+
+/// PUBLISHER: on inbound, `store/set`s the pointer → the hash it carries.
+struct Publisher {
+    hash: Hash,
+}
+#[async_trait::async_trait(?Send)]
+impl Reducer for Publisher {
+    async fn fold(&self, event: &Event, _kv: &mut Kv) -> FoldOutput {
+        if matches!(event.body, EventBody::Inbound { .. }) {
+            FoldOutput::with(vec![EffectRequest::new_with_family(
+                effect_ct::STORE_SET,
+                POINTER,
+                Some(Payload::Inline(encode_name_set(POINTER, &self.hash).into())),
+                Timeliness::Interactive,
+            )])
+        } else {
+            FoldOutput::none()
+        }
+    }
+}
+
+/// CONSUMER: on inbound, `store/resolve`s the pointer; records the resolved hash's hex in KV.
+struct Consumer;
+#[async_trait::async_trait(?Send)]
+impl Reducer for Consumer {
+    async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+        match &event.body {
+            EventBody::Inbound { .. } => FoldOutput::with(vec![EffectRequest::new_with_family(
+                effect_ct::STORE_RESOLVE,
+                POINTER,
+                None,
+                Timeliness::Interactive,
+            )]),
+            EventBody::EffectResult {
+                result: EffectOutcome::Ok(Some(Payload::Inline(bytes))),
+                ..
+            } => {
+                if let Ok((_n, h)) = decode_name_set(bytes) {
+                    kv.put(b"resolved".to_vec(), h.to_hex().into_bytes());
+                }
+                FoldOutput::none()
+            }
+            _ => FoldOutput::none(),
+        }
+    }
+}
+
+fn inbound_go() -> EventBody {
+    EventBody::Inbound {
+        content_type: ContentType {
+            family: "message".into(),
+            version: 1,
+        },
+        payload: Payload::Inline(b"go".to_vec().into()),
+    }
+}
+
+fn set_system() -> Box<Authorizer> {
+    Box::new(
+        Authorizer::new(vec![]).with_family_grants(vec![Capability::for_family(
+            effect_ct::STORE_SET,
+            ResourcePredicate::Prefix("system/".into()),
+        )]),
+    )
+}
+fn resolve_system() -> Box<Authorizer> {
+    Box::new(
+        Authorizer::new(vec![]).with_family_grants(vec![Capability::for_family(
+            effect_ct::STORE_RESOLVE,
+            ResourcePredicate::Prefix("system/".into()),
+        )]),
+    )
+}
+
+#[tokio::test]
+async fn a_later_spawned_session_sees_what_an_earlier_session_published_via_the_canonical_store() {
+    let published = Hash::of(b"compiler-wasm-v3");
+    // A host with a canonical shared store — every session it spawns gets a replay-copy + merges back.
+    let mut host = AgentHost::with_canonical_store(NameStore::new());
+
+    // PUBLISH: spawn a publisher (born with a replay of the empty canonical), deliver a "go" so it sets the
+    // pointer; on deliver return the host folds its write back into canonical.
+    let pub_id = host.spawn(
+        SessionId::new("publisher"),
+        HostedSession::genesis(
+            Hash::of(b"publisher-v1"),
+            Box::new(Publisher { hash: published }),
+            set_system(),
+            CompositeExecutor::new(),
+        ),
+    );
+    host.deliver(&pub_id, inbound_go(), None)
+        .await
+        .expect("publisher session exists")
+        .expect("the publish turn ran");
+
+    // CONSUME: spawn a DIFFERENT session LATER. It's born with a replay of the now-updated canonical, so it
+    // already carries the publisher's pointer — NO explicit export/replay bridge between the two sessions.
+    let con_id = host.spawn(
+        SessionId::new("consumer"),
+        HostedSession::genesis(
+            Hash::of(b"consumer-v1"),
+            Box::new(Consumer),
+            resolve_system(),
+            CompositeExecutor::new(),
+        ),
+    );
+    host.deliver(&con_id, inbound_go(), None)
+        .await
+        .expect("consumer session exists")
+        .expect("the resolve turn ran");
+
+    // The later consumer resolved the exact hash the earlier publisher set — live cross-session visibility
+    // through the host's canonical store, no bridge.
+    let resolved = host
+        .get(&con_id)
+        .expect("consumer registered")
+        .session()
+        .kv()
+        .get(b"resolved")
+        .expect("consumer recorded a resolved hash");
+    assert_eq!(
+        resolved,
+        published.to_hex().as_bytes(),
+        "a later-spawned consumer resolved COMPILER_LATEST to what the earlier publisher set — via the \
+         canonical shared store, no explicit bridge"
+    );
+}
+
+#[tokio::test]
+async fn a_share_less_host_leaves_sessions_store_less() {
+    // Regression: a plain AgentHost::new() (no canonical) does NOT attach a store, so a store/* effect
+    // folds an observable Err (never a panic) — the opt-in boundary. Spawn a resolver with a grant but no
+    // canonical host store; its resolve settles as an error, session stays healthy.
+    let mut host = AgentHost::new();
+    let id = host.spawn(
+        SessionId::new("no-store"),
+        HostedSession::genesis(
+            Hash::of(b"no-store-v1"),
+            Box::new(Consumer),
+            resolve_system(),
+            CompositeExecutor::new(),
+        ),
+    );
+    host.deliver(&id, inbound_go(), None)
+        .await
+        .expect("session exists")
+        .expect("the turn ran (the store/* effect settled as an Err, no panic)");
+    assert_eq!(
+        host.get(&id).unwrap().open_effects(),
+        0,
+        "the resolve settled (as an Err — no store attached on a share-less host)"
+    );
+    assert!(
+        host.get(&id)
+            .unwrap()
+            .session()
+            .kv()
+            .get(b"resolved")
+            .is_none(),
+        "nothing resolved — a share-less host attaches no store"
+    );
+}


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 7eccacabf, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.