### PR TITLE
corpus(14-effects): pin the BARE-param escaping-closure decline (annotated-param twin folds) — a newly-found closure-capture-escape completeness gap

### DIFF
--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -5709,6 +5709,7 @@ pass	α-equivalence handles nesting and distinguishes a bound variable from a sa
 todo	SUM ARG + LIST RESULT declines cleanly (Option arg, List result)
 todo	Set.of over runtime lists at two different element types declines pending the recursive-generic tie
 todo	Set.to-list orders float-carrying sums discriminant-first then by float payload
+todo	a BARE-param escaping closure capturing a handled value declines cleanly (annotated-param twin folds)
 todo	a BLOCK-wrapped branch perform in a MATCH-SCRUTINEE declines cleanly (adv-69 g3 sub-face)
 todo	a BLOCK-wrapped branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3 sub-face)
 todo	a BLOCK-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, not a silent miscompile)

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5722,6 +5722,7 @@ pass	α-equivalence (aconv) recognizes (λx.x) and (λy.y) as the same term up t
 pass	α-equivalence handles nesting and distinguishes a bound variable from a same-numbered free variable
 todo	Set.of over runtime lists at two different element types declines pending the recursive-generic tie
 todo	Type is a first-class value
+todo	a BARE-param escaping closure capturing a handled value declines cleanly (annotated-param twin folds)
 todo	a BLOCK-wrapped branch perform in a MATCH-SCRUTINEE declines cleanly (adv-69 g3 sub-face)
 todo	a BLOCK-wrapped branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3 sub-face)
 todo	a BLOCK-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, not a silent miscompile)

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5625,6 +5625,7 @@ todo	a @param value SEEDS an in-program handler's state
 todo	a @param value crosses into a closure capture and applies
 todo	a @param value drives a CHAMP map lookup as the KEY
 todo	a @param value sizes a guest-built HEAP structure
+todo	a BARE-param escaping closure capturing a handled value declines cleanly (annotated-param twin folds)
 todo	a BLOCK-wrapped branch perform in a MATCH-SCRUTINEE declines cleanly (adv-69 g3 sub-face)
 todo	a BLOCK-wrapped branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3 sub-face)
 todo	a BLOCK-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, not a silent miscompile)

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -2160,6 +2160,27 @@
   (call   main (: 7 Int64))
   (output (: 17 Int64)))
 
+(case "a BARE-param escaping closure capturing a handled value declines cleanly (annotated-param twin folds)"
+  (doc    "The BARE-parameter twin of the escaping-closure-captures-handled-value case above (v-effects
+           self-probe 2026-08-04). The SAME sound shape — a closure capturing a `let`-bound in-extent perform
+           result `v`, escaping the handle, applied outside — but the closure's parameter is BARE `(fn (x) (+
+           x v))` instead of annotated `(fn ((: x Int64)) …)`. The annotated twin (the case above) FOLDS to
+           17; the bare-param version DECLINES with `parameter reference has no local slot` (select.rs:10382,
+           the Core::Param no-slot arm) on all 3 backends. A CLEAN decline (compile-time, never a wrong value)
+           — the escaping-closure lift (`lambda_of`/env-snapshot) slots an ANNOTATED closure param but not a
+           BARE one when the closure captures a handler-computed value, so the bare param's reference reaches
+           emit un-slotted. A completeness gap in the closure-capture-escape family (NOT a miscompile): the
+           bare-param lift needs the same slot allocation the annotated path gets. Pinned as a decline-witness
+           to lock the bare-vs-annotated boundary; flips to 17 PASS when the bare-param escaping-closure lift
+           slots the param. Related to the sibling-closures-sharing-outer-capture-scope decline (same no-slot
+           arm, different trigger).")
+  (input  (do
+            (effect St (op get (-> Unit Int64)))
+            (def (main)
+              ((handle St 7 ((get (u) s (resume s s))) (let ((v (St.get))) (fn (x) (+ x v)))) 10))
+            (export main)))
+  (call   main) (output (: 17 Int64)))
+
 (case "TWO performs in an if condition both fold on the strict-first spine"
   (input  (do
             (effect Amb (op flip (-> Unit Int64)))


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref fbe4fb204, lane baseline). Auto-merge armed; pr-sync's schedule-pass reaps on green.