### PR TITLE
cdz-agent-host: metric SURFACE — hermetic HostMetrics counters on the host boundary (produce-before-export)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -320,6 +320,10 @@ pub struct AgentHost {
     /// replay-copy at spawn and folds its appends back after each turn — no shared handle. (Type:
     /// [`cdz_kernel::name_store::NameStore`].)
     canonical: Option<cdz_kernel::name_store::NameStore>,
+    /// The host's metric surface — monotonic counters bumped at the session-lifecycle + per-turn boundaries
+    /// (spawn/remove/deliver). Hermetic (plain atomics, no metrics dep); read via [`AgentHost::metrics`] for
+    /// a status surface or the feature-gated exporter. `Default` = all-zero, so it needs no explicit init.
+    metrics: crate::metrics::HostMetrics,
 }
 
 /// A by-value copy of a canonical [`NameStore`](cdz_kernel::name_store::NameStore) for a freshly-spawned session — replays the canonical
@@ -340,6 +344,7 @@ impl AgentHost {
         AgentHost {
             sessions: HashMap::new(),
             canonical: None,
+            metrics: crate::metrics::HostMetrics::default(),
         }
     }
 
@@ -358,6 +363,7 @@ impl AgentHost {
         AgentHost {
             sessions: HashMap::new(),
             canonical: Some(canonical),
+            metrics: crate::metrics::HostMetrics::default(),
         }
     }
 
@@ -377,7 +383,13 @@ impl AgentHost {
             Some(canonical) => session.with_name_store(replay_of(canonical)),
             None => session,
         };
-        self.sessions.insert(id.clone(), session);
+        let replaced = self.sessions.insert(id.clone(), session).is_some();
+        self.metrics.record_session_installed();
+        // A spawn onto an existing id REPLACES (drops) the old session without a `remove` call — count that
+        // implicit drop as a removal too, so `sessions_live` (installed − removed) stays accurate.
+        if replaced {
+            self.metrics.record_session_removed();
+        }
         id
     }
 
@@ -396,8 +408,14 @@ impl AgentHost {
         body: EventBody,
         cause: Option<Hash>,
     ) -> Option<Result<(), KernelError>> {
-        let s = self.sessions.get_mut(id)?;
+        let Some(s) = self.sessions.get_mut(id) else {
+            // Addressed to no live session — a misrouted/late event. Count it distinctly from a delivered
+            // turn, then report "unknown" up (None) as before.
+            self.metrics.record_delivery_to_unknown_session();
+            return None;
+        };
         let outcome = s.deliver(body, cause).await;
+        self.metrics.record_turn(outcome.is_ok());
         // §4c v0.3 merge-back: after a SUCCESSFUL turn, fold this session's new name-store writes into the
         // canonical shared store so the next-spawned (or next-reconciled) session sees them. Idempotent — a
         // turn that wrote nothing re-merges as a no-op (the session's log is already a prefix of what it was
@@ -431,7 +449,11 @@ impl AgentHost {
     /// Remove a finished/closed session from the registry, returning it if present (so a caller can
     /// inspect its final state). A completed agent is dropped from the host this way.
     pub fn remove(&mut self, id: &SessionId) -> Option<HostedSession> {
-        self.sessions.remove(id)
+        let removed = self.sessions.remove(id);
+        if removed.is_some() {
+            self.metrics.record_session_removed();
+        }
+        removed
     }
 
     /// How many sessions are registered.
@@ -442,6 +464,12 @@ impl AgentHost {
     /// Is the registry empty (no running sessions)?
     pub fn is_empty(&self) -> bool {
         self.sessions.is_empty()
+    }
+
+    /// The host's live metric surface — read a [`snapshot`](crate::HostMetrics::snapshot) for a status query
+    /// or the feature-gated metrics exporter. The counters are bumped internally at spawn/remove/deliver.
+    pub fn metrics(&self) -> &crate::metrics::HostMetrics {
+        &self.metrics
     }
 
     /// Fire due timers across ALL registered sessions at `now_ms` (a host scheduler tick). Returns the
@@ -528,7 +556,7 @@ pub async fn live_executor_set() -> Result<CompositeExecutor, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ClockExecutor;
+    use crate::{ClockExecutor, HostMetricsSnapshot};
     use cdz_kernel::authz::Authorizer;
     use cdz_kernel::effect::{
         effect_ct, Capability, EffectKind, EffectRequest, Payload, ResourcePredicate, Timeliness,
@@ -719,6 +747,61 @@ mod tests {
         assert_eq!(host.len(), 1);
         // Removing an absent id is None, not a panic.
         assert!(host.remove(&SessionId::new("a")).is_none());
+    }
+
+    #[tokio::test]
+    async fn host_metrics_count_the_lifecycle_and_turn_boundaries() {
+        // The metric surface bumps at the host boundaries: spawn (install), deliver (turn ok/err +
+        // unknown-session), remove. Drive a real sequence and assert the snapshot.
+        let mut host = AgentHost::new();
+        assert_eq!(
+            host.metrics().snapshot(),
+            HostMetricsSnapshot::default(),
+            "a fresh host has zero metrics"
+        );
+
+        host.spawn(SessionId::new("a"), now_host());
+        host.spawn(SessionId::new("b"), now_host());
+        // A delivered turn to a known session (the `now` reducer completes Ok).
+        host.deliver(&SessionId::new("a"), inbound_go(), None).await;
+        // A delivery to an UNKNOWN id — counted distinctly, not as a turn.
+        host.deliver(&SessionId::new("ghost"), inbound_go(), None)
+            .await;
+        // Remove one.
+        host.remove(&SessionId::new("b"));
+
+        let s = host.metrics().snapshot();
+        assert_eq!(s.sessions_installed, 2);
+        assert_eq!(s.sessions_removed, 1);
+        assert_eq!(s.turns_delivered, 1, "only the known-session deliver");
+        assert_eq!(s.turns_ok, 1);
+        assert_eq!(s.turns_err, 0);
+        assert_eq!(
+            s.deliveries_to_unknown_session, 1,
+            "the ghost deliver counted as unknown, not a turn"
+        );
+        assert_eq!(s.sessions_live(), 1, "2 installed − 1 removed");
+    }
+
+    #[tokio::test]
+    async fn respawn_counts_the_replaced_session_as_removed_so_live_stays_accurate() {
+        // A spawn onto an existing id drops the old session without a remove() call; the surface counts that
+        // implicit drop so sessions_live (installed − removed) doesn't drift upward on restarts.
+        let mut host = AgentHost::new();
+        let id = SessionId::new("worker");
+        host.spawn(id.clone(), now_host());
+        host.spawn(id.clone(), now_host()); // restart — replaces
+        let s = host.metrics().snapshot();
+        assert_eq!(s.sessions_installed, 2);
+        assert_eq!(
+            s.sessions_removed, 1,
+            "the replaced session counted as removed"
+        );
+        assert_eq!(
+            s.sessions_live(),
+            1,
+            "one live session despite two installs"
+        );
     }
 
     #[tokio::test]

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -63,6 +63,7 @@ pub mod config;
 pub mod factory;
 pub mod host;
 pub mod http;
+pub mod metrics;
 pub mod model;
 pub mod retry;
 pub mod status;
@@ -94,6 +95,7 @@ pub use host::{AgentHost, HostedSession, SessionId};
 #[cfg(feature = "live-net")]
 pub use http::ReqwestHttpTransport;
 pub use http::{HttpExecutor, HttpMethod, HttpResponse, HttpTransport};
+pub use metrics::{HostMetrics, HostMetricsSnapshot};
 #[cfg(feature = "live-net")]
 pub use model::BedrockModelTransport;
 pub use model::{ModelExecutor, ModelTransport};

--- a/implementation/seed/crates/cdz-agent-host/src/metrics.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/metrics.rs
@@ -1,0 +1,165 @@
+//! The daemon's METRIC SURFACE — the counters a running host produces, so observability has something to
+//! export. (Operator directive: a real daemon with metrics. Concierge-sequenced: "produce metrics → then
+//! export" — this is the PRODUCE half; the s2n-quic-dc-metrics EXPORT half is a following, feature-gated
+//! slice that bridges this surface to a [`MetricsTarget`](crate::MetricsTarget) backend.)
+//!
+//! [`HostMetrics`] is a hermetic, crate-local set of monotonic counters — plain [`AtomicU64`]s, NO metrics
+//! dependency — so it lives in the DEFAULT build and the host loop increments it unconditionally (a counter
+//! bump is a `Relaxed` add, free enough to always run). The exporter reads a [`HostMetricsSnapshot`] and maps
+//! each counter onto the export backend's own metric type; nothing here knows about the backend.
+//!
+//! **Surface scope (v0): the HOST-BOUNDARY observable events** — session lifecycle + per-turn outcomes,
+//! which [`AgentHost`](crate::AgentHost) sees directly at `spawn`/`remove`/`deliver`. Per-EFFECT dispatch
+//! outcomes (ok / retryable / permanent, the [`crate::retry`] classification) happen DEEP in the kernel's
+//! deliver loop (folded into the session log, not visible at the host boundary), so counting them needs an
+//! executor-level reporting seam — a deliberate FOLLOW-UP slice, not faked here from data the host can't see.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// The daemon's live metric counters — monotonic, host-boundary events. Held BY VALUE on the
+/// [`AgentHost`](crate::AgentHost) (each counter is an [`AtomicU64`], so the struct is `Default` = all-zero
+/// and needs no separate init). Incremented on the host loop; read via [`snapshot`](Self::snapshot) for a
+/// status surface or the (feature-gated) metrics exporter. `Relaxed` ordering throughout — these are
+/// independent counters with no happens-before relationship to protect (the single-threaded host loop is the
+/// only writer; a snapshot reads a consistent-enough point-in-time, exact cross-counter atomicity is not a
+/// metric requirement).
+#[derive(Debug, Default)]
+pub struct HostMetrics {
+    /// Sessions installed into the registry (each successful [`AgentHost::spawn`](crate::AgentHost::spawn)).
+    sessions_installed: AtomicU64,
+    /// Sessions removed from the registry (each [`AgentHost::remove`](crate::AgentHost::remove) that found a
+    /// session — a completed/closed agent dropped from the host).
+    sessions_removed: AtomicU64,
+    /// Turns delivered to a KNOWN session (each [`AgentHost::deliver`](crate::AgentHost::deliver) that routed
+    /// to a live session, regardless of the turn's outcome). Equals `turns_ok + turns_err`.
+    turns_delivered: AtomicU64,
+    /// Turns that completed successfully (`deliver` returned `Ok`).
+    turns_ok: AtomicU64,
+    /// Turns that erred (`deliver` returned a `KernelError` — a fold/loop failure on that turn).
+    turns_err: AtomicU64,
+    /// Deliveries addressed to an UNKNOWN session id (routed to no session) — a misrouted/late event, worth
+    /// surfacing distinctly from a delivered turn.
+    deliveries_to_unknown_session: AtomicU64,
+}
+
+impl HostMetrics {
+    /// Record a session install (one successful `spawn`).
+    pub fn record_session_installed(&self) {
+        self.sessions_installed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a session removal (one `remove` that found a session).
+    pub fn record_session_removed(&self) {
+        self.sessions_removed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record one turn delivered to a known session, tagged by whether the turn succeeded. Bumps
+    /// `turns_delivered` plus exactly one of `turns_ok` / `turns_err`, so the ok+err split always sums to the
+    /// delivered total.
+    pub fn record_turn(&self, ok: bool) {
+        self.turns_delivered.fetch_add(1, Ordering::Relaxed);
+        if ok {
+            self.turns_ok.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.turns_err.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Record a delivery addressed to an unknown session id (routed nowhere).
+    pub fn record_delivery_to_unknown_session(&self) {
+        self.deliveries_to_unknown_session
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// A point-in-time copy of every counter — plain `u64`s the status surface / metrics exporter reads
+    /// without touching the atomics directly. (Not cross-counter atomic; see the type-level note.)
+    pub fn snapshot(&self) -> HostMetricsSnapshot {
+        HostMetricsSnapshot {
+            sessions_installed: self.sessions_installed.load(Ordering::Relaxed),
+            sessions_removed: self.sessions_removed.load(Ordering::Relaxed),
+            turns_delivered: self.turns_delivered.load(Ordering::Relaxed),
+            turns_ok: self.turns_ok.load(Ordering::Relaxed),
+            turns_err: self.turns_err.load(Ordering::Relaxed),
+            deliveries_to_unknown_session: self
+                .deliveries_to_unknown_session
+                .load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// A plain-value snapshot of [`HostMetrics`] — what a status query returns and the (feature-gated) exporter
+/// maps onto its backend's metric types. Cloneable/comparable so a test asserts exact counts and the exporter
+/// can diff successive snapshots (deltas) if it emits rates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct HostMetricsSnapshot {
+    /// Sessions installed (cumulative).
+    pub sessions_installed: u64,
+    /// Sessions removed (cumulative).
+    pub sessions_removed: u64,
+    /// Turns delivered to a known session (cumulative; equals `turns_ok + turns_err`).
+    pub turns_delivered: u64,
+    /// Turns that completed `Ok`.
+    pub turns_ok: u64,
+    /// Turns that returned a `KernelError`.
+    pub turns_err: u64,
+    /// Deliveries addressed to an unknown session id.
+    pub deliveries_to_unknown_session: u64,
+}
+
+impl HostMetricsSnapshot {
+    /// Sessions currently live per this snapshot = installed − removed. Saturating (never underflows) —
+    /// a defensive total answer even if a snapshot straddles a remove-without-prior-install (which the host
+    /// loop's ordering makes impossible in practice, but a saturating diff needs no invariant to be safe).
+    pub fn sessions_live(&self) -> u64 {
+        self.sessions_installed
+            .saturating_sub(self.sessions_removed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_fresh_metrics_set_is_all_zero() {
+        let m = HostMetrics::default();
+        assert_eq!(m.snapshot(), HostMetricsSnapshot::default());
+        assert_eq!(m.snapshot().sessions_live(), 0);
+    }
+
+    #[test]
+    fn counters_accumulate_and_snapshot_reflects_them() {
+        let m = HostMetrics::default();
+        m.record_session_installed();
+        m.record_session_installed();
+        m.record_session_removed();
+        m.record_turn(true);
+        m.record_turn(true);
+        m.record_turn(false);
+        m.record_delivery_to_unknown_session();
+
+        let s = m.snapshot();
+        assert_eq!(s.sessions_installed, 2);
+        assert_eq!(s.sessions_removed, 1);
+        assert_eq!(s.turns_delivered, 3, "delivered = ok + err");
+        assert_eq!(s.turns_ok, 2);
+        assert_eq!(s.turns_err, 1);
+        assert_eq!(s.deliveries_to_unknown_session, 1);
+        // The ok/err split always sums to the delivered total.
+        assert_eq!(s.turns_ok + s.turns_err, s.turns_delivered);
+        // Live = installed − removed.
+        assert_eq!(s.sessions_live(), 1);
+    }
+
+    #[test]
+    fn sessions_live_saturates_never_underflows() {
+        // A snapshot with more removals than installs (impossible in the real host ordering, but the diff
+        // must be total) pins at 0, not a wrapped huge number.
+        let s = HostMetricsSnapshot {
+            sessions_installed: 1,
+            sessions_removed: 3,
+            ..HostMetricsSnapshot::default()
+        };
+        assert_eq!(s.sessions_live(), 0);
+    }
+}


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 6b6201201, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.