### PR TITLE
rcdzc: tie APPLY_VAR_CHAIN_LIMIT to DESCENT_DEPTH_LIMIT so the cycle-guard fires within the stack-sizing policy

### DIFF
--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -24313,8 +24313,11 @@ mod match_engine {
                (def (f (: x (Option Box))) (match x ((Some b) (match b ((Mk v) v))) ((None) 0))) \
                (def (main) (f (Some (Mk 5)))) (export main))",
         )));
-        // MUST reject (the annotation is ill-formed) — and MUST return at all (no stack-overflow abort). The
-        // exact code/message is a downstream mismatch (CDZ0203); the crash-safety is the pinned property.
+        // MUST reject (the annotation is ill-formed) — and MUST RETURN at all (no stack-overflow abort): the
+        // crash-safety (a returning, cleanly-coded decline instead of a signal-6 crash) is the pinned
+        // property. The reject currently surfaces as CDZ0203 (a downstream type mismatch once the cycle is
+        // broken to `Ty::Any`); we assert the CODE so a future change can't quietly regress it to an UNCODED
+        // decline or a crash, but the message TEXT is not pinned (it may improve as diagnostics evolve).
         let e =
             r.expect_err("an under-applied generic nested in a type-arg must reject, not crash");
         assert_eq!(e.code.as_deref(), Some("CDZ0203"), "got: {}", e.message);

--- a/implementation/seed/crates/rcdzc/src/unify.rs
+++ b/implementation/seed/crates/rcdzc/src/unify.rs
@@ -55,7 +55,15 @@ use tracing::trace;
 /// any real type's depth: a genuine annotation/inferred type nests only a handful of levels, and even a
 /// pathologically deep generic is well under this — so a well-formed program never approaches it, while a
 /// cycle blows past it and is broken to `Ty::Any` (a clean decline downstream instead of a crash).
-const APPLY_VAR_CHAIN_LIMIT: u32 = 10_000;
+///
+/// TIED to [`crate::db::DESCENT_DEPTH_LIMIT`] — the compiler-wide native-recursion stack-sizing policy (the
+/// worker stack in `host.rs` is sized from it). `apply_depth` is itself NATIVELY recursive (each `chain + 1`
+/// is a real frame, and the structural arms recurse on top of that), so the guard MUST fire within that
+/// policy: a bound above it (the former `10_000`, ~10× the 1024 policy) risks a hard stack OVERFLOW on a
+/// small-stack target (wasm32) BEFORE the guard ever fires — the exact crash the guard exists to prevent.
+/// The policy bound is still far above any real type's var-chain depth, so a well-formed program is
+/// byte-identical; a cycle is now guaranteed to be broken to `Ty::Any` before the stack is exhausted.
+const APPLY_VAR_CHAIN_LIMIT: u32 = crate::db::DESCENT_DEPTH_LIMIT;
 
 /// A substitution: what each type, width, and SIGN variable has been solved to. Applied to a type,
 /// it replaces solved variables with their solutions (transitively).


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref 9fe1d84e9356a313ae72a6e91651a6c1a33f14c6, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.