### PR TITLE
nix(flake): lintCheck — export CARGO_NET_OFFLINE=true (match siblings)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -133,6 +133,11 @@
               runHook preBuild
               export HOME="$TMPDIR/home"
               export CARGO_HOME="$TMPDIR/cargo"
+              # Network is blocked by CARGO_NET_OFFLINE (belt-and-suspenders with the vendored source
+              # below) — matches the sibling cargo-in-nix derivations (rcdzcWasm, mkStripComponent), so
+              # if cargo's source resolution ever changes the lint fails LOUDLY offline instead of
+              # attempting a fetch (github-liaison #1982).
+              export CARGO_NET_OFFLINE=true
               mkdir -p "$HOME" "$CARGO_HOME"
               cat > "$CARGO_HOME/config.toml" <<EOF
               [source.crates-io]


### PR DESCRIPTION
Candidate PR for v-nix's merge-request (ref 53b9a8a57, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.