### PR TITLE
fix(cdz-kernel): ComponentAuthorizer action = content-type FAMILY, not the EffectKind enum (§20b policy sees store/* correctly)

### DIFF
--- a/implementation/seed/crates/cdz-kernel/src/name_store.rs
+++ b/implementation/seed/crates/cdz-kernel/src/name_store.rs
@@ -115,6 +115,18 @@ impl NameStore {
     /// anti-hijack write-authority — a random agent can't swap the compiler out from under everyone).
     pub const COMPILER_LATEST: &'static str = "system/compiler/latest";
 
+    /// The well-known mutable name for the CURRENT authorization policy component (the §20b seam:
+    /// policy-referenced-by-mutable-name). An admin `store/set`s this to a Cedar-policy component's
+    /// blob-hash; the host `store/resolve`s it, blob-fetches the bytes, and rebuilds the session's
+    /// [`ComponentAuthorizer`](crate::wasm_host::ComponentAuthorizer) — so swapping the live policy is just
+    /// a `store/set` to this name (which is ALSO an I6 `capabilities-changed` trigger: a policy swap can move
+    /// a session's grant-states, so the host re-runs `push_capabilities_changed` after the swap). ONE source
+    /// of truth for the pointer name across the kernel, the host, and any admin — not a string duplicated
+    /// per crate. Its `system/` prefix means only a `store/set` grant scoped to `system/` may repoint it (the
+    /// §4c anti-hijack write-authority — a random agent can't swap the policy that governs everyone out from
+    /// under them; the thing that DECIDES authorization is itself write-gated by that authorization).
+    pub const POLICY_CURRENT: &'static str = "system/policy/current";
+
     pub fn new() -> Self {
         NameStore {
             names: HashMap::new(),
@@ -450,6 +462,30 @@ mod tests {
         assert_eq!(
             s.resolve(NameStore::COMPILER_LATEST).unwrap(),
             Hash::of(b"wasm")
+        );
+    }
+
+    #[test]
+    fn policy_current_const_is_a_system_scoped_well_formed_name() {
+        // The §20b policy-pointer const: pin its value (one source of truth) + that it's System-scoped, so a
+        // store/set that swaps the live authorization policy is write-gated by a system/ grant (only an admin
+        // authority may repoint the policy governing everyone — the same anti-hijack property as the compiler
+        // pointer, applied to the thing that DECIDES authorization).
+        assert_eq!(NameStore::POLICY_CURRENT, "system/policy/current");
+        assert_eq!(
+            NameStore::authority_prefix_of(NameStore::POLICY_CURRENT),
+            NameAuthority::System,
+            "the policy pointer must be System-scoped (write-gated)"
+        );
+        let mut s = NameStore::new();
+        s.set(
+            NameStore::POLICY_CURRENT,
+            SetEntry::unsigned(Hash::of(b"policy-wasm")),
+        )
+        .unwrap();
+        assert_eq!(
+            s.resolve(NameStore::POLICY_CURRENT).unwrap(),
+            Hash::of(b"policy-wasm")
         );
     }
 

--- a/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
+++ b/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
@@ -1058,7 +1058,7 @@ impl ComponentAuthorizer {
 #[async_trait::async_trait(?Send)]
 impl crate::authz::Authorize for ComponentAuthorizer {
     /// Decide via the policy component: map the `EffectRequest` to the PARC triple (principal, action =
-    /// effect kind, target = resolved target), instantiate the policy into a fresh store, call
+    /// content-type FAMILY, target = resolved target), instantiate the policy into a fresh store, call
     /// `authorize`, and map the verdict. FAIL-CLOSED: any instantiate/trap failure denies (§10 safe
     /// default), never panics (§17). A generous fuel budget bounds a runaway policy without tripping a
     /// legitimate decision. Native `Authorize` — the policy instantiate/call is a SYNC wasm engine
@@ -1079,7 +1079,13 @@ impl crate::authz::Authorize for ComponentAuthorizer {
         };
         let request = self::authz_bindings::cadenza::agent_kernel_authz::types::AuthRequest {
             principal: self.principal.clone(),
-            action: effect_kind_wire_name(&req.kind).to_string(),
+            // ACTION = the content-type FAMILY (seq-39 source of truth), NOT the EffectKind enum. The flat
+            // `Authorizer` gates on `req.content_type.family` (via `matches_family`), so the policy component
+            // MUST see the same string or the two authz paths disagree. Critically, a register-by-string
+            // family (a `store/*` set/resolve, or any extension family) carries the `Emit` PLACEHOLDER kind —
+            // keying `action` on the enum would present "emit" to the policy for a `store/set`, so a Cedar
+            // policy could never gate store writes (or any register-by-string family) correctly.
+            action: req.content_type.family.to_string(),
             target: req.target.to_string(),
         };
         match world
@@ -1098,18 +1104,6 @@ impl crate::authz::Authorize for ComponentAuthorizer {
     }
 }
 
-/// The wire name of an effect kind for the authorizer's `action` field (Cedar's ACTION verb). Lowercase,
-/// stable — a policy matches on these strings.
-fn effect_kind_wire_name(kind: &crate::effect::EffectKind) -> &'static str {
-    match kind {
-        crate::effect::EffectKind::Shell => "shell",
-        crate::effect::EffectKind::Http => "http",
-        crate::effect::EffectKind::Model => "model",
-        crate::effect::EffectKind::Now => "now",
-        crate::effect::EffectKind::Timer => "timer",
-        crate::effect::EffectKind::Emit => "emit",
-    }
-}
 
 /// Map a kernel [`EventBody`] to the guest `fold.apply` inputs `(content_type, payload, resumes)`.
 /// `resumes` (§19e ruling B) is the event's continuation token, already copied onto result/timer events

--- a/implementation/seed/crates/cdz-kernel/wit/authorizer.wit
+++ b/implementation/seed/crates/cdz-kernel/wit/authorizer.wit
@@ -15,9 +15,12 @@
 // ── The request: a PARC-style triple (principal, action, resource) ───────────────────────────────
 // Mirrors Cedar's authorization model (verified feasible by v-agent-harness-host: cedar-policy 4.x
 // compiles for wasm32 and expresses deny-by-default + forbid-overrides-permit). The kernel maps an
-// `EffectRequest` to this triple: `action` = the effect KIND (a coarse verb — "http"/"model"/"shell"/…),
-// `resource` = the resolved TARGET (the SEC-F1 security-relevant string the policy gates — a URL, model
-// id, command), `principal` = who is acting (the session/agent identity; v0 passes the session id).
+// `EffectRequest` to this triple: `action` = the effect FAMILY string (the seq-39 source of truth —
+// "http"/"model"/"shell"/… for the well-known kinds, AND register-by-string families like "store/set",
+// whose EffectKind is a placeholder; the flat `Authorizer` gates on this same family, so the policy sees
+// the same action string), `resource` = the resolved TARGET (the SEC-F1 security-relevant string the
+// policy gates — a URL, model id, command, or store NAME), `principal` = who is acting (the session/agent
+// identity; v0 passes the session id).
 // `payload` is NOT part of the authz decision (SEC-F1 gates the kind+target, not the body).
 //
 // ── Determinism ──────────────────────────────────────────────────────────────────────────────────
@@ -38,7 +41,10 @@ interface types {
   record auth-request {
     // Who is acting — the session/agent identity (v0: the session id string). Cedar's PRINCIPAL.
     principal: string,
-    // What verb — the effect kind ("http", "model", "shell", "now", "timer", "emit"). Cedar's ACTION.
+    // What verb — the effect FAMILY string ("http", "model", "shell", …, and register-by-string families
+    // like "store/set"/"store/resolve"). Cedar's ACTION. This is the content-type family (seq-39 source of
+    // truth), NOT the EffectKind enum: a store/* or extension family carries a placeholder kind, so keying
+    // on the enum would misreport it as "emit" — the family string is what the flat Authorizer gates on too.
     action: string,
     // The resolved target the policy gates (URL / model id / command / session id). Cedar's RESOURCE.
     // This is the SEC-F1 security-relevant string — a policy admits/denies on principal×action×target.


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 61ec536a9054309d34f02c5ed25ab19292752795, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.