### PR TITLE
cdz-agent-host: don't publish an errored turn's writes to the shared store + doc/test nits (fix-forward #1915/#1921)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -160,11 +160,11 @@ impl HostedSession {
     /// blob-gets the component `bytes`, and calls this to rebuild the authorizer + notify the agent.
     ///
     /// It lifts `bytes` into a [`ComponentAuthorizer`](cdz_kernel::wasm_host::ComponentAuthorizer) (the
-    /// lifted Cedar policy), [`set_authorizer`](Self::set_authorizer)s it, and
-    /// [`push_capabilities_changed`](Self::push_capabilities_changed)es — so a policy swap that widened or
+    /// lifted Cedar policy), installs it via [`set_authorizer`](Self::set_authorizer), then calls
+    /// [`push_capabilities_changed`](Self::push_capabilities_changed) — so a policy swap that widened or
     /// tightened a grant folds a `capabilities-changed` to the agent (a no-op if grant-states didn't move).
-    /// Returns the pushed [`ControlEffect`](cdz_kernel::effect::ControlEffect)s (usually none), or `Err` if
-    /// the bytes aren't a valid policy component (the swap is then NOT applied — the old policy stays).
+    /// Returns the pushed [`ControlEffect`](cdz_kernel::effect::ControlEffect) list (usually empty), or `Err`
+    /// if the bytes aren't a valid policy component (the swap is then NOT applied — the old policy stays).
     ///
     /// `principal` is the agent's authz principal (e.g. `"agent://<id>"`), the same value the session's
     /// original authorizer was built with. The host owns resolving POLICY_CURRENT + the blob fetch (it holds
@@ -353,8 +353,10 @@ impl AgentHost {
     /// When the host has a canonical shared store (see [`with_canonical_store`](Self::with_canonical_store)),
     /// the session is born with a by-value replay of it — so a freshly-spawned agent already sees every
     /// pointer other sessions have published (and the host folds this session's new writes back after each
-    /// turn). A session spawned with its OWN store keeps it (the canonical replay is only attached when the
-    /// host is canonical-backed).
+    /// turn). This REPLACES any store the session was built with (via
+    /// [`HostedSession::with_name_store`]): a canonical-backed host is the single source of the shared name
+    /// space, so it attaches the canonical replay unconditionally. On a share-less host (plain
+    /// [`new`](Self::new)) the session keeps whatever store (or none) it was spawned with.
     pub fn spawn(&mut self, id: SessionId, session: HostedSession) -> SessionId {
         let session = match &self.canonical {
             Some(canonical) => session.with_name_store(replay_of(canonical)),
@@ -381,13 +383,18 @@ impl AgentHost {
     ) -> Option<Result<(), KernelError>> {
         let s = self.sessions.get_mut(id)?;
         let outcome = s.deliver(body, cause).await;
-        // §4c v0.3 merge-back: after the turn, fold this session's new name-store writes into the canonical
-        // shared store so the next-spawned (or next-reconciled) session sees them. Idempotent — a turn that
-        // wrote nothing re-merges as a no-op (the session's log is already a prefix of what it was handed).
-        // Only when the host is canonical-backed AND the session actually has a store attached.
-        if let Some(canonical) = &mut self.canonical {
-            if let Some(session_store) = s.session().name_store() {
-                canonical.merge_appends_from(session_store);
+        // §4c v0.3 merge-back: after a SUCCESSFUL turn, fold this session's new name-store writes into the
+        // canonical shared store so the next-spawned (or next-reconciled) session sees them. Idempotent — a
+        // turn that wrote nothing re-merges as a no-op (the session's log is already a prefix of what it was
+        // handed). Gated on `outcome.is_ok()`: a turn that ERRED (KernelError — session/log corruption or an
+        // invalid transition) may have left partial/invalid store state, and folding that into the SHARED
+        // store would leak it to every future session — so an errored turn's writes are NOT published.
+        // Only when the host is canonical-backed AND the session has a store attached.
+        if outcome.is_ok() {
+            if let Some(canonical) = &mut self.canonical {
+                if let Some(session_store) = s.session().name_store() {
+                    canonical.merge_appends_from(session_store);
+                }
             }
         }
         Some(outcome)

--- a/implementation/seed/crates/cdz-agent-host/tests/policy_swap_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/policy_swap_e2e.rs
@@ -52,7 +52,7 @@ async fn a_policy_swap_via_reload_flips_the_authorizer_and_pushes_a_capabilities
     };
 
     // Start deny-all: the session refuses everything, and its born-knowing manifest reflects that. The
-    // executor serves Now+Model so the mechanism axis is present; only the POLICY denies.
+    // executor serves Now (the mechanism axis is present for that family); only the POLICY denies.
     let mut hosted = HostedSession::genesis(
         Hash::of(b"policy-swap-v1"),
         Box::new(CapabilityAwareAgent),

--- a/implementation/seed/crates/cdz-agent-host/tests/shared_store_host_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/shared_store_host_e2e.rs
@@ -188,4 +188,25 @@ async fn a_share_less_host_leaves_sessions_store_less() {
             .is_none(),
         "nothing resolved — a share-less host attaches no store"
     );
+
+    // No-cross-session-leak: even after a first session ran on this share-less host, a SECOND session
+    // spawned on it is still store-less (the host holds no canonical store to hand down) — the opt-in
+    // boundary means share-less sessions never see each other's (nonexistent) name space.
+    let id2 = host.spawn(
+        SessionId::new("no-store-2"),
+        HostedSession::genesis(
+            Hash::of(b"no-store-2-v1"),
+            Box::new(Consumer),
+            resolve_system(),
+            CompositeExecutor::new(),
+        ),
+    );
+    host.deliver(&id2, inbound_go(), None)
+        .await
+        .expect("session 2 exists")
+        .expect("session 2's turn ran (store/* settled as an Err, no panic)");
+    assert!(
+        host.get(&id2).unwrap().session().kv().get(b"resolved").is_none(),
+        "a second share-less session also resolves nothing — no store handed down, no cross-session leak"
+    );
 }


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 99d5d48c5, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.