### PR TITLE
cdz-agent-host: remove the admin metrics interface (operator seq-117) — registry-refactor slice 1

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/admin.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/admin.rs
@@ -52,10 +52,6 @@ pub enum AdminCommand {
     SessionStatus { id: SessionId },
     /// Stop (remove) a running session, dropping it from the registry.
     StopSession { id: SessionId },
-    /// Fetch the daemon's METRIC snapshot (host-boundary + per-effect counters, the
-    /// [`crate::status::host_metrics_json`] shape) — the observability read over the whole host, not one
-    /// session.
-    Metrics,
 }
 
 impl AdminCommand {
@@ -69,7 +65,6 @@ impl AdminCommand {
             AdminCommand::ListSessions => "admin/list-sessions",
             AdminCommand::SessionStatus { .. } => "admin/session-status",
             AdminCommand::StopSession { .. } => "admin/stop-session",
-            AdminCommand::Metrics => "admin/metrics",
         }
     }
 }
@@ -274,12 +269,6 @@ impl AgentHost {
                 None => AdminResponse::Error {
                     message: format!("unknown session: {}", id.as_str()),
                 },
-            },
-            // Host-wide metrics read — reuses the Status response (a JSON body); the shape is
-            // host_metrics_json's, distinct from a per-session status. Always succeeds (a fresh host reports
-            // zeroed counters), so there's no not-found case.
-            AdminCommand::Metrics => AdminResponse::Status {
-                json: self.metrics_json(),
             },
         }
     }
@@ -624,42 +613,6 @@ mod tests {
             .action(),
             "admin/stop-session"
         );
-        assert_eq!(AdminCommand::Metrics.action(), "admin/metrics");
-    }
-
-    #[tokio::test]
-    async fn metrics_command_returns_the_host_metrics_json() {
-        // The host-wide metrics read: apply_admin(Metrics) returns a Status response whose JSON is the
-        // host_metrics_json shape. Install a session through the factory so sessions.installed moves, then
-        // read metrics. A host with no effect-metrics handle (no metered executors) reports zeroed effect
-        // counters but real host-boundary ones.
-        let mut host = AgentHost::new();
-        let mut factory = StubFactory { builds: 0 };
-        host.apply_admin(
-            AdminCommand::InstallSession(spec("s")),
-            Some(&mut factory),
-            None,
-        )
-        .await;
-        let resp = host.apply_admin(AdminCommand::Metrics, None, None).await;
-        let json = match resp {
-            AdminResponse::Status { json } => json,
-            other => panic!("expected Status, got {other:?}"),
-        };
-        // PARSE + assert structurally (#2044 review): a `contains()` on the serialized object is brittle to
-        // any whitespace/key-order change in serialization — parse the JSON once and compare the numeric
-        // fields, so the test pins the VALUES, not the exact byte layout.
-        let v: serde_json::Value = serde_json::from_str(&json).expect("metrics JSON parses");
-        // host-boundary counters moved with the install.
-        assert_eq!(v["sessions"]["installed"], 1, "{json}");
-        assert_eq!(v["sessions"]["removed"], 0, "{json}");
-        assert_eq!(v["sessions"]["live"], 1, "{json}");
-        // the (unwired) effect counters are present + zeroed (no metered executor set).
-        assert_eq!(v["effects"]["ok"], 0, "{json}");
-        assert_eq!(v["effects"]["retryable_err"], 0, "{json}");
-        assert_eq!(v["effects"]["permanent_err"], 0, "{json}");
-        assert_eq!(v["effects"]["timed_out"], 0, "{json}");
-        assert_eq!(v["effects"]["total"], 0, "{json}");
     }
 
     #[tokio::test]

--- a/implementation/seed/crates/cdz-agent-host/src/admin_wire.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/admin_wire.rs
@@ -43,7 +43,6 @@ pub enum AdminCommandWire {
     ListSessions,
     SessionStatus { id: String },
     StopSession { id: String },
-    Metrics,
 }
 
 /// The wire form of an [`AdminResponse`] — internally tagged on `result` (`{"result":"installed","id":…}`).
@@ -128,7 +127,6 @@ impl From<&AdminCommand> for AdminCommandWire {
             AdminCommand::StopSession { id } => AdminCommandWire::StopSession {
                 id: id.as_str().to_string(),
             },
-            AdminCommand::Metrics => AdminCommandWire::Metrics,
         }
     }
 }
@@ -147,7 +145,6 @@ impl AdminCommandWire {
             AdminCommandWire::StopSession { id } => AdminCommand::StopSession {
                 id: SessionId::new(id.as_str()),
             },
-            AdminCommandWire::Metrics => AdminCommand::Metrics,
         })
     }
 }
@@ -341,17 +338,6 @@ mod tests {
             decode_frame(&frame).unwrap().expect("a full frame decodes");
         assert_eq!(back, wire);
         assert_eq!(consumed, frame.len());
-    }
-
-    #[test]
-    fn metrics_command_round_trips_domain_wire_domain() {
-        // The host-wide `metrics` command: domain → wire → domain preserves it, and its JSON tag is the
-        // stable kebab-case `metrics` an external admin client authors against.
-        let wire = AdminCommandWire::from(&AdminCommand::Metrics);
-        assert_eq!(wire, AdminCommandWire::Metrics);
-        assert_eq!(wire.to_domain().unwrap(), AdminCommand::Metrics);
-        let json = serde_json::to_string(&wire).unwrap();
-        assert_eq!(json, "{\"cmd\":\"metrics\"}", "stable self-describing tag");
     }
 
     #[test]

--- a/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
@@ -179,10 +179,6 @@ async fn main() -> std::process::ExitCode {
                 return std::process::ExitCode::from(1);
             }
         };
-        // Grab the host-wide per-effect metrics handle BEFORE `executors` is moved into the factory below, so
-        // the host's admin `metrics` read can render per-effect counters (ok/retryable/permanent/timed-out)
-        // alongside the host-boundary ones. The executor set's MeteredExecutors tally into this shared Arc.
-        let effect_metrics = executors.metrics();
         // Attach the optional log-sink builder to whichever blob-backed factory we build, then box it. (The
         // two arms are distinct concrete factory types, so the with_log_sink + Box happens per-arm; the
         // executor set is moved into the one arm that runs.)
@@ -217,11 +213,8 @@ async fn main() -> std::process::ExitCode {
             config.blob, config.log
         );
 
-        let host = AsyncAgentHost::with_factory(
-            AgentHost::new().with_effect_metrics(effect_metrics),
-            factory,
-        )
-        .with_admin_authz(Box::new(AllowList::allow_all_for_local_admin()));
+        let host = AsyncAgentHost::with_factory(AgentHost::new(), factory)
+            .with_admin_authz(Box::new(AllowList::allow_all_for_local_admin()));
         // Drop our inbox sender so an idle inbox doesn't hold the loop open; the admin socket's AdminChannel
         // is what keeps the loop alive as a control plane.
         drop(host.inbox());

--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -321,15 +321,9 @@ pub struct AgentHost {
     /// [`cdz_kernel::name_store::NameStore`].)
     canonical: Option<cdz_kernel::name_store::NameStore>,
     /// The host's metric surface — monotonic counters bumped at the session-lifecycle + per-turn boundaries
-    /// (spawn/remove/deliver). Hermetic (plain atomics, no metrics dep); read via [`AgentHost::metrics`] for
-    /// a status surface or the feature-gated exporter. `Default` = all-zero, so it needs no explicit init.
+    /// (spawn/remove/deliver). Hermetic (plain atomics, no metrics dep); the registry-typed export recorder
+    /// is the following refactor (seq-116). `Default` = all-zero, so it needs no explicit init.
     metrics: crate::metrics::HostMetrics,
-    /// The daemon's host-wide PER-EFFECT metrics, if wired — a shared handle the executor set's
-    /// [`MeteredExecutor`](crate::factory::MeteredExecutor)s tally into (the executor set OWNS the `Arc`; the
-    /// daemon hands the host a clone via [`with_effect_metrics`](Self::with_effect_metrics) so an admin
-    /// `metrics` read can render both halves). `None` on a host whose executors aren't metered (tests, a
-    /// hermetic set) — the metrics read then reports zeroed effect counters.
-    effect_metrics: Option<std::sync::Arc<crate::metrics::EffectMetrics>>,
 }
 
 /// A by-value copy of a canonical [`NameStore`](cdz_kernel::name_store::NameStore) for a freshly-spawned session — replays the canonical
@@ -351,7 +345,6 @@ impl AgentHost {
             sessions: HashMap::new(),
             canonical: None,
             metrics: crate::metrics::HostMetrics::default(),
-            effect_metrics: None,
         }
     }
 
@@ -371,20 +364,7 @@ impl AgentHost {
             sessions: HashMap::new(),
             canonical: Some(canonical),
             metrics: crate::metrics::HostMetrics::default(),
-            effect_metrics: None,
         }
-    }
-
-    /// Wire the host-wide per-effect metrics handle (from the executor set — the daemon passes
-    /// `LiveExecutorSet::metrics()`) so an admin `metrics` read renders the per-effect counters alongside the
-    /// host-boundary ones. Builder-style; a host without this reports zeroed effect counters (a hermetic/test
-    /// set has no metered executors to read).
-    pub fn with_effect_metrics(
-        mut self,
-        effect_metrics: std::sync::Arc<crate::metrics::EffectMetrics>,
-    ) -> Self {
-        self.effect_metrics = Some(effect_metrics);
-        self
     }
 
     /// Register a new running session under `id`. Returns the id back for convenience. If `id` already
@@ -518,20 +498,6 @@ impl AgentHost {
     /// or the feature-gated metrics exporter. The counters are bumped internally at spawn/remove/deliver.
     pub fn metrics(&self) -> &crate::metrics::HostMetrics {
         &self.metrics
-    }
-
-    /// Render the daemon's metric surface as JSON (the `admin metrics` read) — both the host-boundary
-    /// counters and the per-effect counters if a handle was wired via
-    /// [`with_effect_metrics`](Self::with_effect_metrics). Without that handle the effect counters read all
-    /// zero (a host whose executors aren't metered has none to report). The shape is
-    /// [`crate::status::host_metrics_json`]'s stable contract.
-    pub fn metrics_json(&self) -> String {
-        let effects = self
-            .effect_metrics
-            .as_ref()
-            .map(|m| m.snapshot())
-            .unwrap_or_default();
-        crate::status::host_metrics_json(&self.metrics.snapshot(), &effects)
     }
 
     /// Fire due timers across ALL registered sessions at `now_ms` (a host scheduler tick). Returns the

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -100,9 +100,7 @@ pub use metrics::{EffectMetrics, EffectMetricsSnapshot, HostMetrics, HostMetrics
 pub use model::BedrockModelTransport;
 pub use model::{ModelExecutor, ModelTransport};
 pub use retry::{classify, permanent, retryable, Retryability};
-pub use status::{
-    host_metrics_json, host_session_status_json, session_status_json, DEFAULT_STALL_AFTER_MS,
-};
+pub use status::{host_session_status_json, session_status_json, DEFAULT_STALL_AFTER_MS};
 
 /// Shared test-only helpers (compiled only under `#[cfg(test)]`; placed LAST so no non-test item follows a
 /// test module — clippy `items_after_test_module`). The one PROVEN-FRESH temp-dir helper the crate's

--- a/implementation/seed/crates/cdz-agent-host/src/status.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/status.rs
@@ -80,51 +80,6 @@ pub fn host_session_status_json(
         .map(|hosted| session_status_json(id, hosted, now_ms, stall_after_ms))
 }
 
-/// Render the daemon's METRIC snapshots as a JSON object string — the read surface that makes the captured
-/// counters ([`HostMetrics`](crate::HostMetrics) host-boundary + [`EffectMetrics`](crate::EffectMetrics)
-/// per-effect) OBSERVABLE (an admin `metrics` read / a status endpoint), so a supervisor sees the live
-/// session-lifecycle + effect-outcome mix. Zero-dep, fixed-shape (same discipline as
-/// [`session_status_json`]); the caller passes both snapshots (the host owns `HostMetrics`, the executor set
-/// owns the shared `EffectMetrics`), so this renderer needs no handle to either.
-///
-/// Shape (a stable parse contract — add fields, don't rename):
-/// ```json
-/// {
-///   "sessions": {"installed": 3, "removed": 1, "live": 2},
-///   "turns": {"delivered": 10, "ok": 9, "err": 1, "to_unknown_session": 2},
-///   "effects": {"ok": 40, "retryable_err": 3, "permanent_err": 1, "timed_out": 0, "total": 44}
-/// }
-/// ```
-/// All values are cumulative counters (except `sessions.live` = installed − removed, SATURATING at 0 — never
-/// negative even if the counters are transiently inconsistent). Numbers are plain integers (no escaping
-/// needed); the object has no string fields, so it's always valid JSON.
-pub fn host_metrics_json(
-    host: &crate::HostMetricsSnapshot,
-    effects: &crate::EffectMetricsSnapshot,
-) -> String {
-    format!(
-        concat!(
-            "{{",
-            "\"sessions\":{{\"installed\":{},\"removed\":{},\"live\":{}}},",
-            "\"turns\":{{\"delivered\":{},\"ok\":{},\"err\":{},\"to_unknown_session\":{}}},",
-            "\"effects\":{{\"ok\":{},\"retryable_err\":{},\"permanent_err\":{},\"timed_out\":{},\"total\":{}}}",
-            "}}"
-        ),
-        host.sessions_installed,
-        host.sessions_removed,
-        host.sessions_live(),
-        host.turns_delivered,
-        host.turns_ok,
-        host.turns_err,
-        host.deliveries_to_unknown_session,
-        effects.effects_ok,
-        effects.effects_retryable_err,
-        effects.effects_permanent_err,
-        effects.effects_timed_out,
-        effects.effects_total(),
-    )
-}
-
 fn state_str(state: SessionState) -> &'static str {
     match state {
         SessionState::Closed => "Closed",
@@ -398,33 +353,5 @@ mod tests {
         let json = host_session_status_json(&host, &id, Some(0), DEFAULT_STALL_AFTER_MS).unwrap();
         assert!(json.contains("\"state\":\"Quiescent\""), "{json}");
         assert!(json.contains("\"in_flight\":[]"), "{json}");
-    }
-
-    #[test]
-    fn host_metrics_json_renders_both_snapshots_with_derived_fields() {
-        // The metrics read surface: host-boundary + per-effect snapshots → one fixed-shape JSON object with
-        // the derived fields (sessions.live = installed−removed; effects.total = ok+retryable+permanent+timed_out).
-        let host = crate::HostMetricsSnapshot {
-            sessions_installed: 3,
-            sessions_removed: 1,
-            turns_delivered: 10,
-            turns_ok: 9,
-            turns_err: 1,
-            deliveries_to_unknown_session: 2,
-        };
-        let effects = crate::EffectMetricsSnapshot {
-            effects_ok: 40,
-            effects_retryable_err: 3,
-            effects_permanent_err: 1,
-            effects_timed_out: 0,
-        };
-        let json = host_metrics_json(&host, &effects);
-        assert_eq!(
-            json,
-            "{\"sessions\":{\"installed\":3,\"removed\":1,\"live\":2},\
-             \"turns\":{\"delivered\":10,\"ok\":9,\"err\":1,\"to_unknown_session\":2},\
-             \"effects\":{\"ok\":40,\"retryable_err\":3,\"permanent_err\":1,\"timed_out\":0,\"total\":44}}",
-            "{json}"
-        );
     }
 }


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 77bd98c05, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.