### PR TITLE
rcdzc(effects): adv-69 a4 sub-face — a block-wrapped outer-effect perform in a let-init inside a NESTED handle body declines cleanly instead of a silent state-drop miscompile

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -3488,10 +3488,17 @@ fn body_has_block_wrapped_let_init_branch_perform(
     node: StructId,
     ctx: &HandlerCtx,
 ) -> bool {
-    // A NESTED handle's own lets belong to THAT handler's reduction — don't descend (mirrors the guard
-    // scanner); reducing this outer handle must not decline on an inner handle's still-unreduced shape.
-    if matches!(resolved_of(db, node), Resolved::Handle { .. }) {
-        return false;
+    // A NESTED handle: its ARMS belong to THAT inner handler's reduction (a block-wrapped perform in an arm
+    // resume-value is the a3 guard's territory), so don't scan them here. But its BODY still runs UNDER this
+    // (outer) handler — a block-wrapped branch perform of THIS handler's OUTER op in a `let`-init in the inner
+    // body drops the outer advance exactly like the top-level face (the intervening inner handle does not
+    // rewrite an outer-effect perform), and the outer reduction's scan previously stopped dead at the inner
+    // `Handle` and MISSED it (a silent 33-vs-34 miscompile, v-effects self-probe 2026-08-04). Descend into the
+    // inner body ONLY, keeping THIS outer `ctx`: `block_wrapped_branch_performs` is ctx-keyed, so it fires only
+    // on a perform of the OUTER discharged op — an inner-effect perform in the inner body never matches, so
+    // this cannot over-decline the inner handler's own shapes.
+    if let Resolved::Handle { body, .. } = resolved_of(db, node) {
+        return body_has_block_wrapped_let_init_branch_perform(db, body, ctx);
     }
     // A `let` at THIS node: check each init for the block-wrapped branch-performing shape.
     if let Some(parts) = db.ast.as_form(node, "let").map(<[_]>::to_vec)

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -66247,6 +66247,44 @@ mod stage1 {
     }
 
     #[test]
+    fn a_block_wrapped_outer_perform_in_a_let_init_inside_a_nested_handle_body_declines() {
+        // adv-69 a4 sub-face (v-effects self-probe). A block-wrapped branch perform of the OUTER effect (A) in
+        // a `let`-init INSIDE a nested inner (B) handle's body, with the continuation re-reading A:
+        // `(handle A 3 ((ga …)) (handle B 100 ((gb …)) (let ((v (let ((k true)) (if k (A.ga) 9)))) (+ (* 10 v)
+        // (A.ga)))))`. The single-handle version declines via the let-init floor, but the intervening nested B
+        // handle made the OUTER A reduction's scanner STOP at the inner `Handle` and miss the block-wrapped
+        // A-perform in B's body → silent 33 vs 34. Fix: the scanner descends into a nested handle's BODY (not
+        // its arms) keeping the outer ctx, so it fires only on an OUTER-effect perform (an inner B-effect
+        // perform never matches → no over-decline of B's own shapes).
+        let src = "(do (effect A (op ga (-> Unit Int64))) (effect B (op gb (-> Unit Int64))) \
+                   (def (main) (handle A 3 ((ga (u) s (resume s (+ s 1)))) \
+                     (handle B 100 ((gb (u) t (resume t t))) \
+                       (let ((v (let ((k true)) (if k (A.ga) 9)))) (+ (* 10 v) (A.ga)))))) \
+                   (export main))";
+        assert!(
+            compile_component(&crate::codec::encode(&parse(src))).is_err(),
+            "a block-wrapped outer-perform in a let-init inside a nested handle body must decline, not miscompile to 33"
+        );
+        // CONTROL — the DIRECT-conditional twin (no block wrapper) at the same position folds (Site 4 lifts a
+        // direct init even through the nested handle), so the fix must NOT over-decline it.
+        let direct = "(do (effect A (op ga (-> Unit Int64))) (effect B (op gb (-> Unit Int64))) \
+                   (def (main) (handle A 3 ((ga (u) s (resume s (+ s 1)))) \
+                     (handle B 100 ((gb (u) t (resume t t))) \
+                       (let ((v (if true (A.ga) 9))) (+ (* 10 v) (A.ga)))))) \
+                   (export main))";
+        assert_eq!(
+            run_returns::<i64>(
+                &compile_component(&crate::codec::encode(&parse(direct))).expect(
+                    "a direct outer-perform in a let-init inside a nested handle body folds"
+                ),
+                "main"
+            ),
+            34,
+            "the direct-init twin must still fold to 34 (no over-decline through the nested handle)"
+        );
+    }
+
+    #[test]
     fn a_mutually_recursive_effectful_group_specializes_under_a_state_handler() {
         // E3 extended to MUTUAL recursion: `ev`/`od` call each other, and the effect (`Ctr.tick`) is reached
         // by `ev` only THROUGH its partner `od`. The fix: `body_reaches_discharged` now follows RECURSIVE

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -5714,6 +5714,7 @@ todo	a Rational entry argument is marshalled through Rational::new
 todo	a String ENTRY arg rides a rope into an effect-op argument and the arm reads its bytes
 todo	a String host RESULT crosses the boundary and is read twice (byte-len + scalar-len of a multibyte response)
 todo	a Symbol entry parameter compares to an interned constant
+todo	a block-wrapped branch perform of the OUTER effect in a let-init INSIDE a nested handler body declines cleanly (adv-69 a4 sub-face)
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject
 todo	a constant-try helper that fails feeds the None arm's fallback into resume
 todo	a recursive scalar-walk classifies characters across a multibyte String entry arg

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5716,6 +5716,7 @@ todo	a BLOCK-wrapped branch perform in a non-tail DO-STATEMENT declines cleanly 
 todo	a DEPTH-2 block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, nested wrappers)
 todo	a DIRECT branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3-direct sub-face)
 todo	a HEAP-accumulator block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor)
+todo	a block-wrapped branch perform of the OUTER effect in a let-init INSIDE a nested handler body declines cleanly (adv-69 a4 sub-face)
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject
 todo	a constant-try helper that fails feeds the None arm's fallback into resume
 todo	a recursive NEWTYPE traversal recurses on its projected recursive field

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5631,6 +5631,7 @@ todo	a ROPE Bytes arg (recursive concat, uncompacted) crosses the host boundary
 todo	a Rational-MAGNITUDE Quantity host value composes the num/den ops with the unit erasure (#13, B2)
 todo	a String host RESULT crosses the boundary and is read twice (byte-len + scalar-len of a multibyte response)
 todo	a build-time delegated effect whose result a returned closure captures does not escape
+todo	a block-wrapped branch perform of the OUTER effect in a let-init INSIDE a nested handler body declines cleanly (adv-69 a4 sub-face)
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject
 todo	a closure captures the result of a build-time host op called with an argument
 todo	a closure capturing a build-time host effect preserves the order of two host calls

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -3490,6 +3490,30 @@
             (export main)))
   (call   main) (output (: 34 Int64)))
 
+(case "a block-wrapped branch perform of the OUTER effect in a let-init INSIDE a nested handler body declines cleanly (adv-69 a4 sub-face)"
+  (doc    "adv-69 a4 (v-effects self-probe 2026-08-04): the let-init block-boundary drop, but the miscompiling
+           `let` sits inside a NESTED inner handler's BODY and performs the OUTER effect. `(handle A 3 ((ga …))
+           (handle B 100 ((gb …)) (let ((v (let ((k true)) (if k (A.ga) 9)))) (+ (* 10 v) (A.ga)))))` — the
+           block-wrapped branch perform is of the OUTER `A`, in a `let`-init in the inner `B` handle's body, and
+           the continuation RE-READS `A`. Seeded A=3 it ran 33, correct is 34 (A.ga returns 3, advances to 4;
+           trailing A.ga must read 4). The single-handle version of this shape declines via the let-init floor,
+           but the intervening nested `B` handle made the OUTER `A` reduction's scanner stop at the inner
+           `Handle` and MISS the block-wrapped `A`-perform in `B`'s body — a silent miscompile. FIX: the scanner
+           now descends into a nested handle's BODY (not its arms — that is a3's territory) keeping the OUTER
+           ctx, so `block_wrapped_branch_performs` (ctx-keyed) fires only on an OUTER-effect perform (an inner
+           `B`-effect perform never matches → no over-decline of `B`'s own shapes). Grades TODO on all backends;
+           flips to 34 PASS on the through-block fold.")
+  (input  (do
+            (effect A (op ga (-> Unit Int64)))
+            (effect B (op gb (-> Unit Int64)))
+            (def (main)
+              (handle A 3 ((ga (u) s (resume s (+ s 1))))
+                (handle B 100 ((gb (u) t (resume t t)))
+                  (let ((v (let ((k true)) (if k (A.ga) 9))))
+                    (+ (* 10 v) (A.ga))))))
+            (export main)))
+  (call   main) (output (: 34 Int64)))
+
 (case "a BLOCK-wrapped branch perform in a MATCH-SCRUTINEE declines cleanly (adv-69 g3 sub-face)"
   (doc    "adv-69 g3 (breaker probe-g3, block-outstate battery): the SAME block-boundary out-state drop, at a
            MATCH-SCRUTINEE consuming position. `(match (let ((b true)) (if b (St.get) 99)) (v (+ (* 10 v)


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 34f1b9c57, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.