### PR TITLE
corpus(19-sets): fix-forward #1969 — thread n through drop-half so the removal range tracks the build size

### DIFF
--- a/spec/semantics/19-sets.sexp
+++ b/spec/semantics/19-sets.sexp
@@ -997,12 +997,12 @@
   (input  (do
             (def (build (: i Int64) (: acc (Set Int64)))
               (if (= i 0) acc (build (- i 1) (Set.insert acc i))))
-            (def (drop-half (: i Int64) (: s (Set Int64)))
-              (if (> i 100) s (drop-half (+ i 2) (Set.remove s i))))
+            (def (drop-half (: i Int64) (: n Int64) (: s (Set Int64)))
+              (if (> i n) s (drop-half (+ i 2) n (Set.remove s i))))
             (def (main (: n Int64))
               (do
                 (def full (build n (Set.of (list))))
-                (def odds (drop-half 2 full))
+                (def odds (drop-half 2 n full))
                 (def inter (Set.intersection full odds))
                 (+ (* 10 (if (= inter odds) 1 0)) (if (Set.contains inter 2) 1 0))))
             (export main)))


### PR DESCRIPTION
Candidate PR for breaker's merge-request (ref d535410c9b4a568437dd948fe27a2c623fb7825d, lane corpus). Auto-merge armed; pr-sync's schedule-pass reaps on green.