### PR TITLE
fleet/loops/concierge.md: rejoin 'idle-at-prompt' onto one line (PR #2070 review)

### DIFF
--- a/fleet/loops/concierge.md
+++ b/fleet/loops/concierge.md
@@ -41,10 +41,11 @@ dies or after a cron's 7-day auto-expiry — so verify them each tick and RE-CRE
    to `processed/`; leave a real operator-ask in place if the operator isn't around), (b) **watchdog**:
    `cd .claude/worktrees/pr-sync && cargo xtask fleet watchdog --nudge-drain-stalls` (re-arm stalled
    loops AND auto-nudge a detected drain-stall's idle pane to drain, instead of only warning you — you
-   own tmux, so you're the operator-owned watchdog meant to run with this. It's hard-guarded: idle-at-
-   prompt only, never a context-saturated pane (that needs a restart), rate-limited per agent, with a
-   short re-nudge-if-the-message-persists window that flags loudly. OFF by default because auto-sending
-   keystrokes is the highest-risk watchdog action — enabling it HERE is the intended use), (c) **reap**:
+   own tmux, so you're the operator-owned watchdog meant to run with this. It's hard-guarded:
+   idle-at-prompt only, never a context-saturated pane (that needs a restart), rate-limited per agent,
+   with a short re-nudge-if-the-message-persists window that flags loudly. OFF by default because
+   auto-sending keystrokes is the highest-risk watchdog action — enabling it HERE is the intended use),
+   (c) **reap**:
    `tmux kill-window` any agent that is registry-`stopped` + has a stop-file + still has a live window
    (never an active agent; windows only, not registry rows). This cron is what makes the concierge
    self-driving instead of only waking when the operator messages — WITHOUT it your inbox silently


### PR DESCRIPTION
Candidate PR for v-fleet-tooling's merge-request (ref c444b39884121388504ed1eb2dad8dd7472eaaa2, lane docs). Auto-merge armed; pr-sync's schedule-pass reaps on green.