### PR TITLE
cdz-agent-host: per-effect metric surface — EffectMetrics + MeteredExecutor decorator (ok/retryable/permanent/timed-out)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/factory.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/factory.rs
@@ -21,10 +21,15 @@
 
 use crate::admin::{InstallSpec, SessionFactory};
 use crate::host::HostedSession;
+use crate::metrics::EffectMetrics;
 use cdz_kernel::authz::Authorize;
 use cdz_kernel::blob::BlobStore;
-use cdz_kernel::executor::CompositeExecutor;
+use cdz_kernel::effect::EffectRequest;
+use cdz_kernel::event::EffectOutcome;
+use cdz_kernel::executor::{CompositeExecutor, Executor};
+use cdz_kernel::hash::Hash;
 use cdz_kernel::wasm_host::AsyncComponentReducer;
+use std::sync::Arc;
 
 /// Builds a per-session executor set (the effects a freshly-installed session may perform). Called ONCE per
 /// install so each session gets its OWN [`CompositeExecutor`] — the kernel's `Executor::perform` takes
@@ -46,6 +51,49 @@ pub trait ExecutorSetBuilder {
 impl<F: Fn() -> CompositeExecutor> ExecutorSetBuilder for F {
     async fn build(&self) -> CompositeExecutor {
         self()
+    }
+}
+
+/// A metering DECORATOR over an [`Executor`] — the executor-level seam for the PER-EFFECT half of the
+/// metric surface (see [`crate::metrics::EffectMetrics`]). It wraps a real executor and, on every
+/// `perform`, dispatches to the inner one and then tallies the outcome into a shared [`EffectMetrics`]:
+/// `Ok` → `record_ok`, `Err(reason)` → `record_err(classify(reason))` (the same [`crate::retry`]
+/// classification a supervisor branches on). Transparent otherwise — the outcome is returned unchanged and
+/// `handles_family` forwards, so wrapping is invisible to the kernel.
+///
+/// This is why the per-effect counts need no kernel change: every dispatch already flows through
+/// `Executor::perform`, so metering at the executor boundary (where the outcome is produced) captures it.
+/// The daemon wraps each real leaf executor with one of these sharing ONE `Arc<EffectMetrics>`, so a
+/// session's ok/retryable/permanent tallies aggregate across all its effect families.
+pub struct MeteredExecutor {
+    inner: Box<dyn Executor>,
+    metrics: Arc<EffectMetrics>,
+}
+
+impl MeteredExecutor {
+    /// Wrap `inner`, tallying each outcome into `metrics`. Boxes ready to register with
+    /// [`CompositeExecutor::with_effect`].
+    pub fn new(inner: Box<dyn Executor>, metrics: Arc<EffectMetrics>) -> Self {
+        MeteredExecutor { inner, metrics }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl Executor for MeteredExecutor {
+    async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
+        let outcome = self.inner.perform(req, idempotency_key).await;
+        match &outcome {
+            EffectOutcome::Ok(_) => self.metrics.record_ok(),
+            EffectOutcome::Err(reason) => self.metrics.record_err(crate::retry::classify(reason)),
+            EffectOutcome::TimedOut => self.metrics.record_timed_out(),
+        }
+        outcome
+    }
+
+    /// Forward the mechanism probe so wrapping doesn't hide the inner executor's served family from the
+    /// capability manifest (a wrapped executor must still report what it serves).
+    fn handles_family(&self, family: &str) -> bool {
+        self.inner.handles_family(family)
     }
 }
 
@@ -450,5 +498,84 @@ mod tests {
             "{entries:?}"
         );
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A stub executor that returns a SCRIPTED sequence of outcomes (one per `perform`), for exercising the
+    /// metering decorator's classification without a real transport.
+    struct ScriptedExecutor {
+        outcomes: std::cell::RefCell<std::collections::VecDeque<EffectOutcome>>,
+    }
+    #[async_trait::async_trait(?Send)]
+    impl Executor for ScriptedExecutor {
+        async fn perform(&mut self, _req: &EffectRequest, _key: Hash) -> EffectOutcome {
+            self.outcomes
+                .borrow_mut()
+                .pop_front()
+                .expect("scripted outcome available")
+        }
+        fn handles_family(&self, family: &str) -> bool {
+            family == "scripted"
+        }
+    }
+
+    #[tokio::test]
+    async fn metered_executor_tallies_outcomes_and_passes_them_through() {
+        use crate::retry::{permanent, retryable};
+        use cdz_kernel::effect::{EffectKind, Payload, Timeliness};
+
+        // Script Ok, a retryable Err, a permanent Err, an UNPREFIXED Err (fail-closed → permanent), and a
+        // TimedOut (its own counter, not an Err).
+        let scripted = ScriptedExecutor {
+            outcomes: std::cell::RefCell::new(
+                vec![
+                    EffectOutcome::Ok(Some(Payload::Inline(b"ok".to_vec().into()))),
+                    EffectOutcome::Err(retryable("bedrock throttled (429)")),
+                    EffectOutcome::Err(permanent("bad request (400)")),
+                    EffectOutcome::Err("no token here".to_string()),
+                    EffectOutcome::TimedOut,
+                ]
+                .into(),
+            ),
+        };
+        let metrics = Arc::new(EffectMetrics::default());
+        let mut metered = MeteredExecutor::new(Box::new(scripted), metrics.clone());
+
+        // handles_family forwards (wrapping doesn't hide the served family from the manifest).
+        assert!(metered.handles_family("scripted"));
+        assert!(!metered.handles_family("other"));
+
+        let req = EffectRequest::new(
+            EffectKind::Model,
+            "m".to_string(),
+            None,
+            Timeliness::Interactive,
+        );
+        // Each outcome passes THROUGH unchanged…
+        assert!(matches!(
+            metered.perform(&req, Hash::of(b"k")).await,
+            EffectOutcome::Ok(_)
+        ));
+        assert!(matches!(
+            metered.perform(&req, Hash::of(b"k")).await,
+            EffectOutcome::Err(_)
+        ));
+        metered.perform(&req, Hash::of(b"k")).await;
+        metered.perform(&req, Hash::of(b"k")).await;
+        assert!(matches!(
+            metered.perform(&req, Hash::of(b"k")).await,
+            EffectOutcome::TimedOut
+        ));
+
+        // …and the shared EffectMetrics tallied the ok/retryable/permanent/timed-out split (the unprefixed
+        // Err classified permanent, fail-closed; TimedOut counted on its own).
+        let s = metrics.snapshot();
+        assert_eq!(s.effects_ok, 1);
+        assert_eq!(s.effects_retryable_err, 1);
+        assert_eq!(
+            s.effects_permanent_err, 2,
+            "explicit permanent + unprefixed"
+        );
+        assert_eq!(s.effects_timed_out, 1);
+        assert_eq!(s.effects_total(), 5);
     }
 }

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -87,7 +87,7 @@ pub use config::{
 pub use factory::LiveExecutorSet;
 pub use factory::{
     AuthorizerBuilder, ComponentSessionFactory, ExecutorSetBuilder, FileLogSinkBuilder,
-    LogSinkBuilder,
+    LogSinkBuilder, MeteredExecutor,
 };
 #[cfg(feature = "live-net")]
 pub use host::live_executor_set;
@@ -95,7 +95,7 @@ pub use host::{AgentHost, HostedSession, SessionId};
 #[cfg(feature = "live-net")]
 pub use http::ReqwestHttpTransport;
 pub use http::{HttpExecutor, HttpMethod, HttpResponse, HttpTransport};
-pub use metrics::{HostMetrics, HostMetricsSnapshot};
+pub use metrics::{EffectMetrics, EffectMetricsSnapshot, HostMetrics, HostMetricsSnapshot};
 #[cfg(feature = "live-net")]
 pub use model::BedrockModelTransport;
 pub use model::{ModelExecutor, ModelTransport};

--- a/implementation/seed/crates/cdz-agent-host/src/metrics.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/metrics.rs
@@ -8,11 +8,15 @@
 //! bump is a `Relaxed` add, free enough to always run). The exporter reads a [`HostMetricsSnapshot`] and maps
 //! each counter onto the export backend's own metric type; nothing here knows about the backend.
 //!
-//! **Surface scope (v0): the HOST-BOUNDARY observable events** — session lifecycle + per-turn outcomes,
-//! which [`AgentHost`](crate::AgentHost) sees directly at `spawn`/`remove`/`deliver`. Per-EFFECT dispatch
-//! outcomes (ok / retryable / permanent, the [`crate::retry`] classification) happen DEEP in the kernel's
-//! deliver loop (folded into the session log, not visible at the host boundary), so counting them needs an
-//! executor-level reporting seam — a deliberate FOLLOW-UP slice, not faked here from data the host can't see.
+//! **Surface, two halves:**
+//! - [`HostMetrics`] — HOST-BOUNDARY events (session lifecycle + per-turn outcomes) that
+//!   [`AgentHost`](crate::AgentHost) sees directly at `spawn`/`remove`/`deliver`.
+//! - [`EffectMetrics`] — PER-EFFECT dispatch outcomes (ok / retryable-err / permanent-err). These happen
+//!   DEEP in the kernel's deliver loop, not at the host boundary, so they're captured by a metering
+//!   [`MeteredExecutor`](crate::factory::MeteredExecutor) decorator that wraps each real executor at
+//!   registration and classifies every [`EffectOutcome`](cdz_kernel::event::EffectOutcome) via
+//!   [`crate::retry::classify`] — no kernel change, no faked data. `EffectMetrics` is `Arc`-shared so all of
+//!   a session's per-family decorators tally into one set the exporter reads.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -116,6 +120,89 @@ impl HostMetricsSnapshot {
     }
 }
 
+/// Per-EFFECT dispatch counters — how the daemon's effects RESOLVED, split by the
+/// [`retry`](crate::retry) classification of a failure. Fed by the
+/// [`MeteredExecutor`](crate::factory::MeteredExecutor) decorator that wraps each real executor: on every
+/// `perform`, it bumps exactly one of ok / retryable-err / permanent-err from the outcome. `Arc`-shared
+/// (all of a session's per-family decorators tally into ONE set), so it's behind a shared reference and its
+/// methods take `&self` (the atomics give interior mutability).
+///
+/// The retryable/permanent split is exactly what a supervision/retry driver acts on, so surfacing it as a
+/// metric lets an operator SEE the transient-vs-fatal failure mix (a rising retryable rate = a flaky
+/// upstream; a permanent spike = a misconfig/bad request) before the retry MECHANISM itself lands.
+#[derive(Debug, Default)]
+pub struct EffectMetrics {
+    /// Effects that resolved `Ok`.
+    effects_ok: AtomicU64,
+    /// Effects that resolved `Err` with a `RETRYABLE:`-classified reason (a transient failure).
+    effects_retryable_err: AtomicU64,
+    /// Effects that resolved `Err` with a PERMANENT reason (incl. the fail-closed unprefixed default).
+    effects_permanent_err: AtomicU64,
+    /// Effects the kernel CANCELLED on deadline (`EffectOutcome::TimedOut`, §16c-S4) — a distinct failure
+    /// mode from a classified `Err` (a hung effect that never returned a result), counted on its own.
+    effects_timed_out: AtomicU64,
+}
+
+impl EffectMetrics {
+    /// Record one successful effect dispatch.
+    pub fn record_ok(&self) {
+        self.effects_ok.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record one FAILED effect dispatch, split by its [`retry`](crate::retry) classification. The metering
+    /// decorator classifies the `Err` reason with [`crate::retry::classify`] and passes the result here, so
+    /// the retryable/permanent split matches exactly what a supervisor would branch on (fail-closed: an
+    /// unprefixed reason classifies Permanent).
+    pub fn record_err(&self, retryability: crate::retry::Retryability) {
+        match retryability {
+            crate::retry::Retryability::Retryable => {
+                self.effects_retryable_err.fetch_add(1, Ordering::Relaxed);
+            }
+            crate::retry::Retryability::Permanent => {
+                self.effects_permanent_err.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Record one effect the kernel cancelled on deadline (`EffectOutcome::TimedOut`).
+    pub fn record_timed_out(&self) {
+        self.effects_timed_out.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// A point-in-time copy of every effect counter.
+    pub fn snapshot(&self) -> EffectMetricsSnapshot {
+        EffectMetricsSnapshot {
+            effects_ok: self.effects_ok.load(Ordering::Relaxed),
+            effects_retryable_err: self.effects_retryable_err.load(Ordering::Relaxed),
+            effects_permanent_err: self.effects_permanent_err.load(Ordering::Relaxed),
+            effects_timed_out: self.effects_timed_out.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// A plain-value snapshot of [`EffectMetrics`] — what the status surface / exporter reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct EffectMetricsSnapshot {
+    /// Effects that resolved `Ok` (cumulative).
+    pub effects_ok: u64,
+    /// Effects that failed with a retryable (transient) reason (cumulative).
+    pub effects_retryable_err: u64,
+    /// Effects that failed with a permanent reason (cumulative; includes the unprefixed fail-closed default).
+    pub effects_permanent_err: u64,
+    /// Effects the kernel cancelled on deadline (cumulative).
+    pub effects_timed_out: u64,
+}
+
+impl EffectMetricsSnapshot {
+    /// Total effects dispatched = ok + retryable-err + permanent-err + timed-out.
+    pub fn effects_total(&self) -> u64 {
+        self.effects_ok
+            .saturating_add(self.effects_retryable_err)
+            .saturating_add(self.effects_permanent_err)
+            .saturating_add(self.effects_timed_out)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -161,5 +248,30 @@ mod tests {
             ..HostMetricsSnapshot::default()
         };
         assert_eq!(s.sessions_live(), 0);
+    }
+
+    #[test]
+    fn effect_metrics_split_ok_retryable_permanent() {
+        use crate::retry::Retryability;
+        let m = EffectMetrics::default();
+        assert_eq!(m.snapshot(), EffectMetricsSnapshot::default());
+
+        m.record_ok();
+        m.record_ok();
+        m.record_err(Retryability::Retryable);
+        m.record_err(Retryability::Permanent);
+        m.record_err(Retryability::Permanent);
+        m.record_timed_out();
+
+        let s = m.snapshot();
+        assert_eq!(s.effects_ok, 2);
+        assert_eq!(s.effects_retryable_err, 1);
+        assert_eq!(s.effects_permanent_err, 2);
+        assert_eq!(s.effects_timed_out, 1);
+        assert_eq!(
+            s.effects_total(),
+            6,
+            "total = ok + retryable + permanent + timed-out"
+        );
     }
 }


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 8ff674950, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.