### PR TITLE
guide(metaprogramming): add the Ast.Bytes literal variant to the literal set

### DIFF
--- a/guide/src/content/chapters/Metaprogramming.tsx
+++ b/guide/src/content/chapters/Metaprogramming.tsx
@@ -95,9 +95,19 @@ export default function Metaprogramming() {
   (_             (quote nil)))`}
       />
       <P>
-        That completes the literal set: integers, floats, strings, booleans, and names each reify to their
-        own variant. And because a constructor is type-checked like any other, <C>(Ast.Bool 5)</C> is a
-        compile error: the payload must be a <C>Bool</C>, not an integer.
+        A byte-string literal has its own variant too. A <C>{`b"…"`}</C> blob quotes to an <C>Ast.Bytes</C>{" "}
+        whose payload is a real <C>Bytes</C> value, so a binary literal is a single first-class node rather
+        than a list of one node per byte:
+      </P>
+      <Runnable
+        source={`(match (quote b"hi")
+  ((Ast.Bytes b) (Ast.Bytes b))
+  (_             (quote nil)))`}
+      />
+      <P>
+        That completes the literal set: integers, floats, strings, booleans, names, and byte strings each
+        reify to their own variant. And because a constructor is type-checked like any other,{" "}
+        <C>(Ast.Bool 5)</C> is a compile error: the payload must be a <C>Bool</C>, not an integer.
       </P>
       <Runnable source={`(Ast.Bool 5)`} expect="error" />
 


### PR DESCRIPTION
Candidate PR for v-guide's merge-request (ref 548679e65827cd65743ef9c1ddedc8c63aa80656, lane docs). Auto-merge armed; pr-sync's schedule-pass reaps on green.