### PR TITLE
rcdzc: add an Ast.Bytes variant — a first-class byte-literal AST node (operator seq 113)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/lower.rs
+++ b/implementation/seed/crates/rcdzc/src/lower.rs
@@ -2865,6 +2865,33 @@ fn print_ast_value(db: &mut Db, node: StructId, disc: &AstDiscs, out: &mut Strin
         };
         out.push_str(&s);
         Some(())
+    } else if d == disc.bytes && payloads.len() == 1 {
+        // A byte-sequence LITERAL renders `b"…"` — printable ASCII verbatim, `\n \t \r \\ \"` named, else
+        // `\xNN` (two lowercase hex). A constant `Ast.Bytes` payload is a `Core::BytesOf` of `ConstInt`
+        // elements each range-checked to `0..=255` at `lower_bytes_of` (a non-constant element declines
+        // there, so no `BytesOf` reaches here). Mirrors cadenza-syntax `literal::escape_bytes` (COPIED, not
+        // depended — the rcdzc lib is dependency-free).
+        let Core::BytesOf { elems } = core_of(db, payloads[0]) else {
+            return None;
+        };
+        out.push_str("b\"");
+        for e in &elems {
+            let Core::ConstInt(v) = core_of(db, *e) else {
+                return None;
+            };
+            let b = u8::try_from(v.to_i64().filter(|n| (0..=255).contains(n))?).ok()?;
+            match b {
+                b'\n' => out.push_str("\\n"),
+                b'\t' => out.push_str("\\t"),
+                b'\r' => out.push_str("\\r"),
+                b'\\' => out.push_str("\\\\"),
+                b'"' => out.push_str("\\\""),
+                0x20..=0x7e => out.push(b as char),
+                _ => out.push_str(&format!("\\x{b:02x}")),
+            }
+        }
+        out.push('"');
+        Some(())
     } else if d == disc.list && payloads.len() == 1 {
         let Core::ListNew { elems } = core_of(db, payloads[0]) else {
             return None;
@@ -3263,6 +3290,7 @@ struct AstDiscs {
     str: u32,
     name: u32,
     list: u32,
+    bytes: u32,
     ty: crate::ty::Ty,
 }
 /// Whether a `Core::SumNew { disc }` at result type `ty` constructs the reify `Ast` sum's `Float` variant
@@ -3296,6 +3324,7 @@ fn ast_variant_discs(db: &mut Db) -> Option<AstDiscs> {
         str: variant_disc_by_name(db, &ty, "Str")?,
         name: variant_disc_by_name(db, &ty, "Name")?,
         list: variant_disc_by_name(db, &ty, "List")?,
+        bytes: variant_disc_by_name(db, &ty, "Bytes")?,
         ty,
     })
 }

--- a/implementation/seed/crates/rcdzc/src/quote.rs
+++ b/implementation/seed/crates/rcdzc/src/quote.rs
@@ -472,7 +472,15 @@ fn reify_inner(
                 let payload = push_atom(ast, Leaf::Str(name));
                 Some(ast_ctor(ast, "Name", payload))
             }
-            // Any other leaf kind (Char/Sym/Bytes/…) has no `Ast` variant yet: not
+            // A byte-sequence LITERAL (`b"…"`) -> `(Ast.Bytes b"…")`. `Ast.Bytes` carries a `Bytes` payload
+            // (a raw blob is a syntactic form — operator seq 113), so `(quote b"hi")` reifies to a single
+            // bytes node whose payload REUSES the literal's leaf; it rides the AST codec as one
+            // length-prefixed raw-bytes leaf (`KIND_BYTES`), not a node-per-byte list.
+            leaf @ Leaf::Bytes(_) => {
+                let payload = push_atom(ast, leaf);
+                Some(ast_ctor(ast, "Bytes", payload))
+            }
+            // Any other leaf kind (Char/Sym/…) has no `Ast` variant yet: not
             // reifiable — bail so the whole quote declines rather than miscompiling.
             _ => None,
         },

--- a/implementation/seed/crates/rcdzc/src/sums.rs
+++ b/implementation/seed/crates/rcdzc/src/sums.rs
@@ -123,6 +123,13 @@ pub fn prelude_decls(ast: &mut Arenas) -> Vec<TypeDecl> {
         let bool_pay = push_atom(ast, Leaf::Name("Bool".to_string()));
         let str_pay = push_atom(ast, Leaf::Name("String".to_string()));
         let name_pay = push_atom(ast, Leaf::Name("String".to_string()));
+        // `Bytes` — a raw byte-sequence LITERAL (`b"…"` / a `Bytes` value), the syntactic form for a
+        // binary blob. Its payload is the `Bytes` type (not a `(List Int64)`), so a blob rides the AST +
+        // its codec as ONE length-prefixed raw-bytes leaf (codec `KIND_BYTES`, tag 11 — already present)
+        // rather than a node-per-byte list, cutting encode/decode overhead on the invoke wire format
+        // (operator seq 113). Appended LAST so existing variant discriminants are unchanged (discs are
+        // read BY NAME via `ast_variant_discs`, so order is display-only).
+        let bytes_pay = push_atom(ast, Leaf::Name("Bytes".to_string()));
         // `(List Ast)` — the recursive list-of-Ast payload for the `List` variant.
         let list_head = push_atom(ast, Leaf::Name("List".to_string()));
         let ast_ref = push_atom(ast, Leaf::Name("Ast".to_string()));
@@ -150,6 +157,7 @@ pub fn prelude_decls(ast: &mut Arenas) -> Vec<TypeDecl> {
                 ("Str", &[str_pay]),
                 ("Name", &[name_pay]),
                 ("List", &[list_ast]),
+                ("Bytes", &[bytes_pay]),
             ],
         )
     };

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -3765,6 +3765,7 @@ pass	an AST from quasiquoting a runtime value equals the same AST built by quote
 pass	an Ast as a MAP key looks up by structural content
 pass	an Ast-value-spliced template round-trips through encode and decode
 pass	an Ast.Bool and an Ast.Int are distinct by variant tag not by numeric value
+pass	an Ast.Bytes node constructs and deconstructs by pattern matching
 pass	an Ast.Int carries a BEYOND-64-bit literal losslessly through quote
 pass	an Ast.Int stores an integer wider than Int64 without loss
 pass	an EFFECTFUL @ensures predicate is value-transparent when SATISFIED — the body's own perform runs first
@@ -4952,11 +4953,13 @@ pass	print of a NEGATIVE Ast.Float round-trips through read (sign survives the t
 pass	print of a negative-zero Ast.Float preserves the sign through read (text-path signed-zero)
 pass	print of a quote containing a float renders re-readably
 pass	print of an Ast.Bool renders the bare word and read inverts it
+pass	print of an Ast.Bytes escapes a non-printable byte as \xNN
 pass	print of an Ast.Float renders a re-readable decimal and read inverts it
 pass	print of an Ast.Str renders a quoted literal with escapes and read inverts it
 pass	print of an exponent-scale Ast.Float round-trips through read
 pass	print of an integer-valued Ast.Float keeps its float form through read
 pass	print renders a bare Ast.Bool as its exact keyword text
+pass	print renders a bare Ast.Bytes as its exact b"…" byte-literal text
 pass	print renders a bare Ast.Int as its exact decimal text
 pass	print renders a bare Ast.Name as its exact identifier text
 pass	print renders a bare NEGATIVE Ast.Int as its exact signed text
@@ -5003,6 +5006,7 @@ pass	quasiquote constructs AST with selective evaluation
 pass	quasiquote makes AST construction readable
 pass	quasiquote nests with inner unquote evaluated
 pass	quasiquotes unquoting a runtime variable and a literal build equal ASTs
+pass	quote of a byte-string literal reifies to an Ast.Bytes node
 pass	quote of a let reifies as an Ast.List with a let head and round-trips
 pass	quote of a nested quote form is inert — the inner quote is not evaluated
 pass	quote produces an AST value without evaluating

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -3776,6 +3776,7 @@ pass	an AST from quasiquoting a runtime value equals the same AST built by quote
 pass	an Ast as a MAP key looks up by structural content
 pass	an Ast-value-spliced template round-trips through encode and decode
 pass	an Ast.Bool and an Ast.Int are distinct by variant tag not by numeric value
+pass	an Ast.Bytes node constructs and deconstructs by pattern matching
 pass	an Ast.Int carries a BEYOND-64-bit literal losslessly through quote
 pass	an Ast.Int stores an integer wider than Int64 without loss
 pass	an EFFECTFUL @ensures predicate is value-transparent when SATISFIED — the body's own perform runs first
@@ -4966,11 +4967,13 @@ pass	print of a NEGATIVE Ast.Float round-trips through read (sign survives the t
 pass	print of a negative-zero Ast.Float preserves the sign through read (text-path signed-zero)
 pass	print of a quote containing a float renders re-readably
 pass	print of an Ast.Bool renders the bare word and read inverts it
+pass	print of an Ast.Bytes escapes a non-printable byte as \xNN
 pass	print of an Ast.Float renders a re-readable decimal and read inverts it
 pass	print of an Ast.Str renders a quoted literal with escapes and read inverts it
 pass	print of an exponent-scale Ast.Float round-trips through read
 pass	print of an integer-valued Ast.Float keeps its float form through read
 pass	print renders a bare Ast.Bool as its exact keyword text
+pass	print renders a bare Ast.Bytes as its exact b"…" byte-literal text
 pass	print renders a bare Ast.Int as its exact decimal text
 pass	print renders a bare Ast.Name as its exact identifier text
 pass	print renders a bare NEGATIVE Ast.Int as its exact signed text
@@ -5017,6 +5020,7 @@ pass	quasiquote constructs AST with selective evaluation
 pass	quasiquote makes AST construction readable
 pass	quasiquote nests with inner unquote evaluated
 pass	quasiquotes unquoting a runtime variable and a literal build equal ASTs
+pass	quote of a byte-string literal reifies to an Ast.Bytes node
 pass	quote of a let reifies as an Ast.List with a let head and round-trips
 pass	quote of a nested quote form is inert — the inner quote is not evaluated
 pass	quote produces an AST value without evaluating

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -3711,6 +3711,7 @@ pass	an AST from quasiquoting a runtime value equals the same AST built by quote
 pass	an Ast as a MAP key looks up by structural content
 pass	an Ast-value-spliced template round-trips through encode and decode
 pass	an Ast.Bool and an Ast.Int are distinct by variant tag not by numeric value
+pass	an Ast.Bytes node constructs and deconstructs by pattern matching
 pass	an Ast.Int carries a BEYOND-64-bit literal losslessly through quote
 pass	an Ast.Int stores an integer wider than Int64 without loss
 pass	an EFFECTFUL @ensures predicate is value-transparent when SATISFIED — the body's own perform runs first
@@ -4875,11 +4876,13 @@ pass	print of a NEGATIVE Ast.Float round-trips through read (sign survives the t
 pass	print of a negative-zero Ast.Float preserves the sign through read (text-path signed-zero)
 pass	print of a quote containing a float renders re-readably
 pass	print of an Ast.Bool renders the bare word and read inverts it
+pass	print of an Ast.Bytes escapes a non-printable byte as \xNN
 pass	print of an Ast.Float renders a re-readable decimal and read inverts it
 pass	print of an Ast.Str renders a quoted literal with escapes and read inverts it
 pass	print of an exponent-scale Ast.Float round-trips through read
 pass	print of an integer-valued Ast.Float keeps its float form through read
 pass	print renders a bare Ast.Bool as its exact keyword text
+pass	print renders a bare Ast.Bytes as its exact b"…" byte-literal text
 pass	print renders a bare Ast.Int as its exact decimal text
 pass	print renders a bare Ast.Name as its exact identifier text
 pass	print renders a bare NEGATIVE Ast.Int as its exact signed text
@@ -4926,6 +4929,7 @@ pass	quasiquote constructs AST with selective evaluation
 pass	quasiquote makes AST construction readable
 pass	quasiquote nests with inner unquote evaluated
 pass	quasiquotes unquoting a runtime variable and a literal build equal ASTs
+pass	quote of a byte-string literal reifies to an Ast.Bytes node
 pass	quote of a let reifies as an Ast.List with a let head and round-trips
 pass	quote of a nested quote form is inert — the inner quote is not evaluated
 pass	quote produces an AST value without evaluating

--- a/spec/semantics/12-metaprogramming.sexp
+++ b/spec/semantics/12-metaprogramming.sexp
@@ -517,6 +517,42 @@
   (input  (= (print (Ast.Name "foo")) "foo"))
   (output (: true Bool)))
 
+(case "an Ast.Bytes node constructs and deconstructs by pattern matching"
+  (doc    "The AST sum has a `Bytes` variant for a raw byte-sequence LITERAL (`b\"…\"`) — a binary blob is a
+           syntactic form, carried as a single `Bytes` payload (operator seq 113) so a blob rides the AST +
+           its codec as ONE length-prefixed raw-bytes leaf rather than a node-per-byte list. `Ast.Bytes` is
+           an ordinary sum variant: `(Ast.Bytes b\"hi\")` constructs it and a `(Ast.Bytes b)` pattern
+           deconstructs it, exactly like the other Ast leaves.")
+  (input  (match (Ast.Bytes b"hi")
+            ((Ast.Bytes _) 1)
+            (_             0)))
+  (output (: 1 Int64)))
+
+(case "quote of a byte-string literal reifies to an Ast.Bytes node"
+  (doc    "`(quote b\"hi\")` reifies the `b\"…\"` byte-string literal to an `Ast.Bytes` node whose payload is
+           the blob — the bytes companion of `(quote \"hi\")`→`Ast.Str` and `(quote 42)`→`Ast.Int`. Pins that
+           the quote reifier has a `Leaf::Bytes`→`Ast.Bytes` arm (it previously declined, having no Bytes
+           variant), so a quoted binary literal is a first-class AST node.")
+  (input  (match (quote b"hi")
+            ((Ast.Bytes _) 1)
+            (_             0)))
+  (output (: 1 Int64)))
+
+(case "print renders a bare Ast.Bytes as its exact b\"…\" byte-literal text"
+  (doc    "`print (Ast.Bytes b\"hi\")` is exactly `\"b\\\"hi\\\"\"` — the `b\"…\"` byte-literal spelling
+           (printable ASCII verbatim, `\\n \\t \\r \\\\ \\\"` named, else `\\xNN`), the canonical re-readable
+           form for a blob. Pins the Bytes rendering distinct from an `Ast.Str` (which has no `b` prefix).")
+  (input  (= (print (Ast.Bytes b"hi")) "b\"hi\""))
+  (output (: true Bool)))
+
+(case "print of an Ast.Bytes escapes a non-printable byte as \\xNN"
+  (doc    "The escape face of the Bytes printer: a byte outside printable ASCII renders `\\xNN` (two
+           lowercase hex), matching the reader's byte-literal escapes. `b\"\\x00\\xff\"` (a NUL and a 0xff)
+           prints back to exactly that spelling. Pins the non-printable escape path the `b\"hi\"` case
+           doesn't reach.")
+  (input  (= (print (Ast.Bytes b"\x00\xff")) "b\"\\x00\\xff\""))
+  (output (: true Bool)))
+
 (case "the AST is a sum type deconstructible by pattern matching"
   (doc    "Witnesses metaprogramming.md #Quote Produces An AST Value (2nd sentence): the AST is a
            sum type with variants for each syntactic form. Pattern matching over (quote 42) binds


### PR DESCRIPTION
Candidate PR for v-metaprogramming's merge-request (ref 82108cb72, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.