### PR TITLE
rcdzc(effects): adv-69 a4-init sub-face — a block-wrapped outer-effect perform in a nested handle's INIT declines cleanly (completes the a4 nested-body fix)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -3489,16 +3489,23 @@ fn body_has_block_wrapped_let_init_branch_perform(
     ctx: &HandlerCtx,
 ) -> bool {
     // A NESTED handle: its ARMS belong to THAT inner handler's reduction (a block-wrapped perform in an arm
-    // resume-value is the a3 guard's territory), so don't scan them here. But its BODY still runs UNDER this
-    // (outer) handler — a block-wrapped branch perform of THIS handler's OUTER op in a `let`-init in the inner
-    // body drops the outer advance exactly like the top-level face (the intervening inner handle does not
-    // rewrite an outer-effect perform), and the outer reduction's scan previously stopped dead at the inner
-    // `Handle` and MISSED it (a silent 33-vs-34 miscompile, v-effects self-probe 2026-08-04). Descend into the
-    // inner body ONLY, keeping THIS outer `ctx`: `block_wrapped_branch_performs` is ctx-keyed, so it fires only
-    // on a perform of the OUTER discharged op — an inner-effect perform in the inner body never matches, so
-    // this cannot over-decline the inner handler's own shapes.
-    if let Resolved::Handle { body, .. } = resolved_of(db, node) {
-        return body_has_block_wrapped_let_init_branch_perform(db, body, ctx);
+    // resume-value is the a3 guard's territory), so don't scan them here. But its INIT and BODY both run UNDER
+    // this (outer) handler — a block-wrapped branch perform of THIS handler's OUTER op in a `let`-init in the
+    // inner body OR the inner handle's INIT (the init is evaluated as part of the handle expression, in the
+    // outer extent — `eval.rs` passes `init` to `reduce_handle` alongside `body`) drops the outer advance
+    // exactly like the top-level face (the intervening inner handle does not rewrite an outer-effect perform),
+    // and the outer reduction's scan previously stopped dead at the inner `Handle` and MISSED it (a silent
+    // 33-vs-34 miscompile, v-effects self-probe 2026-08-04; the INIT position was the a4-init sub-face,
+    // liaison/Copilot on merged #1933). Descend into BOTH the inner init and body, keeping THIS outer `ctx`:
+    // `block_wrapped_branch_performs` is ctx-keyed, so it fires only on a perform of the OUTER discharged op —
+    // an inner-effect perform never matches, so this cannot over-decline the inner handler's own shapes.
+    if let Resolved::Handle { init, body, .. } = resolved_of(db, node) {
+        // The inner handle's INIT may ITSELF be a block-wrapped branch perform (`(handle B (let ((k true))
+        // (if k (A.ga) 9)) …)` — the block IS the init, not a let-binding within it), so check the init node
+        // directly too; then recurse into both init and body for a `let`-init nested anywhere inside them.
+        return block_wrapped_branch_performs(db, init, ctx)
+            || body_has_block_wrapped_let_init_branch_perform(db, init, ctx)
+            || body_has_block_wrapped_let_init_branch_perform(db, body, ctx);
     }
     // A `let` at THIS node: check each init for the block-wrapped branch-performing shape.
     if let Some(parts) = db.ast.as_form(node, "let").map(<[_]>::to_vec)

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -66296,6 +66296,18 @@ mod stage1 {
             34,
             "the direct-init twin must still fold to 34 (no over-decline through the nested handle)"
         );
+        // a4-init (liaison/Copilot on #1933): the block-wrapped OUTER perform in the inner handle's INIT (the
+        // init is evaluated in the outer extent). The a4 fix scanned the inner body but early-returned without
+        // the init — this closes that gap (scan the init node directly + recurse into both init and body).
+        let init_face = "(do (effect A (op ga (-> Unit Int64))) (effect B (op gb (-> Unit Int64))) \
+                   (def (main) (handle A 3 ((ga (u) s (resume s (+ s 1)))) \
+                     (handle B (let ((k true)) (if k (A.ga) 9)) ((gb (u) t (resume t t))) \
+                       (+ (* 10 (B.gb)) (A.ga))))) \
+                   (export main))";
+        assert!(
+            compile_component(&crate::codec::encode(&parse(init_face))).is_err(),
+            "a block-wrapped outer perform in a nested handle's init must decline, not miscompile to 33"
+        );
     }
 
     #[test]

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -5720,6 +5720,7 @@ todo	a String ENTRY arg rides a rope into an effect-op argument and the arm read
 todo	a String host RESULT crosses the boundary and is read twice (byte-len + scalar-len of a multibyte response)
 todo	a Symbol entry parameter compares to an interned constant
 todo	a block-wrapped OUTER-effect perform in a let-init THREE handlers deep declines cleanly (adv-69 a4-depth3 sub-face)
+todo	a block-wrapped OUTER-effect perform in a nested handle's INIT declines cleanly (adv-69 a4-init sub-face)
 todo	a block-wrapped branch perform of the OUTER effect in a let-init INSIDE a nested handler body declines cleanly (adv-69 a4 sub-face)
 todo	a block-wrapped OUTER-effect perform in a non-tail do-statement INSIDE a nested handler body declines cleanly (adv-69 c3-nested sub-face)
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5722,6 +5722,7 @@ todo	a DEPTH-2 block-wrapped branch perform in a let-init declines cleanly (adv-
 todo	a DIRECT branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3-direct sub-face)
 todo	a HEAP-accumulator block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor)
 todo	a block-wrapped OUTER-effect perform in a let-init THREE handlers deep declines cleanly (adv-69 a4-depth3 sub-face)
+todo	a block-wrapped OUTER-effect perform in a nested handle's INIT declines cleanly (adv-69 a4-init sub-face)
 todo	a block-wrapped branch perform of the OUTER effect in a let-init INSIDE a nested handler body declines cleanly (adv-69 a4 sub-face)
 todo	a block-wrapped OUTER-effect perform in a non-tail do-statement INSIDE a nested handler body declines cleanly (adv-69 c3-nested sub-face)
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5637,6 +5637,7 @@ todo	a Rational-MAGNITUDE Quantity host value composes the num/den ops with the 
 todo	a String host RESULT crosses the boundary and is read twice (byte-len + scalar-len of a multibyte response)
 todo	a build-time delegated effect whose result a returned closure captures does not escape
 todo	a block-wrapped OUTER-effect perform in a let-init THREE handlers deep declines cleanly (adv-69 a4-depth3 sub-face)
+todo	a block-wrapped OUTER-effect perform in a nested handle's INIT declines cleanly (adv-69 a4-init sub-face)
 todo	a block-wrapped branch perform of the OUTER effect in a let-init INSIDE a nested handler body declines cleanly (adv-69 a4 sub-face)
 todo	a block-wrapped OUTER-effect perform in a non-tail do-statement INSIDE a nested handler body declines cleanly (adv-69 c3-nested sub-face)
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -3537,6 +3537,29 @@
             (export main)))
   (call   main) (output (: 34 Int64)))
 
+(case "a block-wrapped OUTER-effect perform in a nested handle's INIT declines cleanly (adv-69 a4-init sub-face)"
+  (doc    "adv-69 a4-init (liaison/Copilot on merged #1933): the a4 nested-handle-escape, but the block-wrapped
+           OUTER-effect perform sits in the inner handle's INIT — `(handle A 3 ((ga …)) (handle B (let ((k true))
+           (if k (A.ga) 9)) ((gb …)) (+ (* 10 (B.gb)) (A.ga))))`. The inner `B` handle's INIT is evaluated as
+           part of the handle expression in the OUTER `A` extent (eval.rs passes `init` to `reduce_handle`
+           alongside `body`), so a block-wrapped `A`-perform there drops the outer advance exactly like the a4
+           body face: seeded A=3 it ran 33, correct is 34 (B's init A.ga returns 3, A→4; B.gb returns B-state 3;
+           trailing A.ga must read 4 → 10*3 + 4). The a4 fix scanned the inner handle's BODY but early-returned
+           without the INIT, missing this position. FIX: the nested-Handle scan checks the init node directly
+           (`block_wrapped_branch_performs`) AND recurses into both init and body — ctx-keyed, so only an
+           OUTER-op perform fires (no over-decline of `B`'s shapes). Grades TODO on all backends; flips to 34
+           PASS on the through-block fold.")
+  (input  (do
+            (effect A (op ga (-> Unit Int64)))
+            (effect B (op gb (-> Unit Int64)))
+            (def (main)
+              (handle A 3 ((ga (u) s (resume s (+ s 1))))
+                (handle B (let ((k true)) (if k (A.ga) 9))
+                  ((gb (u) t (resume t t)))
+                  (+ (* 10 (B.gb)) (A.ga)))))
+            (export main)))
+  (call   main) (output (: 34 Int64)))
+
 (case "a BLOCK-wrapped branch perform in a MATCH-SCRUTINEE declines cleanly (adv-69 g3 sub-face)"
   (doc    "adv-69 g3 (breaker probe-g3, block-outstate battery): the SAME block-boundary out-state drop, at a
            MATCH-SCRUTINEE consuming position. `(match (let ((b true)) (if b (St.get) 99)) (v (+ (* 10 v)


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref e844d64d2, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.