### PR TITLE
rcdzc(effects): adv-69 g3 + c3 sub-faces — block-wrapped branch perform in a match-scrutinee / non-tail do-statement declines cleanly instead of a silent state-drop miscompile

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -2140,6 +2140,14 @@ pub fn reduce_handle(
     if body_has_nested_arm_resume_value_block_wrapped_branch_perform(db, body, &ctx) {
         return None;
     }
+    // adv-69 g3 + c3 sub-faces: the SAME block-boundary out-state drop at a MATCH-SCRUTINEE (g3) or a non-tail
+    // `do`-STATEMENT (c3) consuming a block-wrapped branch perform — positions Site 5 / Site 1 lift only when
+    // the conditional is DIRECT, not block-wrapped. Decline cleanly rather than folding the dropped-advance
+    // wrong value (probe-g3 ran 33/34, probe-c3 ran 33/73). Keyed on the WRAPPED shape only, so a direct
+    // conditional in either position (the passing d2/e1 twins) still folds.
+    if body_has_block_wrapped_scrutinee_or_statement_branch_perform(db, body, &ctx) {
+        return None;
+    }
     // E5 PURE ONE-HOLE-CONTINUATION fold (general one-shot, the pure-continuation case). When the handle
     // BODY reaches EXACTLY ONE discharged perform `P` through STRICT, UNCONDITIONAL, effect-free positions
     // (`pure_hole`), its delimited continuation is the PURE one-hole context `C = body[P := □]`. Resuming
@@ -3407,8 +3415,11 @@ fn conditional_branch_performs(db: &mut Db, node: StructId, ctx: &HandlerCtx) ->
 /// back to the block-ENTRY state and the branch perform's advance is DROPPED at the block boundary — a
 /// silent wrong-value (adv-69, HIGH: `+ (* 10 v) (E.op)` reads the stale pre-branch state). Detecting this
 /// residual shape (AFTER the hoist ran, so a liftable direct-init case is already in tail position) lets
-/// `reduce_handle` DECLINE cleanly (honest Todo) rather than fold a wrong value. Peels only PURE-binding
-/// block wrappers to the tail; a wrapper with a PERFORMING binding is a different (threaded) shape, not this.
+/// `reduce_handle` DECLINE cleanly (honest Todo) rather than fold a wrong value. Peels `let`/`do` block
+/// wrappers to reach the tail conditional. (The `let` arm peels its BODY regardless of whether the binding
+/// PERFORMS — the `..` discards the init: a performing binding is threaded by the ordinary `let` arm, so it
+/// does not itself trigger this decline, but this scanner does not need to distinguish it — declining on the
+/// tail conditional is sound either way; a performing binding just means the peel keeps going to the body.)
 fn block_wrapped_branch_performs(db: &mut Db, node: StructId, ctx: &HandlerCtx) -> bool {
     match resolved_of(db, node) {
         // A `let` block: its value is the body; recurse through it. (A performing binding is threaded by
@@ -3494,6 +3505,62 @@ fn body_has_block_wrapped_let_init_branch_perform(
         Struct::List(children) => children
             .iter()
             .any(|&c| body_has_block_wrapped_let_init_branch_perform(db, c, ctx)),
+        Struct::Atom(_) => false,
+    }
+}
+
+/// adv-69 **g3 + c3 sub-faces** (breaker block-outstate battery, post-floor 39-probe run). The SAME block-
+/// boundary out-state drop as the let-init floor, but at two more consuming positions the hoist does NOT
+/// reach:
+///   * **g3 — MATCH-SCRUTINEE**: `(match (let ((b true)) (if b (St.get) 99)) (v (+ (* 10 v) (St.get))))` — a
+///     block-wrapped branch perform in the scrutinee. Site 5 lifts a scrutinee that is DIRECTLY a branch-
+///     performing conditional, but a block wrapper is opaque to it, so the scrutinee's out-state reverts to
+///     entry (ran 33, correct 34).
+///   * **c3 — DO-STATEMENT (non-last, discarded)**: `(do (let ((x true)) (if x (St.put 7) unit)) (+ (* 10
+///     (St.get)) x))` — a block-wrapped branch perform as a non-tail `do` item. Site 1 hoists a non-last item
+///     that is DIRECTLY a branch-performing conditional, but a block wrapper defeats its `conditional_branch_
+///     performs` match, so the statement's `put` advance is dropped (ran 33, correct 73; the minimal twins
+///     d2/e1 — a BARE `if` in the statement, or a def-bound cond — hoist fine and PASS).
+///
+/// Both key on `block_wrapped_branch_performs` (the WRAPPED shape ONLY): a DIRECT `if`/`match` in either
+/// position is lifted by Site 1/5 and still folds — so this never over-declines the working hoist paths.
+/// Until the through-block fold lands (the deferred commuting conversion), DECLINE these residual shapes so
+/// they grade a clean Todo, never the silent wrong value. Related:
+/// [[adv69-block-wrapped-branch-perform-drops-state-advance-at-block-boundary]].
+fn body_has_block_wrapped_scrutinee_or_statement_branch_perform(
+    db: &mut Db,
+    node: StructId,
+    ctx: &HandlerCtx,
+) -> bool {
+    // A nested handle's own body belongs to THAT handler's reduction — don't descend (mirrors the sibling
+    // scanners); a3's `Resume{value}` scanner covers the nested-arm position separately.
+    if matches!(resolved_of(db, node), Resolved::Handle { .. }) {
+        return false;
+    }
+    // g3: a MATCH whose SCRUTINEE is a block-wrapped branch-performing conditional.
+    if let Resolved::Match { scrutinee, .. } = resolved_of(db, node)
+        && block_wrapped_branch_performs(db, scrutinee, ctx)
+    {
+        return true;
+    }
+    // c3: a `do` with a NON-LAST item that is a block-wrapped branch-performing conditional (a discarded
+    // statement whose branch performs — its advance is dropped at the block boundary). The LAST item is the
+    // do's value (tail) — a block-wrapped conditional there is the let-init/body shape the other scanners /
+    // hoist handle; only the non-tail statement position is this face.
+    if let Some(items) = db.ast.as_form(node, "do").map(<[_]>::to_vec)
+        && items.len() >= 2
+    {
+        for &it in &items[..items.len() - 1] {
+            if block_wrapped_branch_performs(db, it, ctx) {
+                return true;
+            }
+        }
+    }
+    // Recurse structurally — the miscompiling position may be nested anywhere in the body.
+    match db.ast.get(node).clone() {
+        Struct::List(children) => children
+            .iter()
+            .any(|&c| body_has_block_wrapped_scrutinee_or_statement_branch_perform(db, c, ctx)),
         Struct::Atom(_) => false,
     }
 }

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -66206,6 +66206,33 @@ mod stage1 {
     }
 
     #[test]
+    fn a_block_wrapped_branch_perform_in_a_scrutinee_or_statement_declines_not_miscompiles() {
+        // adv-69 g3 + c3 sub-faces (breaker probe-g3/c3, block-outstate battery). Same block-boundary
+        // out-state drop as the let-init floor, at two more positions the hoist doesn't reach when the
+        // conditional is BLOCK-wrapped.
+        // g3 — MATCH-SCRUTINEE: `(match (let ((b true)) (if b (St.get) 99)) (v (+ (* 10 v) (St.get))))` — Site 5
+        // lifts a DIRECT branch-performing scrutinee, but a block wrapper reverts its out-state → ran 33, want 34.
+        let g3 = "(do (effect St (op get (-> Unit Int64))) \
+                   (def (main) (handle St 3 ((get (u) s (resume s (+ s 1)))) \
+                     (match (let ((b true)) (if b (St.get) 99)) (v (+ (* 10 v) (St.get)))))) \
+                   (export main))";
+        assert!(
+            compile_component(&crate::codec::encode(&parse(g3))).is_err(),
+            "a block-wrapped branch perform in a match-scrutinee must decline, not miscompile to 33"
+        );
+        // c3 — non-tail DO-STATEMENT: `(do (let ((x true)) (if x (St.put 7) unit)) (+ (* 10 (St.get)) x))` — Site
+        // 1 hoists a DIRECT non-last branch-performing item, but a block wrapper drops the `put` advance → 33/73.
+        let c3 = "(do (effect St (op get (-> Unit Int64)) (op put (-> Int64 Unit))) \
+                   (def (main (: x Int64)) (handle St x ((get (u) s (resume s s)) (put (v) _s (resume unit v))) \
+                     (do (let ((x true)) (if x (St.put 7) unit)) (+ (* 10 (St.get)) x)))) \
+                   (export main))";
+        assert!(
+            compile_component(&crate::codec::encode(&parse(c3))).is_err(),
+            "a block-wrapped branch perform in a non-tail do-statement must decline, not miscompile to 33"
+        );
+    }
+
+    #[test]
     fn a_mutually_recursive_effectful_group_specializes_under_a_state_handler() {
         // E3 extended to MUTUAL recursion: `ev`/`od` call each other, and the effect (`Ctr.tick`) is reached
         // by `ev` only THROUGH its partner `od`. The fix: `body_reaches_discharged` now follows RECURSIVE

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -5691,8 +5691,10 @@ pass	α-equivalence handles nesting and distinguishes a bound variable from a sa
 todo	SUM ARG + LIST RESULT declines cleanly (Option arg, List result)
 todo	Set.of over runtime lists at two different element types declines pending the recursive-generic tie
 todo	Set.to-list orders float-carrying sums discriminant-first then by float payload
+todo	a BLOCK-wrapped branch perform in a MATCH-SCRUTINEE declines cleanly (adv-69 g3 sub-face)
 todo	a BLOCK-wrapped branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3 sub-face)
 todo	a BLOCK-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, not a silent miscompile)
+todo	a BLOCK-wrapped branch perform in a non-tail DO-STATEMENT declines cleanly (adv-69 c3 sub-face)
 todo	a BigInt entry argument is marshalled through the value's own constructor
 todo	a BigInt entry parameter added to a beyond-i64 annotated literal
 todo	a BigInt entry parameter is COMPUTED on, not just compared

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5704,8 +5704,10 @@ pass	α-equivalence (aconv) recognizes (λx.x) and (λy.y) as the same term up t
 pass	α-equivalence handles nesting and distinguishes a bound variable from a same-numbered free variable
 todo	Set.of over runtime lists at two different element types declines pending the recursive-generic tie
 todo	Type is a first-class value
+todo	a BLOCK-wrapped branch perform in a MATCH-SCRUTINEE declines cleanly (adv-69 g3 sub-face)
 todo	a BLOCK-wrapped branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3 sub-face)
 todo	a BLOCK-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, not a silent miscompile)
+todo	a BLOCK-wrapped branch perform in a non-tail DO-STATEMENT declines cleanly (adv-69 c3 sub-face)
 todo	a DEPTH-2 block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, nested wrappers)
 todo	a HEAP-accumulator block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor)
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5607,8 +5607,10 @@ todo	a @param value SEEDS an in-program handler's state
 todo	a @param value crosses into a closure capture and applies
 todo	a @param value drives a CHAMP map lookup as the KEY
 todo	a @param value sizes a guest-built HEAP structure
+todo	a BLOCK-wrapped branch perform in a MATCH-SCRUTINEE declines cleanly (adv-69 g3 sub-face)
 todo	a BLOCK-wrapped branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3 sub-face)
 todo	a BLOCK-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, not a silent miscompile)
+todo	a BLOCK-wrapped branch perform in a non-tail DO-STATEMENT declines cleanly (adv-69 c3 sub-face)
 todo	a Bool host arg BESIDE a scalar and a String composes in one mixed-arity op
 todo	a Bytes value SENT to the host is still readable after the call (the arg marshal borrows)
 todo	a DEPTH-2 block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, nested wrappers)

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -3468,6 +3468,47 @@
             (export main)))
   (call   main) (output (: 34 Int64)))
 
+(case "a BLOCK-wrapped branch perform in a MATCH-SCRUTINEE declines cleanly (adv-69 g3 sub-face)"
+  (doc    "adv-69 g3 (breaker probe-g3, block-outstate battery): the SAME block-boundary out-state drop, at a
+           MATCH-SCRUTINEE consuming position. `(match (let ((b true)) (if b (St.get) 99)) (v (+ (* 10 v)
+           (St.get))))` — the scrutinee is a block-wrapped branch-performing conditional. Site 5 lifts a
+           scrutinee that is DIRECTLY a branch-performing conditional (per-branch threading carries its
+           advance), but a block wrapper is opaque to it, so the scrutinee's out-state reverts to entry: seeded
+           3 it ran 33, correct is 34 (v=3, state→4, trailing `(St.get)` reads 4). Keyed on the WRAPPED shape
+           only (a DIRECT `if`/`match` scrutinee still folds — no over-decline of the Site-5 path). Declines
+           cleanly → a clean Todo, never the silent 33; flips to 34 PASS on the through-block fold.")
+  (input  (do
+            (effect St (op get (-> Unit Int64)))
+            (def (main)
+              (handle St 3 ((get (u) s (resume s (+ s 1))))
+                (match (let ((b true)) (if b (St.get) 99))
+                  (v (+ (* 10 v) (St.get))))))
+            (export main)))
+  (call   main) (output (: 34 Int64)))
+
+(case "a BLOCK-wrapped branch perform in a non-tail DO-STATEMENT declines cleanly (adv-69 c3 sub-face)"
+  (doc    "adv-69 c3 (breaker probe-c3, block-outstate battery): the SAME block-boundary out-state drop, at a
+           non-tail `do`-STATEMENT position. `(do (let ((x true)) (if x (St.put 7) unit)) (+ (* 10 (St.get))
+           x))` — a block-wrapped branch perform as a DISCARDED (non-last) `do` item. Site 1 hoists a non-last
+           item that is DIRECTLY a branch-performing conditional (distributing the continuation into each
+           branch), but a block wrapper defeats its match, so the statement's `St.put 7` advance is dropped:
+           seeded 3 the trailing `(St.get)` reads the stale pre-statement state → ran 33, correct is 73 (put
+           sets state 7, `(St.get)` resumes 7 → 10*7 + shadowed-outer x=3 = 73). The minimal twins d2/e1 — a
+           BARE `if` in the statement, or a def-bound cond — hoist fine and PASS, so this keys on the block
+           wrapper. Declines cleanly → a clean Todo, never the silent 33; flips to 73 PASS on the through-block
+           fold.")
+  (input  (do
+            (effect St (op get (-> Unit Int64)) (op put (-> Int64 Unit)))
+            (def (main (: x Int64))
+              (handle St x
+                ((get (u) s (resume s s))
+                 (put (v) _s (resume unit v)))
+                (do
+                  (let ((x true)) (if x (St.put 7) unit))
+                  (+ (* 10 (St.get)) x))))
+            (export main)))
+  (call   main (: 3 Int64)) (output (: 73 Int64)))
+
 (case "two performs bound by nested lets thread the handler state in order"
   (doc    "Two performs on the strict spine, each BOUND by its own `let`, thread the handler state in
            evaluation order across the binds. `(let ((a (Ask.get))) (let ((b (Ask.get))) (+ a b)))` under a


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 05df69f16, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.