### PR TITLE
rcdzc: Ast.encode/decode round-trips Ast.Bytes as one length-prefixed node (seq 113 B2a)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/lower.rs
+++ b/implementation/seed/crates/rcdzc/src/lower.rs
@@ -2763,6 +2763,11 @@ const AST_TAG_LIST: u8 = 0x02;
 const AST_TAG_BOOL: u8 = 0x03;
 const AST_TAG_STR: u8 = 0x04;
 const AST_TAG_FLOAT: u8 = 0x05;
+// A raw byte-sequence node (`Ast.Bytes`) — a length-prefixed raw-bytes payload, so a blob rides this
+// value codec as ONE node, not a node-per-byte list (operator seq 113). ADDITIVE: a fresh tag past the
+// existing 0x00–0x05, so legacy bytes decode exactly as before. Same length-prefix framing as Str/Name
+// (4-byte LE length + that many bytes), but the bytes are RAW (not UTF-8) and decode to `Ast.Bytes`.
+const AST_TAG_BYTES: u8 = 0x06;
 
 /// Lower `(Ast.encode t)` — FOLD a compile-time-visible `Ast` value to a `Core::BytesOf` of its
 /// canonical bytes; a runtime `Ast` (no visible `Core::SumNew`) declines. A poison operand propagates.
@@ -3400,6 +3405,26 @@ fn encode_ast_value(db: &mut Db, node: StructId, disc: &AstDiscs, out: &mut Vec<
             encode_ast_value(db, e, disc, out)?;
         }
         Some(())
+    } else if d == disc.bytes && payloads.len() == 1 {
+        // A byte-sequence node: tag then the length-prefixed RAW bytes (4-byte LE length + bytes verbatim,
+        // the Str/Name framing but not UTF-8). The payload is a `Core::BytesOf` of `ConstInt` elements each
+        // range-checked to `0..=255` at `lower_bytes_of` (a non-constant element declines there, so no
+        // `BytesOf` reaches here). This is the whole point of the variant: one length-prefixed node, not a
+        // node-per-byte list.
+        let Core::BytesOf { elems } = core_of(db, payloads[0]) else {
+            return None;
+        };
+        let mut raw = Vec::with_capacity(elems.len());
+        for e in elems {
+            let Core::ConstInt(v) = core_of(db, e) else {
+                return None;
+            };
+            raw.push(u8::try_from(v.to_i64().filter(|n| (0..=255).contains(n))?).ok()?);
+        }
+        out.push(AST_TAG_BYTES);
+        out.extend_from_slice(&(u32::try_from(raw.len()).ok()?).to_le_bytes());
+        out.extend_from_slice(&raw);
+        Some(())
     } else {
         None
     }
@@ -3751,6 +3776,27 @@ fn decode_ast_value(db: &mut Db, raw: &[u8], disc: &AstDiscs) -> Option<(StructI
                 db,
                 Core::SumNew {
                     disc: disc.name,
+                    payloads: vec![payload],
+                },
+                disc.ty.clone(),
+            );
+            Some((node, 1 + 4 + len))
+        }
+        AST_TAG_BYTES => {
+            // Length-prefixed RAW bytes (not UTF-8, unlike Str/Name) → an `Ast.Bytes` whose payload is a
+            // `Core::BytesOf` of the decoded bytes (each a `UInt8` `Leaf::Int`, the `b"…"`/`Bytes.of` shape).
+            // `4 + len` can overflow `usize` on wasm32 for a large untrusted length → `checked_add` → `None`
+            // (never-panic on untrusted input, matching the Str/Name arms).
+            let len_field = rest.get(..4)?;
+            let len = u32::from_le_bytes(len_field.try_into().ok()?) as usize;
+            let end = 4usize.checked_add(len)?;
+            let raw_bytes = rest.get(4..end)?.to_vec();
+            let elems = bytes_to_elems(db, &raw_bytes);
+            let payload = synth_core(db, Core::BytesOf { elems }, crate::ty::Ty::Bytes);
+            let node = synth_core(
+                db,
+                Core::SumNew {
+                    disc: disc.bytes,
                     payloads: vec![payload],
                 },
                 disc.ty.clone(),

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -3767,7 +3767,10 @@ pass	an AST from quasiquoting a runtime value equals the same AST built by quote
 pass	an Ast as a MAP key looks up by structural content
 pass	an Ast-value-spliced template round-trips through encode and decode
 pass	an Ast.Bool and an Ast.Int are distinct by variant tag not by numeric value
+pass	an Ast.Bytes carrying NUL and high bytes round-trips through encode and decode
+pass	an Ast.Bytes nested in an Ast.List round-trips through encode and decode
 pass	an Ast.Bytes node constructs and deconstructs by pattern matching
+pass	an Ast.Bytes node round-trips through encode and decode
 pass	an Ast.Int carries a BEYOND-64-bit literal losslessly through quote
 pass	an Ast.Int stores an integer wider than Int64 without loss
 pass	an EFFECTFUL @ensures predicate is value-transparent when SATISFIED — the body's own perform runs first
@@ -3974,6 +3977,7 @@ pass	an element is projected from a tuple returned by a function
 pass	an element is projected from a tuple returned by a nullary function
 pass	an element pattern matches a list by its length and elements
 pass	an element read across a concatenation boundary is the right value
+pass	an empty Ast.Bytes round-trips through encode and decode
 pass	an empty binary form is the empty byte sequence
 pass	an empty byte-string literal is the empty byte sequence
 pass	an empty list escaping to the host is rejected as undetermined, like a bare None

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -3778,7 +3778,10 @@ pass	an AST from quasiquoting a runtime value equals the same AST built by quote
 pass	an Ast as a MAP key looks up by structural content
 pass	an Ast-value-spliced template round-trips through encode and decode
 pass	an Ast.Bool and an Ast.Int are distinct by variant tag not by numeric value
+pass	an Ast.Bytes carrying NUL and high bytes round-trips through encode and decode
+pass	an Ast.Bytes nested in an Ast.List round-trips through encode and decode
 pass	an Ast.Bytes node constructs and deconstructs by pattern matching
+pass	an Ast.Bytes node round-trips through encode and decode
 pass	an Ast.Int carries a BEYOND-64-bit literal losslessly through quote
 pass	an Ast.Int stores an integer wider than Int64 without loss
 pass	an EFFECTFUL @ensures predicate is value-transparent when SATISFIED — the body's own perform runs first
@@ -3986,6 +3989,7 @@ pass	an element is projected from a tuple returned by a function
 pass	an element is projected from a tuple returned by a nullary function
 pass	an element pattern matches a list by its length and elements
 pass	an element read across a concatenation boundary is the right value
+pass	an empty Ast.Bytes round-trips through encode and decode
 pass	an empty binary form is the empty byte sequence
 pass	an empty byte-string literal is the empty byte sequence
 pass	an empty list escaping to the host is rejected as undetermined, like a bare None

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -3713,7 +3713,10 @@ pass	an AST from quasiquoting a runtime value equals the same AST built by quote
 pass	an Ast as a MAP key looks up by structural content
 pass	an Ast-value-spliced template round-trips through encode and decode
 pass	an Ast.Bool and an Ast.Int are distinct by variant tag not by numeric value
+pass	an Ast.Bytes carrying NUL and high bytes round-trips through encode and decode
+pass	an Ast.Bytes nested in an Ast.List round-trips through encode and decode
 pass	an Ast.Bytes node constructs and deconstructs by pattern matching
+pass	an Ast.Bytes node round-trips through encode and decode
 pass	an Ast.Int carries a BEYOND-64-bit literal losslessly through quote
 pass	an Ast.Int stores an integer wider than Int64 without loss
 pass	an EFFECTFUL @ensures predicate is value-transparent when SATISFIED — the body's own perform runs first
@@ -3916,6 +3919,7 @@ pass	an element is projected from a tuple returned by a function
 pass	an element is projected from a tuple returned by a nullary function
 pass	an element pattern matches a list by its length and elements
 pass	an element read across a concatenation boundary is the right value
+pass	an empty Ast.Bytes round-trips through encode and decode
 pass	an empty binary form is the empty byte sequence
 pass	an empty byte-string literal is the empty byte sequence
 pass	an empty list escaping to the host is rejected as undetermined, like a bare None

--- a/spec/semantics/12-metaprogramming.sexp
+++ b/spec/semantics/12-metaprogramming.sexp
@@ -553,6 +553,46 @@
   (input  (= (print (Ast.Bytes b"\x00\xff")) "b\"\\x00\\xff\""))
   (output (: true Bool)))
 
+(case "an Ast.Bytes node round-trips through encode and decode"
+  (doc    "The interchange face of `Ast.Bytes` (operator seq 113 payoff): `Ast.encode` writes the blob as a
+           SINGLE length-prefixed raw-bytes node (a fresh additive tag past the Int/Name/List/Bool/Str/Float
+           tags — legacy bytes decode exactly as before), and `Ast.decode` reads it back to an EQUAL
+           `Ast.Bytes`. This is the whole point: a byte blob crosses the value codec as one node, not a
+           node-per-byte `Ast.List` of `Ast.Int` u8s. `Ast.decode` is total, so the round-trip matches the
+           `Ok` arm.")
+  (input  (match (Ast.decode (Ast.encode (Ast.Bytes b"hi")))
+            ((Ok a)  (= a (Ast.Bytes b"hi")))
+            ((Err _) false)))
+  (output (: true Bool)))
+
+(case "an empty Ast.Bytes round-trips through encode and decode"
+  (doc    "The zero-length edge of the bytes codec: `(Ast.Bytes b\"\")` encodes to the tag + a zero length
+           (no payload bytes) and decodes back to an equal empty `Ast.Bytes`. Pins that the length-prefix
+           framing handles the empty blob — a decoder mis-reading a zero length would diverge here.")
+  (input  (match (Ast.decode (Ast.encode (Ast.Bytes b"")))
+            ((Ok a)  (= a (Ast.Bytes b"")))
+            ((Err _) false)))
+  (output (: true Bool)))
+
+(case "an Ast.Bytes carrying NUL and high bytes round-trips through encode and decode"
+  (doc    "The raw-byte face (distinct from `Ast.Str`, which is UTF-8): `(Ast.Bytes b\"\\x00\\xff\")` carries
+           a NUL and a 0xff — bytes an `Ast.Str` could not — and round-trips byte-exactly through
+           `Ast.encode`/`Ast.decode`. Pins that the bytes payload is RAW (not re-validated as UTF-8), the
+           key difference from the Str codec arm.")
+  (input  (match (Ast.decode (Ast.encode (Ast.Bytes b"\x00\xff")))
+            ((Ok a)  (= a (Ast.Bytes b"\x00\xff")))
+            ((Err _) false)))
+  (output (: true Bool)))
+
+(case "an Ast.Bytes nested in an Ast.List round-trips through encode and decode"
+  (doc    "Composition: an `Ast.Bytes` as a child of an `Ast.List` (`(f b\"hi\")`) round-trips through the
+           value codec — the list arm recurses into the bytes arm and back. Pins that the bytes node
+           composes inside a compound, not only standalone.")
+  (input  (match (Ast.decode (Ast.encode (Ast.List (list (Ast.Name "f") (Ast.Bytes b"hi")))))
+            ((Ok a)  (= a (Ast.List (list (Ast.Name "f") (Ast.Bytes b"hi")))))
+            ((Err _) false)))
+  (output (: true Bool)))
+
 (case "the AST is a sum type deconstructible by pattern matching"
   (doc    "Witnesses metaprogramming.md #Quote Produces An AST Value (2nd sentence): the AST is a
            sum type with variants for each syntactic form. Pattern matching over (quote 42) binds


### PR DESCRIPTION
Candidate PR for v-metaprogramming's merge-request (ref f27c4636e, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.