### PR TITLE
cdz-agent-daemon: wire the admin control interface into the daemon + fix the #1971 socket-reclaim NotFound race

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -351,6 +351,10 @@ jobs:
           # (unlike the sibling cdz-kernel live-exec, whose subprocess spawn works on any runner). The default
           # build stays hermetic; the live transports are exercised where egress exists, not in this job.
           cargo clippy --all-targets --features live-net -- -D warnings
+          # `admin,live-net` together: the cdz-agent-daemon bin's live control-plane wiring (admin socket +
+          # the real executor set) only compiles under BOTH — lint it so that path can't rot. Lint-only for
+          # the same live-net egress reason.
+          cargo clippy --all-targets --features admin,live-net -- -D warnings
 
   rcdzc-wasm:
     # The Cadenza COMPILER as a WASM artifact (implementation/seed/crates/rcdzc-wasm, v-agent-harness

--- a/implementation/seed/crates/cdz-agent-host/Cargo.toml
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.toml
@@ -44,7 +44,7 @@ live-net = ["dep:reqwest", "dep:aws-config", "dep:aws-sdk-bedrockruntime"]
 # is feature-gated. It enables tokio's `net` feature (for `UnixListener`/`UnixStream`) + `io-util` (the
 # `AsyncReadExt`/`AsyncWriteExt` the frame read/write use). Local IPC only — a Unix socket is not network
 # egress, so this is not the same concern as `live-net`; gating it keeps the default build listener-free.
-admin = ["tokio/net", "tokio/io-util"]
+admin = ["tokio/net", "tokio/io-util", "tokio/signal"]
 
 [dependencies]
 # The kernel whose Executor/Authorize traits + effect/event types we implement. Path dep across the

--- a/implementation/seed/crates/cdz-agent-host/src/admin_socket.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/admin_socket.rs
@@ -149,7 +149,15 @@ fn reclaim_dead_socket_then_bind(path: &Path) -> io::Result<UnixListener> {
         // Any other connect error is ambiguous — fail safe rather than risk clobbering a live socket.
         Err(e) => return Err(e),
     }
-    std::fs::remove_file(path)?;
+    // Unlink the dead socket, then rebind. IGNORE a NotFound here (#1971 review): the connect NotFound arm
+    // above, or a TOCTOU where another process unlinked between symlink_metadata and now, means the path is
+    // already gone — that's a RECOVERABLE state (bind will succeed on the free path), so a NotFound from
+    // remove_file must NOT abort the rebind. Any other remove error is real and propagates.
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
     UnixListener::bind(path)
 }
 

--- a/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
@@ -2,20 +2,22 @@
 //!
 //! Boots entirely from ONE TOML config file whose path is the SOLE cli argument (operator directive: "set
 //! the entire thing up via config and not from cli args; the only arg I want is the path to the config").
-//! The config ([`DaemonConfig`](cdz_agent_host::DaemonConfig)) selects the INFRASTRUCTURE — the durable-log backend, observability
-//! (s2n-quic-dc-metrics), and effect-retry policy. Sessions are NOT listed in the config: the daemon boots
-//! its infrastructure + an empty session registry, and sessions are INSTALLED at runtime (the install
-//! mechanism — control interface vs a spawn/supervision path — is the next slice, pending the operator's
-//! steer; this slice is the no-regret INFRA-BOOT half every answer needs).
+//! The config ([`DaemonConfig`](cdz_agent_host::DaemonConfig)) selects the INFRASTRUCTURE — the durable-log
+//! backend, observability (s2n-quic-dc-metrics), effect-retry policy, and the admin control interface.
+//! Sessions are NOT listed in the config: the daemon boots its infrastructure + an EMPTY session registry,
+//! and sessions are INSTALLED at runtime through the ADMIN CONTROL INTERFACE — when `[admin].enabled`, the
+//! daemon binds a local Unix socket and serves admin commands (install / list / status / stop) concurrently
+//! with the host loop, ctrl-c ending both. That socket is the operator's "communicate with the daemon +
+//! send it commands as admin" path.
 //!
 //! ```text
-//! cargo run --bin cdz-agent-daemon --features live-net -- /etc/cdz/daemon.toml
+//! cargo run --bin cdz-agent-daemon --features admin,live-net -- /etc/cdz/daemon.toml
 //! ```
 //!
-//! The live wiring (`live_executor_set` → the real Bedrock/HTTP transports) is behind `live-net`; the
-//! default build compiles a no-op main so the bin target always has a main + the hermetic gate never pulls
-//! the network tree. Config parsing itself is always-on (it's infra-core), so a config-path smoke test runs
-//! without live-net.
+//! The live wiring (`live_executor_set` → the real Bedrock/HTTP transports) is behind `live-net`, and the
+//! admin socket behind `admin`; the default build compiles a no-op main so the bin target always has a main
+//! (and the hermetic gate never pulls the network tree). Config parsing itself is always-on (it's
+//! infra-core), so a config-path smoke test runs without either feature.
 
 #[cfg(not(feature = "live-net"))]
 fn main() {
@@ -29,7 +31,11 @@ fn main() {
 #[cfg(feature = "live-net")]
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> std::process::ExitCode {
-    use cdz_agent_host::{AgentHost, AsyncAgentHost, DaemonConfig};
+    use cdz_agent_host::DaemonConfig;
+    // AgentHost/AsyncAgentHost are used only by the admin control-interface block below (the sole consumer
+    // of the host loop today); import them there so a `live-net`-without-`admin` build has no unused import.
+    #[cfg(feature = "admin")]
+    use cdz_agent_host::{AgentHost, AsyncAgentHost};
 
     // The SOLE cli arg is the config path.
     let mut args = std::env::args().skip(1);
@@ -66,23 +72,77 @@ async fn main() -> std::process::ExitCode {
         }
     };
 
-    // Boot the async multi-session loop over an EMPTY registry — sessions are installed at runtime (the
-    // install mechanism is the next slice). The daemon runs until shutdown (ctrl-c wiring lands with the
-    // control interface); with no sessions + no held inbox sender the loop returns immediately today, which
-    // is the honest current behavior: "the infra boots; nothing is installed yet."
-    let host = AsyncAgentHost::new(AgentHost::new());
-    let (_shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
-    // Drop our inbox sender so the loop isn't held open by us; a real control interface will hold one to
-    // feed install/inbound messages.
-    drop(host.inbox());
-    match host.run_with_wall_clock(shutdown_rx).await {
-        Ok(_registry) => {
-            eprintln!("cdz-agent-daemon: shut down cleanly.");
-            std::process::ExitCode::SUCCESS
-        }
-        Err(e) => {
-            eprintln!("cdz-agent-daemon: host loop failed: {e:?}");
-            std::process::ExitCode::from(1)
-        }
+    // The admin CONTROL INTERFACE is what makes this a live control plane: when `[admin].enabled` (and the
+    // `admin` feature is compiled), boot the async multi-session loop over an EMPTY registry, bind the Unix
+    // socket, and serve it CONCURRENTLY with the loop — ctrl-c drives a graceful shutdown of both. Sessions
+    // are INSTALLED at runtime through that socket. Without an active control interface the loop would have
+    // no producer to serve, so there's nothing to run.
+    //
+    // The admin authorizer is the trusted-local-admin allowlist: the socket is owner-only (0o600), so every
+    // caller is the daemon's owner, and the allowlist grants that principal the v0 admin actions (a finer
+    // Cedar policy is a later slice).
+    #[cfg(feature = "admin")]
+    if config.admin.enabled {
+        let Some(socket_path) = config.admin.socket.clone() else {
+            // validate() guarantees a socket path when enabled; defend anyway rather than panic.
+            eprintln!("cdz-agent-daemon: [admin] enabled but no socket path — aborting");
+            return std::process::ExitCode::from(1);
+        };
+        let socket = match cdz_agent_host::AdminSocket::bind(&socket_path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("cdz-agent-daemon: could not bind admin socket {socket_path}: {e}");
+                return std::process::ExitCode::from(1);
+            }
+        };
+        eprintln!("cdz-agent-daemon: admin control interface listening on {socket_path}");
+
+        let host = AsyncAgentHost::new(AgentHost::new()).with_admin_authz(Box::new(
+            cdz_agent_host::AllowList::allow_all_for_local_admin(),
+        ));
+        // Drop our inbox sender so an idle inbox doesn't hold the loop open; the admin socket's AdminChannel
+        // is what keeps the loop alive as a control plane.
+        drop(host.inbox());
+        let admin_channel = host.admin_channel();
+
+        let (loop_sd_tx, loop_sd_rx) = tokio::sync::oneshot::channel::<()>();
+        let (sock_sd_tx, sock_sd_rx) = tokio::sync::oneshot::channel::<()>();
+        // ctrl-c → shut down BOTH the host loop and the socket server.
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                eprintln!("cdz-agent-daemon: ctrl-c received — shutting down");
+                let _ = loop_sd_tx.send(());
+                let _ = sock_sd_tx.send(());
+            }
+        });
+        // Run the loop + the socket server together: the loop owns the !Send registry, the socket task is
+        // the Send producer feeding it. Both end on ctrl-c.
+        let (loop_result, ()) = tokio::join!(
+            host.run_with_wall_clock(loop_sd_rx),
+            socket.serve(admin_channel, sock_sd_rx)
+        );
+        return match loop_result {
+            Ok(_registry) => {
+                eprintln!("cdz-agent-daemon: shut down cleanly.");
+                std::process::ExitCode::SUCCESS
+            }
+            Err(e) => {
+                eprintln!("cdz-agent-daemon: host loop failed: {e:?}");
+                std::process::ExitCode::from(1)
+            }
+        };
     }
+
+    #[cfg(not(feature = "admin"))]
+    if config.admin.enabled {
+        eprintln!(
+            "cdz-agent-daemon: [admin] enabled in config but this build lacks the `admin` feature — \
+             no control interface. Rebuild with `--features admin` (or `admin,live-net`)."
+        );
+    }
+
+    // No active control interface (admin disabled, or the `admin` feature isn't compiled). The host loop
+    // would have no producer to serve, so there's nothing to run — report + exit cleanly.
+    eprintln!("cdz-agent-daemon: no active control interface — nothing to serve; exiting.");
+    std::process::ExitCode::SUCCESS
 }


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref d134c639a, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.