### PR TITLE
fix(cdz-kernel): invoke-arc review follow-ups — val_shape drops untrusted variant/enum case label (DoS) + selector doc-link (#2053/#2057)

### DIFF
--- a/implementation/seed/crates/cdz-kernel/src/selector.rs
+++ b/implementation/seed/crates/cdz-kernel/src/selector.rs
@@ -37,7 +37,7 @@ pub enum Sink {
 /// One routing RULE: match an artifact by its opaque `kind` and/or `name`, and send a match to `sink`.
 /// Both matchers `None` = a catch-all (matches every artifact) — the natural DEFAULT rule at the end of
 /// a rule list. `kind` matches EXACTLY; `name_prefix` matches a name PREFIX (mirrors the authz
-/// [`crate::authz::ResourcePredicate::Prefix`] style — a prefix is enough for real routing and needs no
+/// [`crate::effect::ResourcePredicate::Prefix`] style — a prefix is enough for real routing and needs no
 /// glob/regex dependency). When both are set, BOTH must match (AND). Matching is on opaque strings only
 /// (keystone invariant): a rule carries zero knowledge of what produced the artifact.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
+++ b/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
@@ -634,8 +634,11 @@ fn val_shape(val: &wasmtime::component::Val) -> String {
         Val::List(items) => format!("list(len {})", items.len()),
         Val::Record(fields) => format!("record({} fields)", fields.len()),
         Val::Tuple(items) => format!("tuple(len {})", items.len()),
-        Val::Variant(case, _) => format!("variant({case})"),
-        Val::Enum(case) => format!("enum({case})"),
+        // Drop the case LABEL: it's component type-metadata (attacker-controllable, arbitrarily long), so
+        // embedding it re-opens the same unbounded-message DoS the rest of val_shape closes (#2057 follow-up).
+        // Just the arm.
+        Val::Variant(_, _) => "variant".into(),
+        Val::Enum(_) => "enum".into(),
         Val::Option(_) => "option".into(),
         Val::Result(_) => "result".into(),
         Val::Flags(f) => format!("flags({} set)", f.len()),


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 99ab226a8402e30e852df8a169b6e687ba622e86, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.