### PR TITLE
corpus(05-compound): 2-pin record keys at trie depth — descriptor-ordered descent + churn identity (+ pr2055 arithmetic fold-in)

### DIFF
--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -2690,6 +2690,7 @@ pass	a record with a duplicate field name is a type error
 pass	a record with a non-adjacent duplicate field name is a type error
 pass	a record with a runtime field is returned as a program result
 pass	a record-field loop invariant consumed per iteration accumulates stably
+pass	a record-keyed trie churned back equals the direct build with the seed resolving
 pass	a record-parameter export returns a tuple computed from its fields
 pass	a record-returning closure alongside a parameterized plain export — the closure
 pass	a record-returning closure alongside a parameterized plain export — the plain
@@ -3527,6 +3528,7 @@ pass	a trapping shared payload before the differing position must not preempt a 
 pass	a trie of 30 QUANTITY keys resolves a cross-normalized magnitude lookup at depth
 pass	a trie of 40 MULTI-LIMB BigInt keys enumerates in magnitude order
 pass	a trie of 40 RATIONAL keys with all-different denominators enumerates in numeric order
+pass	a trie of 40 RECORD keys resolves descriptor-ordered field descent at depth
 pass	a trie of 40 TUPLE keys resolves compound-key descent at depth
 pass	a trie spanning NEGATIVE and positive keys enumerates in signed numeric order
 pass	a triple-nested match on the SAME variant-refined scrutinee folds every level to the known arm

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -2702,6 +2702,7 @@ pass	a record with a duplicate field name is a type error
 pass	a record with a non-adjacent duplicate field name is a type error
 pass	a record with a runtime field is returned as a program result
 pass	a record-field loop invariant consumed per iteration accumulates stably
+pass	a record-keyed trie churned back equals the direct build with the seed resolving
 pass	a record-parameter export returns a tuple computed from its fields
 pass	a record-returning closure alongside a parameterized plain export — the closure
 pass	a record-returning closure alongside a parameterized plain export — the plain
@@ -3538,6 +3539,7 @@ pass	a trapping shared payload before the differing position must not preempt a 
 pass	a trie of 30 QUANTITY keys resolves a cross-normalized magnitude lookup at depth
 pass	a trie of 40 MULTI-LIMB BigInt keys enumerates in magnitude order
 pass	a trie of 40 RATIONAL keys with all-different denominators enumerates in numeric order
+pass	a trie of 40 RECORD keys resolves descriptor-ordered field descent at depth
 pass	a trie of 40 TUPLE keys resolves compound-key descent at depth
 pass	a trie spanning NEGATIVE and positive keys enumerates in signed numeric order
 pass	a triple-nested match on the SAME variant-refined scrutinee folds every level to the known arm

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -2650,6 +2650,7 @@ pass	a record with a duplicate field name is a type error
 pass	a record with a non-adjacent duplicate field name is a type error
 pass	a record with a runtime field is returned as a program result
 pass	a record-field loop invariant consumed per iteration accumulates stably
+pass	a record-keyed trie churned back equals the direct build with the seed resolving
 pass	a record-parameter export returns a tuple computed from its fields
 pass	a record-returning closure alongside a parameterized plain export — the closure
 pass	a record-returning closure alongside a parameterized plain export — the plain
@@ -3479,6 +3480,7 @@ pass	a trapping shared payload before the differing position must not preempt a 
 pass	a trie of 30 QUANTITY keys resolves a cross-normalized magnitude lookup at depth
 pass	a trie of 40 MULTI-LIMB BigInt keys enumerates in magnitude order
 pass	a trie of 40 RATIONAL keys with all-different denominators enumerates in numeric order
+pass	a trie of 40 RECORD keys resolves descriptor-ordered field descent at depth
 pass	a trie of 40 TUPLE keys resolves compound-key descent at depth
 pass	a trie spanning NEGATIVE and positive keys enumerates in signed numeric order
 pass	a triple-nested match on the SAME variant-refined scrutinee folds every level to the known arm

--- a/spec/semantics/05-compound-types.sexp
+++ b/spec/semantics/05-compound-types.sexp
@@ -1983,8 +1983,9 @@
 (case "a map-over-map rebuild transforms every retrieved value into a NEW trie in one walk"
   (doc    "The transform companion: an incremental rebuild walks 40 keys, looks each up in the SOURCE
            map, and inserts the transformed value (+1) into a DESTINATION map — source borrowed and
-           destination threaded through the same recursion, both live across the whole walk (len 40,
-           the transformed spot-read +1 → 401). The map-valued `map` operation a compiler pass runs
+           destination threaded through the same recursion, both live across the whole walk — len 40
+           gives 10·40 = 400, and the spot-read confirming dst[25] = 51 adds 1, so 401. The
+           map-valued `map` operation a compiler pass runs
            over a keyed table; a borrow/thread confusion between the two maps would corrupt either the
            source reads or the destination build.")
   (input  (do
@@ -14310,6 +14311,43 @@
             (export main)))
   (call   main (: -0.0 Float64)) (output (: 2 Int64))
   (call   main (: 0.0 Float64)) (output (: 1 Int64)))
+
+(case "a trie of 40 RECORD keys resolves descriptor-ordered field descent at depth"
+  (doc    "The record-key rows above run on 1-2 keys; this pins the record-key descent over a POPULATED
+           trie: 40 keys `(x i mod 6)(y i div 6)` — 2D record coordinates — fill a multi-level trie and
+           an interior `(record (x 4) (y 5))` lookup resolves to its entry (i=34 → 434). The record
+           hash walks fields in the descriptor's canonical order at every slot; a first-field-only hash
+           would collide the 6-7 keys sharing each x residue and misroute the descent.")
+  (input  (do
+            (def (fill (: i Int64) (: m (Map (Record (x Int64) (y Int64)) Int64)))
+              (if (= i 0) m (fill (- i 1) (Map.insert m (record (x (% i 6)) (y (/ i 6))) i))))
+            (def (main (: n Int64))
+              (do
+                (def m (fill n Map.empty))
+                (+ (* 10 (Map.len m))
+                   (match (Map.lookup m (record (x 4) (y 5))) ((Some v) v) ((None _u) -1)))))
+            (export main)))
+  (call   main (: 40 Int64)) (output (: 434 Int64)))
+
+(case "a record-keyed trie churned back equals the direct build with the seed resolving"
+  (doc    "The compound-key churn-identity face: 29 record keys (i = 1..n-1 at n = 30) churned around a
+           `(record (x 7) (y 8))` seed leave the map EQUAL to the direct build by canonical `=` (10)
+           with the seed still resolving (+1 → 11). Removal traffic in record keyspace collapses nodes
+           exactly as the scalar churn pins require — the two-field key layout leaves no residue in the
+           canonical form.")
+  (input  (do
+            (def (grow (: i Int64) (: n Int64) (: m (Map (Record (x Int64) (y Int64)) Int64)))
+              (if (= i n) m (grow (+ i 1) n (Map.insert m (record (x (+ i 100)) (y i)) i))))
+            (def (shrink (: i Int64) (: n Int64) (: m (Map (Record (x Int64) (y Int64)) Int64)))
+              (if (= i n) m (shrink (+ i 1) n (Map.remove m (record (x (+ i 100)) (y i))))))
+            (def (main (: n Int64))
+              (do
+                (def direct (Map.insert Map.empty (record (x 7) (y 8)) 50))
+                (def churned (shrink 1 n (grow 1 n direct)))
+                (+ (* 10 (if (= churned direct) 1 0))
+                   (match (Map.lookup churned (record (x 7) (y 8))) ((Some v) (if (= v 50) 1 0)) ((None _u) -1)))))
+            (export main)))
+  (call   main (: 30 Int64)) (output (: 11 Int64)))
 
 (case "a tuple key whose element is itself a float-bearing tuple keys by content"
   (doc    "The NESTED (depth-2) face: the float sits one level down — `(tuple 1 (tuple x 2))` — and the key


### PR DESCRIPTION
Candidate PR for breaker's merge-request (ref c935e2d592dcd45ec8d2d02a10308631714fcff6, lane baseline). Auto-merge armed; pr-sync's schedule-pass reaps on green.