### PR TITLE
cdz-agent-host: admin control interface Unix-socket transport (`admin` feature) + [admin] config + #1954 doc-nit

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -340,6 +340,12 @@ jobs:
           cargo test
           cargo clippy --all-targets -- -D warnings
           cargo fmt --check
+          # `admin` gates the admin control interface's Unix-socket LISTENER. Unlike `live-net`, it needs NO
+          # egress or credentials — a Unix domain socket is local IPC that binds + connects on any runner — so
+          # it's fully TESTED here (its e2e binds a real socket in the temp dir + round-trips frames), not
+          # lint-only. Both test + clippy so the feature-gated transport is covered.
+          cargo test --features admin
+          cargo clippy --all-targets --features admin -- -D warnings
           # `live-net` gates the network executors (Bedrock model / real HTTP transports), which need egress
           # + credentials a CI runner lacks — so LINT-ONLY here (clippy), no `cargo test --features live-net`
           # (unlike the sibling cdz-kernel live-exec, whose subprocess spawn works on any runner). The default

--- a/implementation/seed/crates/cdz-agent-host/Cargo.toml
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.toml
@@ -37,6 +37,15 @@ path = "src/bin/cdz_agent_daemon.rs"
 # tree, no network types). The `dep:` bindings tie the optional dependencies to this feature only.
 live-net = ["dep:reqwest", "dep:aws-config", "dep:aws-sdk-bedrockruntime"]
 
+# `admin` gates the ADMIN CONTROL INTERFACE's transport — the Unix-domain-socket listener that carries
+# admin command/response frames to a running daemon (operator: "a way to communicate with the daemon + send
+# it commands as an admin"). OFF by default so the hermetic gate BINDS NO SOCKET + pulls no tokio `net`
+# tree: the admin COMMAND layer + wire CODEC stay always-on (hermetically tested), only the socket LISTENER
+# is feature-gated. It enables tokio's `net` feature (for `UnixListener`/`UnixStream`) + `io-util` (the
+# `AsyncReadExt`/`AsyncWriteExt` the frame read/write use). Local IPC only — a Unix socket is not network
+# egress, so this is not the same concern as `live-net`; gating it keeps the default build listener-free.
+admin = ["tokio/net", "tokio/io-util"]
+
 [dependencies]
 # The kernel whose Executor/Authorize traits + effect/event types we implement. Path dep across the
 # workspace boundary (both are their own workspaces). We CONSUME these traits; we never edit its src.

--- a/implementation/seed/crates/cdz-agent-host/src/admin_socket.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/admin_socket.rs
@@ -1,0 +1,343 @@
+//! The admin control interface's TRANSPORT — a local Unix-domain-socket listener that carries
+//! [`AdminCommandWire`]/[`AdminResponseWire`] frames between an admin client and the running daemon.
+//!
+//! This is the outermost slice of the admin control interface, and the only part that touches the OS: it
+//! binds a Unix socket, and for each connection reads a length-prefixed JSON command frame, forwards it to
+//! the host loop over the in-process [`AdminChannel`] (awaiting the reply on a oneshot), and writes the
+//! response frame back. The socket task is `Send` (it only moves bytes + channel handles), so it can run
+//! as its own tokio task while the single-threaded host loop applies the command against the `!Send`
+//! registry — the Send/!Send split the [`crate::async_host`] loop was built for.
+//!
+//! **Feature-gated (`admin`).** The whole module is behind the `admin` cargo feature so the DEFAULT build
+//! binds no socket + pulls no tokio `net` tree (the hermetic-gate discipline). The admin COMMAND layer
+//! ([`crate::admin`]) and wire CODEC ([`crate::admin_wire`]) stay always-on and hermetically tested; only
+//! this LISTENER is opt-in. Local IPC only — a Unix socket is not network egress (a remote admin transport
+//! would be a later opt-in with its own auth); the file-permissions gate (owner-only) is the v0 auth, with
+//! a Cedar `admin/*` policy layer to follow.
+
+use crate::admin_wire::{decode_frame, encode_frame, AdminCommandWire, AdminResponseWire};
+use crate::async_host::{AdminChannel, AdminRequest};
+use std::io;
+use std::path::{Path, PathBuf};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+
+/// A bound admin control socket. Construct with [`AdminSocket::bind`] (binds the path + sets owner-only
+/// perms), then [`serve`](AdminSocket::serve) it — the accept loop that feeds admin commands to the host.
+/// Dropping it removes the socket file (best-effort) so a restart can re-bind the same path.
+pub struct AdminSocket {
+    listener: UnixListener,
+    path: PathBuf,
+}
+
+impl AdminSocket {
+    /// Bind the admin control socket at `path`, replacing any stale socket file left by a previous run, and
+    /// restrict it to OWNER-ONLY (mode `0o600`) — the v0 OS-level auth (admin = whoever owns the daemon
+    /// process). `Err` if the bind or the perms-set fails.
+    ///
+    /// (A stale socket file from an unclean shutdown would make `bind` fail with `AddrInUse`; we remove a
+    /// pre-existing file first. This is safe for a single-daemon deployment — two daemons sharing one admin
+    /// socket path is a misconfiguration, not something to defend by leaving a stale file to block bind.)
+    pub fn bind(path: impl AsRef<Path>) -> io::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        // Remove a stale socket file (ignore "not found"); a real bind failure surfaces below.
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+        let listener = UnixListener::bind(&path)?;
+        // Owner-only: an admin command installs/stops sessions, so the socket must not be world-writable.
+        // This is the v0 auth gate (a Cedar admin/* policy layer follows). Unix-only perms via a raw mode.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+        }
+        Ok(AdminSocket { listener, path })
+    }
+
+    /// The bound socket path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Accept admin connections forever, dispatching each command through `admin` to the host loop. Runs
+    /// until `shutdown` fires (then returns) — typically spawned as a tokio task beside the host loop. Each
+    /// accepted connection is served inline (admin traffic is low-volume + serialized through the one host
+    /// loop anyway, so there's no win in spawning per-connection; keeping it inline needs no `Send` bound on
+    /// the connection future and keeps the ordering obvious). An accept error is logged to stderr and the
+    /// loop continues — one bad connection never takes the listener down.
+    pub async fn serve(
+        self,
+        admin: AdminChannel,
+        mut shutdown: tokio::sync::oneshot::Receiver<()>,
+    ) {
+        loop {
+            tokio::select! {
+                _ = &mut shutdown => break,
+                accepted = self.listener.accept() => {
+                    match accepted {
+                        Ok((stream, _addr)) => {
+                            // Serve this connection to completion. An error mid-connection (client hung up,
+                            // a malformed frame) ends only THIS connection — never the listener.
+                            if let Err(e) = serve_connection(stream, &admin).await {
+                                eprintln!("cdz-agent-daemon admin: connection ended with error: {e}");
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("cdz-agent-daemon admin: accept failed: {e}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Drop for AdminSocket {
+    fn drop(&mut self) {
+        // Best-effort cleanup so a restart can re-bind the same path (ignore errors — the process is going
+        // away regardless).
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Serve one admin connection: read command frames, dispatch each to the host loop, write back the response
+/// frame — until the client closes the connection (clean EOF) or an error occurs. A connection can carry
+/// MULTIPLE commands (the client may pipeline), so this loops until EOF rather than one-shot.
+async fn serve_connection(mut stream: UnixStream, admin: &AdminChannel) -> io::Result<()> {
+    // Accumulate bytes; decode as many whole frames as have arrived, dispatch each, reply. This handles a
+    // command split across reads (partial frame → keep reading) and multiple commands in one read.
+    let mut buf: Vec<u8> = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        // Drain every COMPLETE frame currently in `buf`.
+        loop {
+            match decode_frame::<AdminCommandWire>(&buf) {
+                Ok(Some((cmd_wire, consumed))) => {
+                    buf.drain(..consumed);
+                    let response = dispatch(cmd_wire, admin).await;
+                    let frame = encode_frame(&response).map_err(|e| {
+                        io::Error::new(io::ErrorKind::InvalidData, format!("encode response: {e}"))
+                    })?;
+                    stream.write_all(&frame).await?;
+                    stream.flush().await?;
+                }
+                // Not a full frame yet — go read more bytes.
+                Ok(None) => break,
+                // A malformed frame (oversized length / bad JSON): reply with an error frame, then stop
+                // serving this connection (the stream framing is now untrustworthy).
+                Err(e) => {
+                    let err = AdminResponseWire::Error {
+                        message: format!("bad admin frame: {e}"),
+                    };
+                    if let Ok(frame) = encode_frame(&err) {
+                        let _ = stream.write_all(&frame).await;
+                        let _ = stream.flush().await;
+                    }
+                    return Ok(());
+                }
+            }
+        }
+        // Read more bytes. 0 = clean EOF (client closed) → we're done with this connection.
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            return Ok(());
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+}
+
+/// Forward one decoded command to the host loop and await its reply. Converts the wire command to the
+/// domain [`crate::admin::AdminCommand`] (returning a wire error response if the frame's hash is malformed),
+/// sends it on the [`AdminChannel`] with a fresh reply oneshot, and maps the domain response back to wire.
+async fn dispatch(cmd_wire: AdminCommandWire, admin: &AdminChannel) -> AdminResponseWire {
+    let command = match cmd_wire.to_domain() {
+        Ok(c) => c,
+        // A structurally-valid frame whose content is invalid (e.g. a non-canonical reducer hash) — answer
+        // with an error, don't tear down the connection.
+        Err(e) => {
+            return AdminResponseWire::Error {
+                message: format!("invalid admin command: {e}"),
+            }
+        }
+    };
+    let (reply, rx) = tokio::sync::oneshot::channel();
+    if admin.send(AdminRequest { command, reply }).is_err() {
+        // The host loop is gone (shutting down) — report it rather than hang.
+        return AdminResponseWire::Error {
+            message: "daemon host loop is not accepting admin commands".into(),
+        };
+    }
+    match rx.await {
+        Ok(resp) => AdminResponseWire::from_domain(&resp),
+        // The loop dropped the reply without answering (shutdown mid-command).
+        Err(_) => AdminResponseWire::Error {
+            message: "daemon shut down before replying to the admin command".into(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::admin::{AdminCommand, InstallSpec, SessionFactory};
+    use crate::async_host::AsyncAgentHost;
+    use crate::host::{AgentHost, HostedSession, SessionId};
+    use cdz_kernel::authz::Authorizer;
+    use cdz_kernel::event::Event;
+    use cdz_kernel::executor::CompositeExecutor;
+    use cdz_kernel::hash::Hash;
+    use cdz_kernel::kv::Kv;
+    use cdz_kernel::reducer::{FoldOutput, Reducer};
+
+    struct StubAgent;
+    #[async_trait::async_trait(?Send)]
+    impl Reducer for StubAgent {
+        async fn fold(&self, _event: &Event, _kv: &mut Kv) -> FoldOutput {
+            FoldOutput::none()
+        }
+    }
+
+    struct StubFactory;
+    #[async_trait::async_trait(?Send)]
+    impl SessionFactory for StubFactory {
+        async fn build(&mut self, spec: &InstallSpec) -> Result<HostedSession, String> {
+            Ok(HostedSession::genesis(
+                spec.reducer_hash,
+                Box::new(StubAgent),
+                Box::new(Authorizer::deny_all()),
+                CompositeExecutor::new(),
+            ))
+        }
+    }
+
+    /// A unique temp path for a test socket (no `Date`/`rand` in this env; the test name + a counter arg
+    /// keeps it unique across the two socket tests).
+    fn socket_path(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("cdz-admin-test-{tag}.sock"))
+    }
+
+    /// Round-trip a command over a real client `UnixStream` to the served socket: write a frame, read the
+    /// response frame, decode it.
+    async fn client_call(stream: &mut UnixStream, cmd: AdminCommand) -> AdminResponseWire {
+        let frame = encode_frame(&AdminCommandWire::from(&cmd)).unwrap();
+        stream.write_all(&frame).await.unwrap();
+        stream.flush().await.unwrap();
+        // Read until a full response frame decodes.
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            if let Some((resp, _)) = decode_frame::<AdminResponseWire>(&buf).unwrap() {
+                return resp;
+            }
+            let n = stream.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "server closed before a full response");
+            buf.extend_from_slice(&chunk[..n]);
+        }
+    }
+
+    #[tokio::test]
+    async fn install_and_list_over_a_real_unix_socket() {
+        let path = socket_path("install-list");
+        let sock = AdminSocket::bind(&path).expect("bind admin socket");
+
+        // Owner-only perms on the socket file (the v0 auth gate).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "socket is owner-only");
+        }
+
+        // The host loop (with a factory so installs work) + its admin channel.
+        let async_host = AsyncAgentHost::with_factory(AgentHost::new(), Box::new(StubFactory));
+        let admin = async_host.admin_channel();
+        let (host_sd_tx, host_sd_rx) = tokio::sync::oneshot::channel();
+        let (sock_sd_tx, sock_sd_rx) = tokio::sync::oneshot::channel();
+
+        // Client work: connect, install a session, list it back.
+        let client = async {
+            let mut stream = UnixStream::connect(&path).await.expect("connect");
+            let installed = client_call(
+                &mut stream,
+                AdminCommand::InstallSession(InstallSpec {
+                    id: SessionId::new("s1"),
+                    reducer_hash: Hash::of(b"s1"),
+                    goal: None,
+                }),
+            )
+            .await;
+            assert_eq!(installed, AdminResponseWire::Installed { id: "s1".into() });
+
+            let listed = client_call(&mut stream, AdminCommand::ListSessions).await;
+            assert_eq!(
+                listed,
+                AdminResponseWire::Sessions {
+                    ids: vec!["s1".into()]
+                }
+            );
+            // Done: close the client stream, then stop the socket + host loop.
+            drop(stream);
+            let _ = sock_sd_tx.send(());
+            let _ = host_sd_tx.send(());
+        };
+
+        // Run the host loop, the socket server, and the client concurrently (single-threaded — everything
+        // is on one task set via join!, matching the daemon's single-threaded shape).
+        let (_host, (), ()) = tokio::join!(
+            async_host.run(host_sd_rx, || 0),
+            sock.serve(admin, sock_sd_rx),
+            client,
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn a_garbage_frame_gets_an_error_response_not_a_crash() {
+        let path = socket_path("garbage");
+        let sock = AdminSocket::bind(&path).expect("bind");
+        let async_host = AsyncAgentHost::with_factory(AgentHost::new(), Box::new(StubFactory));
+        let admin = async_host.admin_channel();
+        let (host_sd_tx, host_sd_rx) = tokio::sync::oneshot::channel();
+        let (sock_sd_tx, sock_sd_rx) = tokio::sync::oneshot::channel();
+
+        let client = async {
+            let mut stream = UnixStream::connect(&path).await.unwrap();
+            // A well-framed but non-JSON body: 4-byte length header + garbage bytes.
+            let body = b"this is not json";
+            let mut frame = (body.len() as u32).to_be_bytes().to_vec();
+            frame.extend_from_slice(body);
+            stream.write_all(&frame).await.unwrap();
+            stream.flush().await.unwrap();
+
+            // Read the error response.
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 4096];
+            let resp = loop {
+                if let Some((resp, _)) = decode_frame::<AdminResponseWire>(&buf).unwrap() {
+                    break resp;
+                }
+                let n = stream.read(&mut chunk).await.unwrap();
+                assert!(n > 0, "server closed without an error response");
+                buf.extend_from_slice(&chunk[..n]);
+            };
+            assert!(
+                matches!(resp, AdminResponseWire::Error { message } if message.contains("bad admin frame")),
+                "a garbage frame gets an error response"
+            );
+            drop(stream);
+            let _ = sock_sd_tx.send(());
+            let _ = host_sd_tx.send(());
+        };
+
+        let (_host, (), ()) = tokio::join!(
+            async_host.run(host_sd_rx, || 0),
+            sock.serve(admin, sock_sd_rx),
+            client,
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/implementation/seed/crates/cdz-agent-host/src/admin_wire.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/admin_wire.rs
@@ -200,13 +200,13 @@ pub fn encode_frame<T: Serialize>(value: &T) -> Result<Vec<u8>, WireError> {
 }
 
 /// Decode one length-prefixed JSON frame from the front of `buf`, returning the decoded value and the
-/// number of bytes consumed (so a caller draining a stream buffer can advance past it). `Err` if the buffer
-/// is too short for the declared frame (an incomplete read — the caller should read more bytes), if the
-/// declared length exceeds [`MAX_FRAME_LEN`], or if the body isn't valid JSON for `T`.
+/// number of bytes consumed (so a caller draining a stream buffer can advance past it). `Err` if the
+/// declared length exceeds [`MAX_FRAME_LEN`] or if the body isn't valid JSON for `T`.
 ///
 /// Returns `Ok(None)` when `buf` doesn't yet hold a full frame (fewer than 4 header bytes, or fewer than
-/// the declared body length) — the "need more bytes" signal a streaming reader loops on. A genuinely
-/// malformed frame (oversized length, bad JSON) is `Err`.
+/// the declared body length) — the "need more bytes" signal a streaming reader loops on (NOT an `Err`: a
+/// short buffer is an incomplete read to retry, not a malformed frame). Only an oversized declared length
+/// or a full-but-unparseable body is `Err`.
 pub fn decode_frame<T: for<'de> Deserialize<'de>>(
     buf: &[u8],
 ) -> Result<Option<(T, usize)>, WireError> {

--- a/implementation/seed/crates/cdz-agent-host/src/config.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/config.rs
@@ -32,6 +32,10 @@ pub struct DaemonConfig {
     /// bounded exponential backoff.
     #[serde(default)]
     pub retries: RetryConfig,
+    /// The admin control interface (the Unix-domain socket an admin sends commands to). Defaults to
+    /// disabled — a daemon with no admin section boots without a control socket.
+    #[serde(default)]
+    pub admin: AdminConfig,
 }
 
 /// The durable-log backend — config-SELECTABLE (the operator's "selectable backends"): `memory` for dev,
@@ -61,6 +65,24 @@ pub struct ObservabilityConfig {
     /// Where to emit metrics to (a collector address); required-ish when `enabled` — validated below.
     #[serde(default)]
     pub endpoint: Option<String>,
+}
+
+/// The admin control interface config — the local Unix-domain socket an admin communicates with the
+/// running daemon over (install/list/status/stop sessions). Disabled by default; when enabled, `socket` is
+/// the filesystem path to bind (validated present below). LOCAL only — a Unix socket, not a network
+/// listener, matching the hermetic/no-egress posture (a remote admin transport would be a later opt-in with
+/// its own auth). The socket LISTENER itself is behind the `admin` cargo feature; this config is always
+/// parseable so a config-path smoke test needs no feature.
+#[derive(Debug, Clone, Deserialize, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct AdminConfig {
+    /// Serve the admin control interface. Default off (no control socket).
+    #[serde(default)]
+    pub enabled: bool,
+    /// The Unix-domain socket path to bind (e.g. `/run/cdz/admin.sock`); required when `enabled` —
+    /// validated below.
+    #[serde(default)]
+    pub socket: Option<String>,
 }
 
 /// Effect-retry policy: a bounded exponential backoff the daemon's supervisor applies to a RETRYABLE
@@ -158,6 +180,25 @@ impl DaemonConfig {
             return Err(ConfigError(
                 "[observability] enabled=true needs an endpoint".into(),
             ));
+        }
+        match &self.admin {
+            AdminConfig {
+                enabled: true,
+                socket: None,
+            } => {
+                return Err(ConfigError(
+                    "[admin] enabled=true needs a socket path".into(),
+                ));
+            }
+            AdminConfig {
+                enabled: true,
+                socket: Some(s),
+            } if s.trim().is_empty() => {
+                return Err(ConfigError(
+                    "[admin] enabled=true needs a non-empty socket path".into(),
+                ));
+            }
+            _ => {}
         }
         Ok(())
     }
@@ -262,5 +303,38 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.0.contains("table"), "{err}");
+    }
+
+    #[test]
+    fn admin_defaults_to_disabled_and_carries_its_socket_when_set() {
+        // Default: no [admin] section → disabled, no socket.
+        let cfg = DaemonConfig::from_toml_str("").unwrap();
+        assert_eq!(cfg.admin, AdminConfig::default());
+        assert!(!cfg.admin.enabled);
+        assert!(cfg.admin.socket.is_none());
+
+        // Set: enabled + a socket path is carried through.
+        let cfg = DaemonConfig::from_toml_str(
+            r#"
+            [admin]
+            enabled = true
+            socket = "/run/cdz/admin.sock"
+            "#,
+        )
+        .expect("admin config parses");
+        assert!(cfg.admin.enabled);
+        assert_eq!(cfg.admin.socket.as_deref(), Some("/run/cdz/admin.sock"));
+    }
+
+    #[test]
+    fn admin_enabled_without_a_socket_is_rejected() {
+        let err = DaemonConfig::from_toml_str(
+            r#"
+            [admin]
+            enabled = true
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.0.contains("socket"), "{err}");
     }
 }

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -42,8 +42,10 @@
 //! ([`AdminChannel`]) alongside its inbox + timers, applying each on the loop
 //! task (where the `!Send` registry lives) and replying via a per-command oneshot — so a `Send`
 //! socket-listener task can drive the control interface without the registry ever crossing a thread. The
-//! Unix-socket transport that reads/writes those frames and the Cedar `admin/*` authorization of each
-//! command are the following slices.
+//! `admin_socket` module (behind the `admin` cargo feature) is that transport: an `AdminSocket` binds a
+//! local Unix-domain socket (owner-only perms), reads length-prefixed command frames, forwards them over
+//! the channel, and writes response frames back — the default build binds no socket. The Cedar `admin/*`
+//! authorization of each command is the following slice.
 //!
 //! All executor errors are RECOVERABLE + classified for the kernel's supervision tree (see [`retry`]):
 //! an `EffectOutcome::Err` reason leads with a `RETRYABLE:`/`PERMANENT:` token so a supervisor decides
@@ -52,6 +54,8 @@
 //! The shared surface with `cdz-kernel` is ONLY the trait signatures; this crate never edits kernel src.
 
 pub mod admin;
+#[cfg(feature = "admin")]
+pub mod admin_socket;
 pub mod admin_wire;
 pub mod async_host;
 pub mod clock;
@@ -63,13 +67,15 @@ pub mod retry;
 pub mod status;
 
 pub use admin::{AdminCommand, AdminResponse, InstallSpec, SessionFactory};
+#[cfg(feature = "admin")]
+pub use admin_socket::AdminSocket;
 pub use admin_wire::{
     decode_frame, encode_frame, AdminCommandWire, AdminResponseWire, InstallSpecWire, WireError,
     MAX_FRAME_LEN,
 };
 pub use async_host::{AdminChannel, AdminRequest, AsyncAgentHost, Inbound, Inbox};
 pub use clock::ClockExecutor;
-pub use config::{DaemonConfig, LogConfig, ObservabilityConfig, RetryConfig};
+pub use config::{AdminConfig, DaemonConfig, LogConfig, ObservabilityConfig, RetryConfig};
 #[cfg(feature = "live-net")]
 pub use host::live_executor_set;
 pub use host::{AgentHost, HostedSession, SessionId};


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref d86a1924c, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.