### PR TITLE
cdz-agent-host: admin `metrics` command — the host-wide metrics READ over the control interface

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/admin.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/admin.rs
@@ -52,6 +52,10 @@ pub enum AdminCommand {
     SessionStatus { id: SessionId },
     /// Stop (remove) a running session, dropping it from the registry.
     StopSession { id: SessionId },
+    /// Fetch the daemon's METRIC snapshot (host-boundary + per-effect counters, the
+    /// [`crate::status::host_metrics_json`] shape) — the observability read over the whole host, not one
+    /// session.
+    Metrics,
 }
 
 impl AdminCommand {
@@ -65,6 +69,7 @@ impl AdminCommand {
             AdminCommand::ListSessions => "admin/list-sessions",
             AdminCommand::SessionStatus { .. } => "admin/session-status",
             AdminCommand::StopSession { .. } => "admin/stop-session",
+            AdminCommand::Metrics => "admin/metrics",
         }
     }
 }
@@ -269,6 +274,12 @@ impl AgentHost {
                 None => AdminResponse::Error {
                     message: format!("unknown session: {}", id.as_str()),
                 },
+            },
+            // Host-wide metrics read — reuses the Status response (a JSON body); the shape is
+            // host_metrics_json's, distinct from a per-session status. Always succeeds (a fresh host reports
+            // zeroed counters), so there's no not-found case.
+            AdminCommand::Metrics => AdminResponse::Status {
+                json: self.metrics_json(),
             },
         }
     }
@@ -612,6 +623,38 @@ mod tests {
             }
             .action(),
             "admin/stop-session"
+        );
+        assert_eq!(AdminCommand::Metrics.action(), "admin/metrics");
+    }
+
+    #[tokio::test]
+    async fn metrics_command_returns_the_host_metrics_json() {
+        // The host-wide metrics read: apply_admin(Metrics) returns a Status response whose JSON is the
+        // host_metrics_json shape. Install a session through the factory so sessions.installed moves, then
+        // read metrics. A host with no effect-metrics handle (no metered executors) reports zeroed effect
+        // counters but real host-boundary ones.
+        let mut host = AgentHost::new();
+        let mut factory = StubFactory { builds: 0 };
+        host.apply_admin(
+            AdminCommand::InstallSession(spec("s")),
+            Some(&mut factory),
+            None,
+        )
+        .await;
+        let resp = host.apply_admin(AdminCommand::Metrics, None, None).await;
+        let json = match resp {
+            AdminResponse::Status { json } => json,
+            other => panic!("expected Status, got {other:?}"),
+        };
+        // host-boundary counter moved with the install…
+        assert!(
+            json.contains("\"installed\":1"),
+            "sessions.installed reflects the install: {json}"
+        );
+        // …and the (unwired) effect counters are present + zeroed.
+        assert!(
+            json.contains("\"effects\":{\"ok\":0,\"retryable_err\":0,\"permanent_err\":0,\"timed_out\":0,\"total\":0}"),
+            "effects zeroed without a metered executor set: {json}"
         );
     }
 

--- a/implementation/seed/crates/cdz-agent-host/src/admin_wire.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/admin_wire.rs
@@ -43,6 +43,7 @@ pub enum AdminCommandWire {
     ListSessions,
     SessionStatus { id: String },
     StopSession { id: String },
+    Metrics,
 }
 
 /// The wire form of an [`AdminResponse`] — internally tagged on `result` (`{"result":"installed","id":…}`).
@@ -127,6 +128,7 @@ impl From<&AdminCommand> for AdminCommandWire {
             AdminCommand::StopSession { id } => AdminCommandWire::StopSession {
                 id: id.as_str().to_string(),
             },
+            AdminCommand::Metrics => AdminCommandWire::Metrics,
         }
     }
 }
@@ -145,6 +147,7 @@ impl AdminCommandWire {
             AdminCommandWire::StopSession { id } => AdminCommand::StopSession {
                 id: SessionId::new(id.as_str()),
             },
+            AdminCommandWire::Metrics => AdminCommand::Metrics,
         })
     }
 }
@@ -338,6 +341,17 @@ mod tests {
             decode_frame(&frame).unwrap().expect("a full frame decodes");
         assert_eq!(back, wire);
         assert_eq!(consumed, frame.len());
+    }
+
+    #[test]
+    fn metrics_command_round_trips_domain_wire_domain() {
+        // The host-wide `metrics` command: domain → wire → domain preserves it, and its JSON tag is the
+        // stable kebab-case `metrics` an external admin client authors against.
+        let wire = AdminCommandWire::from(&AdminCommand::Metrics);
+        assert_eq!(wire, AdminCommandWire::Metrics);
+        assert_eq!(wire.to_domain().unwrap(), AdminCommand::Metrics);
+        let json = serde_json::to_string(&wire).unwrap();
+        assert_eq!(json, "{\"cmd\":\"metrics\"}", "stable self-describing tag");
     }
 
     #[test]

--- a/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
@@ -119,6 +119,10 @@ async fn main() -> std::process::ExitCode {
                 return std::process::ExitCode::from(1);
             }
         };
+        // Grab the host-wide per-effect metrics handle BEFORE `executors` is moved into the factory below, so
+        // the host's admin `metrics` read can render per-effect counters (ok/retryable/permanent/timed-out)
+        // alongside the host-boundary ones. The executor set's MeteredExecutors tally into this shared Arc.
+        let effect_metrics = executors.metrics();
         // Attach the optional log-sink builder to whichever blob-backed factory we build, then box it. (The
         // two arms are distinct concrete factory types, so the with_log_sink + Box happens per-arm; the
         // executor set is moved into the one arm that runs.)
@@ -153,8 +157,11 @@ async fn main() -> std::process::ExitCode {
             config.blob, config.log
         );
 
-        let host = AsyncAgentHost::with_factory(AgentHost::new(), factory)
-            .with_admin_authz(Box::new(AllowList::allow_all_for_local_admin()));
+        let host = AsyncAgentHost::with_factory(
+            AgentHost::new().with_effect_metrics(effect_metrics),
+            factory,
+        )
+        .with_admin_authz(Box::new(AllowList::allow_all_for_local_admin()));
         // Drop our inbox sender so an idle inbox doesn't hold the loop open; the admin socket's AdminChannel
         // is what keeps the loop alive as a control plane.
         drop(host.inbox());

--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -324,6 +324,12 @@ pub struct AgentHost {
     /// (spawn/remove/deliver). Hermetic (plain atomics, no metrics dep); read via [`AgentHost::metrics`] for
     /// a status surface or the feature-gated exporter. `Default` = all-zero, so it needs no explicit init.
     metrics: crate::metrics::HostMetrics,
+    /// The daemon's host-wide PER-EFFECT metrics, if wired — a shared handle the executor set's
+    /// [`MeteredExecutor`](crate::factory::MeteredExecutor)s tally into (the executor set OWNS the `Arc`; the
+    /// daemon hands the host a clone via [`with_effect_metrics`](Self::with_effect_metrics) so an admin
+    /// `metrics` read can render both halves). `None` on a host whose executors aren't metered (tests, a
+    /// hermetic set) — the metrics read then reports zeroed effect counters.
+    effect_metrics: Option<std::sync::Arc<crate::metrics::EffectMetrics>>,
 }
 
 /// A by-value copy of a canonical [`NameStore`](cdz_kernel::name_store::NameStore) for a freshly-spawned session — replays the canonical
@@ -345,6 +351,7 @@ impl AgentHost {
             sessions: HashMap::new(),
             canonical: None,
             metrics: crate::metrics::HostMetrics::default(),
+            effect_metrics: None,
         }
     }
 
@@ -364,7 +371,20 @@ impl AgentHost {
             sessions: HashMap::new(),
             canonical: Some(canonical),
             metrics: crate::metrics::HostMetrics::default(),
+            effect_metrics: None,
         }
+    }
+
+    /// Wire the host-wide per-effect metrics handle (from the executor set — the daemon passes
+    /// `LiveExecutorSet::metrics()`) so an admin `metrics` read renders the per-effect counters alongside the
+    /// host-boundary ones. Builder-style; a host without this reports zeroed effect counters (a hermetic/test
+    /// set has no metered executors to read).
+    pub fn with_effect_metrics(
+        mut self,
+        effect_metrics: std::sync::Arc<crate::metrics::EffectMetrics>,
+    ) -> Self {
+        self.effect_metrics = Some(effect_metrics);
+        self
     }
 
     /// Register a new running session under `id`. Returns the id back for convenience. If `id` already
@@ -470,6 +490,20 @@ impl AgentHost {
     /// or the feature-gated metrics exporter. The counters are bumped internally at spawn/remove/deliver.
     pub fn metrics(&self) -> &crate::metrics::HostMetrics {
         &self.metrics
+    }
+
+    /// Render the daemon's metric surface as JSON (the `admin metrics` read) — both the host-boundary
+    /// counters and the per-effect counters if a handle was wired via
+    /// [`with_effect_metrics`](Self::with_effect_metrics). Without that handle the effect counters read all
+    /// zero (a host whose executors aren't metered has none to report). The shape is
+    /// [`crate::status::host_metrics_json`]'s stable contract.
+    pub fn metrics_json(&self) -> String {
+        let effects = self
+            .effect_metrics
+            .as_ref()
+            .map(|m| m.snapshot())
+            .unwrap_or_default();
+        crate::status::host_metrics_json(&self.metrics.snapshot(), &effects)
     }
 
     /// Fire due timers across ALL registered sessions at `now_ms` (a host scheduler tick). Returns the


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref b15d90ece, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.