### PR TITLE
docs(cdz-kernel): precise the new_with_family Cow comment — the old Arc<str> alloc was per &str-input, not literally "every call" (liaison LOW nit)

### DIFF
--- a/implementation/seed/crates/cdz-kernel/src/effect.rs
+++ b/implementation/seed/crates/cdz-kernel/src/effect.rs
@@ -286,8 +286,10 @@ impl EffectRequest {
     ) -> Self {
         // Take the family as `Cow<'static, str>` (not `Arc<str>`): a well-known family passed as a
         // `&'static str` const arrives as `Cow::Borrowed` with ZERO heap alloc — the same invariant `new`
-        // holds via `kind.family()` (#1563/#1722). (An `Arc<str>` parameter forced a heap alloc on EVERY call
-        // even for a `&'static str` const that the match below immediately re-borrows and discards.)
+        // holds via `kind.family()` (#1563/#1722). (An `Arc<str>` parameter forced a heap alloc for every
+        // `&str`/`&'static str`-const input via `Arc::from` — which is every call site here — that the match
+        // below then immediately re-borrows and discards; a caller already holding an `Arc<str>` wouldn't
+        // re-allocate, but none do.)
         let family: std::borrow::Cow<'static, str> = family.into();
         // Canonicalize a WELL-KNOWN family (an effect kind OR a control-plane family) to its `&'static str`
         // const → `Cow::Borrowed`, zero alloc. A well-known effect family carries its own kind; a


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 40652203cc794a318116a075a769abed8b1183a5, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.