### PR TITLE
rcdzc(effects): FIX do-arm forcing a DEAD post-abort suffix — break the do-item loop on a non-final abort (#2002/#2014 review follow-on)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -4658,9 +4658,22 @@ fn thread_bounded(
             // dropped — byte-identical to before for the single-handler-depth surface.
             let items_len = items.len();
             let mut kept: Vec<StructId> = Vec::new();
+            let abort_before_do = ctx.abort_value.get();
             for (i, it) in items.into_iter().enumerate() {
                 let (r, next) = thread_bounded(db, it, cur, ctx, inline_depth)?;
                 cur = next;
+                // A NON-FINAL item that ABORTS ends the sequence: everything AFTER it is DEAD (never runs at
+                // runtime — the abort abandons the continuation). Its rewrite `r` is the abort value, which
+                // becomes the do's value. Stop here — do NOT thread the dead suffix (threading it would run
+                // its performs / push pending self-call temps for code that never executes, and letting the
+                // loop continue would OVERWRITE `last` with the dead FINAL item's rewrite, dropping the abort
+                // value → `(do (A.tick) (B.bail 99) (A.tick))` under B mis-yielded the trailing dead `(A.tick)`
+                // as the do-value instead of 99, forcing the dead tick: 23/34 instead of 110). A non-final
+                // abort at the LAST item falls through to the `i+1==items_len` arm normally.
+                if i + 1 < items_len && ctx.abort_value.get() != abort_before_do {
+                    last = Some(r);
+                    break;
+                }
                 if i + 1 == items_len {
                     last = Some(r);
                 } else if ctx.abort_value.get().is_none()

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -66472,6 +66472,33 @@ mod stage1 {
     }
 
     #[test]
+    fn an_inner_abort_in_a_nonfinal_do_statement_elides_the_dead_suffix_after_it() {
+        // ABORT do-arm dead-suffix (github-liaison review follow-on on #2002/#2014). The aborting `(B.bail 99)`
+        // is a NON-FINAL do-statement with a foreign `(A.tick)` both BEFORE and AFTER it — `(do (A.tick)
+        // (B.bail 99) (A.tick))` under B. The pre-abort `A.tick` commits A-state 10→11 (kept); the trailing
+        // `(A.tick)` is DEAD (the abort abandons the rest) and must NOT run → value 99, outer `(A.get)` reads
+        // 11 → 110. Pre-fix the do-arm kept threading past the abort and set `last` to the dead final `(A.tick)`
+        // (dropping the abort value + forcing the dead tick) → 23 (and a dead multivalue self-call → 34).
+        // Fixed by BREAKING the do-item loop when a non-final item fires the abort.
+        let src = "(do (effect A (op tick (-> Unit Int64)) (op get (-> Unit Int64))) \
+                   (effect B (op bail (-> Int64 Int64))) \
+                   (def (main) \
+                     (handle A 10 ((tick (u) s (resume s (+ s 1))) (get (u) s (resume s s))) \
+                       (let ((b (handle B 0 ((bail (v) s v)) (do (A.tick) (B.bail 99) (A.tick))))) \
+                         (+ b (A.get))))) \
+                   (export main))";
+        assert_eq!(
+            run_returns::<i64>(
+                &compile_component(&crate::codec::encode(&parse(src)))
+                    .expect("the do-arm dead-suffix elision compiles"),
+                "main"
+            ),
+            110,
+            "the dead trailing perform after the abort must NOT run (99 + 11 = 110), not be forced as the do-value (was 23)"
+        );
+    }
+
+    #[test]
     fn an_inner_abort_preserves_an_outer_advance_committed_in_a_match_scrutinee_before_it() {
         // ABORT-FOLD scrutinee collapse (v-effects self-probe, breaker ao9 — the match-scrutinee face of the
         // abort-outer-advance class). The foreign `(A.tick)` and the abort sit on the strict do-spine of a

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -4080,6 +4080,7 @@ pass	an inline-never definition with a const dictionary still monomorphizes the 
 pass	an inlined helper matching a sum built FROM the fused binder plus an enclosing capture
 pass	an inlined multi-use checked-arith argument is shared and computed directly into its slot
 pass	an inner abort ELIDES an outer perform sequenced AFTER it (dead-path control)
+pass	an inner abort in a NON-FINAL do-statement elides the DEAD suffix after it (pre-abort advance kept)
 pass	an inner abort preserves TWO outer advances committed before it (multi-step outer trace)
 pass	an inner abort preserves an OUTER advance committed in a MATCH-SCRUTINEE before it (scrutinee collapse)
 pass	an inner abort preserves an OUTER advance committed in a MATCH-ARM body before it (arm do-shape)

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -4093,6 +4093,7 @@ pass	an inline-never definition with a const dictionary still monomorphizes the 
 pass	an inlined helper matching a sum built FROM the fused binder plus an enclosing capture
 pass	an inlined multi-use checked-arith argument is shared and computed directly into its slot
 pass	an inner abort ELIDES an outer perform sequenced AFTER it (dead-path control)
+pass	an inner abort in a NON-FINAL do-statement elides the DEAD suffix after it (pre-abort advance kept)
 pass	an inner abort preserves TWO outer advances committed before it (multi-step outer trace)
 pass	an inner abort preserves an OUTER advance committed in a MATCH-SCRUTINEE before it (scrutinee collapse)
 pass	an inner abort preserves an OUTER advance committed in a MATCH-ARM body before it (arm do-shape)

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -4021,6 +4021,7 @@ pass	an inline-never definition with a const dictionary still monomorphizes the 
 pass	an inlined helper matching a sum built FROM the fused binder plus an enclosing capture
 pass	an inlined multi-use checked-arith argument is shared and computed directly into its slot
 pass	an inner abort ELIDES an outer perform sequenced AFTER it (dead-path control)
+pass	an inner abort in a NON-FINAL do-statement elides the DEAD suffix after it (pre-abort advance kept)
 pass	an inner abort preserves TWO outer advances committed before it (multi-step outer trace)
 pass	an inner abort preserves an OUTER advance committed in a MATCH-SCRUTINEE before it (scrutinee collapse)
 pass	an inner abort preserves an OUTER advance committed in a MATCH-ARM body before it (arm do-shape)

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -1321,6 +1321,26 @@
                   (+ b (A.get))))) (export main)))
   (output (: 109 Int64)))
 
+(case "an inner abort in a NON-FINAL do-statement elides the DEAD suffix after it (pre-abort advance kept)"
+  (doc    "The dead-suffix control for the do-shape abort-fold (github-liaison review follow-on on #2002/#2014,
+           self-probed). The aborting `(B.bail 99)` is a NON-FINAL do-statement with a foreign `(A.tick)` BOTH
+           before AND after it — `(do (A.tick) (B.bail 99) (A.tick))` under B. The PRE-abort `A.tick` commits
+           A-state 10→11 (kept); the abort abandons the rest, so the trailing `(A.tick)` is DEAD and must NOT
+           run. Value is the abort 99, outer `(A.get)` reads 11 → `(+ 99 11)` = 110. Before the fix the do-arm
+           kept threading past the abort and set `last` to the DEAD final `(A.tick)` (dropping the abort value
+           and FORCING the dead tick) → 23; a multivalue self-call in the dead suffix was likewise forced (34).
+           Fixed by BREAKING the do-item loop when a non-final item fires the abort: the abort value is the do's
+           value, the dead suffix is never threaded. Composes with the pre-abort-prefix preservation (the
+           kept `A.tick` still advances) — this pins BOTH halves in one body.")
+  (input  (do
+            (effect A (op tick (-> Unit Int64)) (op get (-> Unit Int64)))
+            (effect B (op bail (-> Int64 Int64)))
+            (def (main)
+              (handle A 10 ((tick (u) s (resume s (+ s 1))) (get (u) s (resume s s)))
+                (let ((b (handle B 0 ((bail (v) s v)) (do (A.tick) (B.bail 99) (A.tick)))))
+                  (+ b (A.get))))) (export main)))
+  (output (: 110 Int64)))
+
 (case "an inner abort preserves an OUTER advance committed in a MATCH-SCRUTINEE before it (scrutinee collapse)"
   (doc    "The MATCH-SCRUTINEE face of the outer-advance preservation (breaker ao9). The foreign `(A.tick)`
            and the abort sit on the strict do-spine of a `match` SCRUTINEE — `(match (do (A.tick) (B.bail 99))


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 399530486, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.