### PR TITLE
rcdzc(effects): adv-69 a3 guard — doc-accuracy fix + a3-direct decline-witness (the resume-value drop is not block-wrapper-specific)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -3444,20 +3444,27 @@ fn block_wrapped_branch_performs(db: &mut Db, node: StructId, ctx: &HandlerCtx) 
 /// boundary INSIDE the inner arm's resume-VALUE drops the outer `St.get`'s state advance (runs 33, correct
 /// 34) — the same class of block-boundary out-state drop as the let-init face, but at a DIFFERENT position
 /// (`Resume{value}`) that the let-init scanner deliberately does not reach (it stops at a nested `Handle`).
-/// Detect a `Resume` whose VALUE is a block-wrapped branch-performing conditional performing THIS handler's
-/// op, so `reduce_handle` declines cleanly (honest Todo) instead of folding the dropped-advance wrong value.
-/// PRECISELY POSITIONAL — keyed on the `Resume{value}` slot, NOT a position-agnostic block-wrapped-perform
-/// scan (that over-declines 5 working cases where the block-wrapped perform sits in a threaded position the
-/// fold DOES serve). The through-block fold that flips a3 → PASS is the same deferred commuting conversion
-/// as the let-init face. Related: [[adv69-block-wrapped-let-init-branch-perform-state-drop]].
+/// Detect a `Resume` whose VALUE is a branch-performing conditional performing THIS handler's op — whether
+/// DIRECT (`(resume (if b (St.get) 99) t)`) or BLOCK-WRAPPED (`(resume (let ((b true)) (if b (St.get) 99))
+/// t)`) — so `reduce_handle` declines cleanly (honest Todo) instead of folding the dropped-advance wrong
+/// value. BOTH forms drop the advance at this position (verified: dropping the direct-conditional disjunct
+/// makes `(resume (if true (St.get) 99) t)` miscompile to 33, not fold to 34) — unlike the let-init face,
+/// where a DIRECT init is lifted by Site 4 and only the block-wrapped residue remains; a `resume`-value is
+/// never hoisted (it lives in a nested handle's arm the outer reduction doesn't rewrite), so a direct
+/// conditional there is a genuine miscompile too. PRECISELY POSITIONAL — keyed on the `Resume{value}` slot,
+/// NOT a position-agnostic branch-perform scan (that over-declines 5 working cases where the perform sits in
+/// a threaded position the fold DOES serve). The through-block fold that flips a3 → PASS is the same deferred
+/// commuting conversion as the let-init face. Related:
+/// [[adv69-block-wrapped-branch-perform-drops-state-advance-at-block-boundary]].
 fn body_has_nested_arm_resume_value_block_wrapped_branch_perform(
     db: &mut Db,
     node: StructId,
     ctx: &HandlerCtx,
 ) -> bool {
-    // A `Resume` whose VALUE block-wraps a branch perform of THIS handler's op is the a3 drop. (A `Resume`
-    // reached while scanning the outer handle's BODY belongs to a nested handle's arm — the outer body
-    // itself has no bare resume; the outer handler's own arms are not in `body`.)
+    // A `Resume` whose VALUE is a branch perform of THIS handler's op — direct (`conditional_branch_performs`)
+    // OR block-wrapped (`block_wrapped_branch_performs`) — is the a3 drop; both forms revert the out-state at
+    // this position. (A `Resume` reached while scanning the outer handle's BODY belongs to a nested handle's
+    // arm — the outer body itself has no bare resume; the outer handler's own arms are not in `body`.)
     if let Resolved::Resume { value, .. } = resolved_of(db, node)
         && (conditional_branch_performs(db, value, ctx)
             || block_wrapped_branch_performs(db, value, ctx))

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -66203,6 +66203,20 @@ mod stage1 {
             compile_component(&crate::codec::encode(&parse(src))).is_err(),
             "a block-wrapped branch perform in a nested arm resume-value must decline, not miscompile to 33"
         );
+        // a3-direct: the DIRECT-conditional twin (no block wrapper) at the SAME resume-value position ALSO
+        // drops the advance — a `resume`-value is never hoisted (it lives in the inner handle's arm), so the
+        // guard's direct-conditional disjunct is load-bearing (dropping it makes this miscompile to 33, not
+        // fold to 34). Pins that the resume-value drop is NOT block-wrapper-specific (contrast the let-init
+        // face, where a direct init IS lifted by Site 4 and folds). liaison/Copilot #1917 doc-accuracy point.
+        let direct = "(do (effect St (op get (-> Unit Int64))) (effect Up (op ask (-> Unit Int64))) \
+                   (def (main) (handle St 3 ((get (u) s (resume s (+ s 1)))) \
+                     (handle Up 0 ((ask (u) t (resume (if true (St.get) 99) t))) \
+                       (+ (* 10 (Up.ask)) (St.get))))) \
+                   (export main))";
+        assert!(
+            compile_component(&crate::codec::encode(&parse(direct))).is_err(),
+            "a direct branch perform in a nested arm resume-value must decline too, not miscompile to 33"
+        );
     }
 
     #[test]

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -5702,6 +5702,7 @@ todo	a BigInt entry parameter added to a beyond-i64 annotated literal
 todo	a BigInt entry parameter is COMPUTED on, not just compared
 todo	a Bytes entry argument is marshalled as a Vec<u8>
 todo	a DEPTH-2 block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, nested wrappers)
+todo	a DIRECT branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3-direct sub-face)
 todo	a HEAP-accumulator block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor)
 todo	a List entry argument is marshalled as a vec!
 todo	a MULTIBYTE and an EMPTY runtime String entry arg measure their UTF-8 byte lengths

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5711,6 +5711,7 @@ todo	a BLOCK-wrapped branch perform in a NESTED handler-arm resume-value decline
 todo	a BLOCK-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, not a silent miscompile)
 todo	a BLOCK-wrapped branch perform in a non-tail DO-STATEMENT declines cleanly (adv-69 c3 sub-face)
 todo	a DEPTH-2 block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, nested wrappers)
+todo	a DIRECT branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3-direct sub-face)
 todo	a HEAP-accumulator block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor)
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject
 todo	a constant-try helper that fails feeds the None arm's fallback into resume

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5616,6 +5616,7 @@ todo	a BLOCK-wrapped branch perform in a non-tail DO-STATEMENT declines cleanly 
 todo	a Bool host arg BESIDE a scalar and a String composes in one mixed-arity op
 todo	a Bytes value SENT to the host is still readable after the call (the arg marshal borrows)
 todo	a DEPTH-2 block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, nested wrappers)
+todo	a DIRECT branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3-direct sub-face)
 todo	a Float64 closure captures a Float64 build-time host effect result
 todo	a Float64-inner Qty host result crosses as its float magnitude
 todo	a HEAP-accumulator block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor)

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -3468,6 +3468,28 @@
             (export main)))
   (call   main) (output (: 34 Int64)))
 
+(case "a DIRECT branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3-direct sub-face)"
+  (doc    "The DIRECT-conditional twin of the a3 case: `(resume (if true (St.get) 99) t)` — a branch-performing
+           conditional DIRECTLY (no block wrapper) in a nested handler's arm resume-value, performing the OUTER
+           op. Unlike the let-init face — where a DIRECT init is lifted by Site 4 and folds — a `resume`-value
+           is never hoisted (it lives inside the inner `Up` handle's arm, which the outer `St` reduction does
+           not rewrite), so the direct conditional here ALSO drops the outer `St.get`'s advance: seeded 3 it ran
+           33, correct is 34. The a3 guard's `Resume{value}` scanner declines this via its direct-conditional
+           disjunct (verified: dropping that disjunct makes this miscompile to 33, not fold to 34 — so the
+           disjunct is load-bearing, not an over-decline). Pins that the resume-value drop is NOT block-wrapper-
+           specific (contrast the let-init face). Grades TODO on all backends; flips to 34 PASS on the
+           through-block fold.")
+  (input  (do
+            (effect St (op get (-> Unit Int64)))
+            (effect Up (op ask (-> Unit Int64)))
+            (def (main)
+              (handle St 3 ((get (u) s (resume s (+ s 1))))
+                (handle Up 0
+                  ((ask (u) t (resume (if true (St.get) 99) t)))
+                  (+ (* 10 (Up.ask)) (St.get)))))
+            (export main)))
+  (call   main) (output (: 34 Int64)))
+
 (case "a BLOCK-wrapped branch perform in a MATCH-SCRUTINEE declines cleanly (adv-69 g3 sub-face)"
   (doc    "adv-69 g3 (breaker probe-g3, block-outstate battery): the SAME block-boundary out-state drop, at a
            MATCH-SCRUTINEE consuming position. `(match (let ((b true)) (if b (St.get) 99)) (v (+ (* 10 v)


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 8f534699b, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.