### PR TITLE
rcdzc(effects): cite corpus CASE-NAMES not line numbers in abort-fold comments (#2010 review, LOW doc-maintainability)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -2462,7 +2462,8 @@ pub fn reduce_handle(
         //
         // GATED to `rewritten` being a `do`-FORM. This is what SEPARATES the sound do-shape from the STILL-
         // AMBIGUOUS strict-operand shape (`(+ (A.tick) (B.bail 99))` → `rewritten` `(+ (A.tick) 99)`, a `+`
-        // form): a bare-abort `+` case that is CORRECT-because-UNOBSERVED (14-effects:1251 `(+ (A.a) (+ (B.b)
+        // form): a bare-abort `+` case that is CORRECT-because-UNOBSERVED (the corpus case "an abortive
+        // perform under THREE nested handlers abandons the two resumptive frames above it", `(+ (A.a) (+ (B.b)
         // (Bail.bail 99)))` = 99) is indistinguishable at THIS (inner) handler from the miscompiling one (the
         // difference lives in the OUTER continuation, invisible here) — so the strict-op lift is a SEPARATE
         // increment. Only the do-form, where the do-arm already produced the sound for-effect sequencing, is
@@ -5273,8 +5274,9 @@ fn thread_bounded(
             // 99)` — the SAME shape the do-arm produces, which the landed do-shape fold in reduce_handle then
             // preserves (the outer fold discharges the prefix, advancing the outer state, before the value).
             // Done in `thread` (not reduce_handle) because only here can we preserve UNCONDITIONALLY: sound for
-            // BOTH the observed miscompile (→110) AND the correct-because-unobserved 14-eff:1251 `(+ (A.a) (+
-            // (B.b) (Bail.bail 99)))` (→ nested `(do (A.a) (do (B.b) 99))` = 99 still, the prefix runs
+            // BOTH the observed miscompile (→110) AND the correct-because-unobserved deep-nested case ("a
+            // strict-operand abort in a DEEP-nested handler stack keeps its 99 when the advances are
+            // UNOBSERVED") `(+ (A.a) (+ (B.b) (Bail.bail 99)))` (→ nested `(do (A.a) (do (B.b) 99))` = 99 still, the prefix runs
             // unobserved). `body_reaches_foreign_perform` reads the ORIGINAL operand `a` (parented — no orphan
             // resolve-pin poison, and equivalent to the rewrite: a foreign perform is never folded by this ctx,
             // a discharged one is not foreign). Only lifts when a foreign operand actually PRECEDED the abort

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -66510,7 +66510,8 @@ mod stage1 {
         // 109. Fixed: thread's Apply arm LIFTS the pre-abort foreign operand into a for-effect `do` prefix
         // `(do (A.tick) 99)` — the shape the landed do-shape fold then preserves. Done in `thread` (not
         // reduce_handle) so it preserves UNCONDITIONALLY: sound for the observed case (→110) AND the unobserved
-        // deep-nested 1251 (stays 99 — the prefix runs for effect only).
+        // deep-nested case (the corpus "a strict-operand abort in a DEEP-nested handler stack keeps its 99
+        // when the advances are UNOBSERVED" — stays 99, the prefix runs for effect only).
         let src = "(do (effect A (op tick (-> Unit Int64)) (op get (-> Unit Int64))) \
                    (effect B (op bail (-> Int64 Int64))) \
                    (def (main) \


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 9e4ff4a9f, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.