### PR TITLE
corpus(07-type-system): 3-pin CDZ0216 compound-key descent — closure inside a tuple key, record field, and list set-element all reject

### DIFF
--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -652,6 +652,7 @@ pass	a LET-bound escaping-effect closure returned from a host block cannot cross
 pass	a LET-bound outer perform under an inner handle threads its state advance
 pass	a LIST OF SUMS resumed from a handler feeds an event-sourcing fold in the body
 pass	a LIST built in the handle body from perform results crosses the handle exit live
+pass	a LIST of closures as a set element is rejected (the collection-element face of the descent)
 pass	a LIST of closures rides one perform and the arm picks by state per call
 pass	a LIST shrinker drops elements greedily and converges to a minimal failing sublist
 pass	a LONGEST-COMMON-PREFIX walks two strings in scalar lockstep to the first mismatch
@@ -808,6 +809,7 @@ pass	a RECORD closure ARG with a LIST result
 pass	a RECORD closure ARG with a narrow Bool field, among scalars
 pass	a RECORD field built from a runtime param boxes its Map handle correctly (function[27] record-path twin)
 pass	a RECORD used as a map key hashes and matches by its field SET, independent of written order
+pass	a RECORD with a closure field as a map key is rejected (the record face of the compound descent)
 pass	a RECORD with a nested TUPLE field crosses the direct-call boundary
 pass	a RECURSIVE effectful walk accumulates into a list-state handler
 pass	a RECURSIVE sum as a Map key hits and misses by structural content
@@ -947,6 +949,7 @@ pass	a TOGGLE fold flips set membership per occurrence — odd count in, even co
 pass	a TOPOLOGICAL sort drains min-ready nodes and verifies every edge points forward
 pass	a TRANSPOSE of a 2x3 list-of-rows walks columns across row spines
 pass	a TRIPLY-nested Record ARG crosses the direct-call boundary
+pass	a TUPLE containing a closure as a map key is rejected (CDZ0216 descends into compound keys)
 pass	a TUPLE op argument with a HEAP leaf destructures inside the arm
 pass	a TUPLE-result perform's projected field feeds a SECOND perform's argument, threading state across both
 pass	a TUPLE-returning operation resumes a pair built from the handler state, then projected

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -657,6 +657,7 @@ pass	a LET-bound escaping-effect closure returned from a host block cannot cross
 pass	a LET-bound outer perform under an inner handle threads its state advance
 pass	a LIST OF SUMS resumed from a handler feeds an event-sourcing fold in the body
 pass	a LIST built in the handle body from perform results crosses the handle exit live
+pass	a LIST of closures as a set element is rejected (the collection-element face of the descent)
 pass	a LIST of closures rides one perform and the arm picks by state per call
 pass	a LIST shrinker drops elements greedily and converges to a minimal failing sublist
 pass	a LONGEST-COMMON-PREFIX walks two strings in scalar lockstep to the first mismatch
@@ -815,6 +816,7 @@ pass	a RECORD closure ARG with a LIST result
 pass	a RECORD closure ARG with a narrow Bool field, among scalars
 pass	a RECORD field built from a runtime param boxes its Map handle correctly (function[27] record-path twin)
 pass	a RECORD used as a map key hashes and matches by its field SET, independent of written order
+pass	a RECORD with a closure field as a map key is rejected (the record face of the compound descent)
 pass	a RECORD with a nested TUPLE field crosses the direct-call boundary
 pass	a RECURSIVE effectful walk accumulates into a list-state handler
 pass	a RECURSIVE sum as a Map key hits and misses by structural content
@@ -959,6 +961,7 @@ pass	a TOGGLE fold flips set membership per occurrence — odd count in, even co
 pass	a TOPOLOGICAL sort drains min-ready nodes and verifies every edge points forward
 pass	a TRANSPOSE of a 2x3 list-of-rows walks columns across row spines
 pass	a TRIPLY-nested Record ARG crosses the direct-call boundary
+pass	a TUPLE containing a closure as a map key is rejected (CDZ0216 descends into compound keys)
 pass	a TUPLE op argument with a HEAP leaf destructures inside the arm
 pass	a TUPLE-result perform's projected field feeds a SECOND perform's argument, threading state across both
 pass	a TUPLE-returning operation resumes a pair built from the handler state, then projected

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -639,6 +639,7 @@ pass	a LET-bound escaping-effect closure returned from a host block cannot cross
 pass	a LET-bound outer perform under an inner handle threads its state advance
 pass	a LIST OF SUMS resumed from a handler feeds an event-sourcing fold in the body
 pass	a LIST built in the handle body from perform results crosses the handle exit live
+pass	a LIST of closures as a set element is rejected (the collection-element face of the descent)
 pass	a LIST of closures rides one perform and the arm picks by state per call
 pass	a LIST shrinker drops elements greedily and converges to a minimal failing sublist
 pass	a LONGEST-COMMON-PREFIX walks two strings in scalar lockstep to the first mismatch
@@ -793,6 +794,7 @@ pass	a RECORD closure ARG with a LIST result
 pass	a RECORD closure ARG with a narrow Bool field, among scalars
 pass	a RECORD field built from a runtime param boxes its Map handle correctly (function[27] record-path twin)
 pass	a RECORD used as a map key hashes and matches by its field SET, independent of written order
+pass	a RECORD with a closure field as a map key is rejected (the record face of the compound descent)
 pass	a RECORD with a nested TUPLE field crosses the direct-call boundary
 pass	a RECURSIVE effectful walk accumulates into a list-state handler
 pass	a RECURSIVE sum as a Map key hits and misses by structural content
@@ -934,6 +936,7 @@ pass	a TOGGLE fold flips set membership per occurrence — odd count in, even co
 pass	a TOPOLOGICAL sort drains min-ready nodes and verifies every edge points forward
 pass	a TRANSPOSE of a 2x3 list-of-rows walks columns across row spines
 pass	a TRIPLY-nested Record ARG crosses the direct-call boundary
+pass	a TUPLE containing a closure as a map key is rejected (CDZ0216 descends into compound keys)
 pass	a TUPLE op argument with a HEAP leaf destructures inside the arm
 pass	a TUPLE-result perform's projected field feeds a SECOND perform's argument, threading state across both
 pass	a TUPLE-returning operation resumes a pair built from the handler state, then projected

--- a/spec/semantics/07-type-system.sexp
+++ b/spec/semantics/07-type-system.sexp
@@ -1933,6 +1933,50 @@
             (export main)))
   (error  CDZ0216))
 
+(case "a TUPLE containing a closure as a map key is rejected (CDZ0216 descends into compound keys)"
+  (doc    "The compound-wrapped face of the fn-Map-KEY reject above: the function is not the key itself
+           but a COMPONENT of a tuple key — `(Map.insert Map.empty (tuple 1 f) 42)`. Keyability is
+           decided over the WHOLE key type, so the check must descend into the tuple and find the
+           un-equatable fn leaf → CDZ0216. A keyability check inspecting only the top-level constructor
+           (Tuple is normally keyable) would admit the closure into the CHAMP hash path — the exact
+           smuggle that re-opens the adv-50 wasm-invents-identity vs rust-E0277 divergence the bare
+           reject closed. The closure CAPTURES a runtime binding (n) so nothing erases it.")
+  (input  (do
+            (def (main (: n Int64))
+              (do
+                (def f (fn ((: x Int64)) (+ x n)))
+                (Map.len (Map.insert Map.empty (tuple 1 f) 42))))
+            (export main)))
+  (error  CDZ0216))
+
+(case "a RECORD with a closure field as a map key is rejected (the record face of the compound descent)"
+  (doc    "The record companion of the tuple-wrapped fn-key reject: `(record (id 1) (cb f))` as a Map
+           key — the keyability descent must walk record FIELDS (by the descriptor, not just the head
+           constructor) and reject on the fn-typed `cb` → CDZ0216. Together with the tuple face this
+           pins that both compound layouts route their component types through the same keyability
+           check; a callback-registry record accidentally used as a key gets the coded reject, not a
+           backend-divergent identity.")
+  (input  (do
+            (def (main (: n Int64))
+              (do
+                (def f (fn ((: x Int64)) (+ x n)))
+                (Map.len (Map.insert Map.empty (record (id 1) (cb f)) 42))))
+            (export main)))
+  (error  CDZ0216))
+
+(case "a LIST of closures as a set element is rejected (the collection-element face of the descent)"
+  (doc    "The third wrapper kind: the closure hides inside a LIST that is itself a Set ELEMENT —
+           `(Set.of (list (list (fn ...))))`. The element-keyability check must descend through the
+           collection's ELEMENT type (a (List (-> Int64 Int64)) is un-equatable because its element is)
+           → CDZ0216. Completes the compound descent family: tuple component, record field, and
+           collection element all reject uniformly on every backend (no wasm-invented closure identity
+           at any nesting).")
+  (input  (do
+            (def (main (: n Int64))
+              (Set.len (Set.of (list (list (fn ((: x Int64)) (+ x n)))))))
+            (export main)))
+  (error  CDZ0216))
+
 (case "Type.of grounds a Map-value function nested inside a tuple"
   (doc    "The compounding facet: a runtime-Map-value function wrapped in an outer container —
            `(tuple (Map.insert Map.empty 1 f) 0)`. The tuple-element reflection recurses INTO the


### PR DESCRIPTION
Candidate PR for breaker's merge-request (ref 59d2b5128bb4a29fd4be8cf2976a9c6508d96b36, lane baseline). Auto-merge armed; pr-sync's schedule-pass reaps on green.