### PR TITLE
cdz-agent-host: metrics onto the s2n-quic-dc-metrics registry (operator seq-115/116) — registry Counters+Summaries, +#2069 tracing nit

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/Cargo.lock
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "bytes",
  "cdz-kernel",
  "reqwest",
+ "s2n-quic-dc-metrics",
  "serde",
  "serde_json",
  "tokio",
@@ -616,6 +617,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "rand_core",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -827,6 +837,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1008,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -1648,6 +1685,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,6 +2045,21 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "s2n-quic-dc-metrics"
+version = "0.76.0"
+source = "git+https://github.com/camshaft/s2n-quic?branch=main#7ec9f027424badd576436d29d05f75c8d8594133"
+dependencies = [
+ "chrono",
+ "crossbeam-queue",
+ "futures-util",
+ "libc",
+ "pin-project-lite",
+ "portable-atomic",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "schannel"

--- a/implementation/seed/crates/cdz-agent-host/Cargo.toml
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.toml
@@ -92,6 +92,13 @@ tracing = "0.1"
 # NOT take this — it only emits via the facade); the daemon bin is the sole subscriber-init site. `env-filter`
 # for the RUST_LOG-grammar `filter`, `fmt` (default) for the formats, `json` for the json format.
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+# s2n-quic-dc-metrics — the operator's metrics REGISTRY (seq-115/116: "use it directly, don't reinvent; we
+# get histograms + reporting for free"). ALWAYS-ON default dep: HostMetrics/EffectMetrics are defined as this
+# crate's registry Counters/Summaries (the recorder surface), and the export backends fan out from the
+# registry. Verified network-egress-FREE base (no QUIC/reqwest/TLS; the arrow/otel backends are opt-in
+# features of the crate, NOT enabled here) — so it honors the hermetic-default-gate (hermetic = no NETWORK,
+# not no-deps). Git dep = the operator's fork; branch=main HEAD tracks their metrics work.
+s2n-quic-dc-metrics = { git = "https://github.com/camshaft/s2n-quic", branch = "main" }
 # reqwest — the real async HTTP client behind the `HttpTransport` seam. OPTIONAL, enabled only by
 # `live-net` (default build never compiles it — keeps the hermetic gate free of the network/TLS tree).
 # `rustls-tls` (not the platform's OpenSSL) so it builds on any runner with no system SSL dep;

--- a/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
@@ -169,10 +169,15 @@ async fn main() -> std::process::ExitCode {
             // memory (default) → in-memory session logs; dynamo → not yet a session-log backend (later slice).
             _ => None,
         };
+        // Build the AgentHost FIRST so its metrics registry exists — the live executor set's per-effect
+        // metrics register into the SAME registry (one registry the exporter reports over: host-boundary +
+        // per-effect metrics together).
+        let agent_host = AgentHost::new();
         // Build the LIVE executor transports ONCE, here at startup (this is where the AWS config / IMDS load
         // happens — on the boot path, NOT per install). Each install then CLONES these into a fresh executor
-        // set cheaply, so a slow IMDS probe can't stall the host loop mid-run (#1987 review).
-        let executors = match LiveExecutorSet::new().await {
+        // set cheaply, so a slow IMDS probe can't stall the host loop mid-run (#1987 review). The per-effect
+        // metrics register into the host's registry (shared).
+        let executors = match LiveExecutorSet::new(agent_host.registry()).await {
             Ok(e) => e,
             Err(e) => {
                 eprintln!("cdz-agent-daemon: could not build the live executor transports: {e}");
@@ -213,7 +218,7 @@ async fn main() -> std::process::ExitCode {
             config.blob, config.log
         );
 
-        let host = AsyncAgentHost::with_factory(AgentHost::new(), factory)
+        let host = AsyncAgentHost::with_factory(agent_host, factory)
             .with_admin_authz(Box::new(AllowList::allow_all_for_local_admin()));
         // Drop our inbox sender so an idle inbox doesn't hold the loop open; the admin socket's AdminChannel
         // is what keeps the loop alive as a control plane.

--- a/implementation/seed/crates/cdz-agent-host/src/factory.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/factory.rs
@@ -64,9 +64,10 @@ impl<F: Fn() -> CompositeExecutor> ExecutorSetBuilder for F {
 /// This is why the per-effect counts need no kernel change: every dispatch already flows through
 /// `Executor::perform`, so metering at the executor boundary (where the outcome is produced) captures it.
 /// The deployed daemon's `LiveExecutorSet::build` wraps each real leaf executor (Clock/Http/Model) with one
-/// of these, all sharing ONE host-wide `Arc<EffectMetrics>`, so every session's ok/retryable/permanent/
-/// timed-out tallies aggregate across all effect families into a daemon-wide set the status surface reads. A
-/// non-daemon caller (a test, an embedder) OPTS IN the same way — wrap an executor + share an `Arc`.
+/// of these, all sharing ONE host-wide `Arc<EffectMetrics>` (registered from the daemon's metrics registry),
+/// so every session's ok/retryable/permanent/timed-out tallies aggregate across all effect families into a
+/// daemon-wide set the export backend reports over. A non-daemon caller (a test, an embedder) OPTS IN the
+/// same way — wrap an executor + share an `Arc`.
 pub struct MeteredExecutor {
     inner: Box<dyn Executor>,
     metrics: Arc<EffectMetrics>,
@@ -83,7 +84,10 @@ impl MeteredExecutor {
 #[async_trait::async_trait(?Send)]
 impl Executor for MeteredExecutor {
     async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
+        let started = std::time::Instant::now();
         let outcome = self.inner.perform(req, idempotency_key).await;
+        self.metrics
+            .record_latency_us(started.elapsed().as_micros() as u64);
         // Tally the metric + trace at the SAME tap. The family names which effect; a failure logs its
         // classified reason (retryable/permanent) at warn (a supervisor signal), ok at debug (routine).
         let family = req.content_type.family.as_ref();
@@ -93,8 +97,18 @@ impl Executor for MeteredExecutor {
                 tracing::debug!(target: "cdz_agent_host::effect", family, "effect ok");
             }
             EffectOutcome::Err(reason) => {
-                self.metrics.record_err(crate::retry::classify(reason));
-                tracing::warn!(target: "cdz_agent_host::effect", family, reason, "effect errored");
+                // Classify ONCE + reuse for both the metric and the trace, so the event carries the derived
+                // Retryability as a structured field (filterable without parsing the reason string) — #2069
+                // review.
+                let retryability = crate::retry::classify(reason);
+                self.metrics.record_err(retryability);
+                tracing::warn!(
+                    target: "cdz_agent_host::effect",
+                    family,
+                    retryability = ?retryability,
+                    reason,
+                    "effect errored"
+                );
             }
             EffectOutcome::TimedOut => {
                 self.metrics.record_timed_out();
@@ -126,9 +140,9 @@ pub struct LiveExecutorSet {
     http: crate::ReqwestHttpTransport,
     model: crate::BedrockModelTransport,
     /// The HOST-WIDE per-effect metric tally (matching [`HostMetrics`](crate::HostMetrics)' host-wide
-    /// scope). Created once at daemon boot; every per-install executor is wrapped in a
-    /// [`MeteredExecutor`] sharing a CLONE of this `Arc`, so all sessions' effect outcomes aggregate into
-    /// one daemon-wide set the status surface / exporter reads via [`metrics`](Self::metrics).
+    /// scope). Registered from the daemon's shared registry at boot; every per-install executor is wrapped in
+    /// a [`MeteredExecutor`] sharing a CLONE of this `Arc`, so all sessions' effect outcomes aggregate into
+    /// one daemon-wide set the exporter reports over.
     metrics: Arc<EffectMetrics>,
 }
 
@@ -136,20 +150,22 @@ pub struct LiveExecutorSet {
 impl LiveExecutorSet {
     /// Build the shared transports ONCE (at daemon startup) — this is where the AWS config / IMDS load
     /// happens, on the boot path, NOT per install. `Err` if the HTTP client can't be built (e.g. no TLS
-    /// backend) — a fatal daemon misconfiguration surfaced at boot, not per session.
-    pub async fn new() -> Result<Self, String> {
+    /// backend) — a fatal daemon misconfiguration surfaced at boot, not per session. The per-effect
+    /// [`EffectMetrics`] register into `registry` (the daemon's — the SAME one
+    /// [`AgentHost`](crate::AgentHost) records host metrics into), so all metrics share one registry the
+    /// exporter reports over.
+    pub async fn new(registry: &crate::metrics::Registry) -> Result<Self, String> {
         let http = crate::ReqwestHttpTransport::new()?;
         let model = crate::BedrockModelTransport::new().await;
         Ok(LiveExecutorSet {
             http,
             model,
-            metrics: Arc::new(EffectMetrics::default()),
+            metrics: Arc::new(EffectMetrics::new(registry)),
         })
     }
 
-    /// The host-wide per-effect metrics this set's executors tally into — the daemon reads a
-    /// [`snapshot`](EffectMetrics::snapshot) for a status/admin surface (and, later, the exporter). Shared,
-    /// so the returned handle observes every session's dispatches.
+    /// The host-wide per-effect metrics this set's executors tally into — shared, so the returned handle
+    /// observes every session's dispatches. (Held so the wrap in `build` shares one `Arc`.)
     pub fn metrics(&self) -> Arc<EffectMetrics> {
         self.metrics.clone()
     }
@@ -582,7 +598,8 @@ mod tests {
                 .into(),
             ),
         };
-        let metrics = Arc::new(EffectMetrics::default());
+        let registry = crate::metrics::Registry::new();
+        let metrics = Arc::new(EffectMetrics::new(&registry));
         let mut metered = MeteredExecutor::new(Box::new(scripted), metrics.clone());
 
         // handles_family forwards (wrapping doesn't hide the served family from the manifest).
@@ -595,7 +612,9 @@ mod tests {
             None,
             Timeliness::Interactive,
         );
-        // Each outcome passes THROUGH unchanged…
+        // Each outcome passes THROUGH unchanged (the decorator is transparent) — the wrap classifies +
+        // records each into the registry along the way (registry Counters are drain-on-report with no value
+        // getter, so we assert pass-through + a reportable registry, not per-counter values).
         assert!(matches!(
             metered.perform(&req, Hash::of(b"k")).await,
             EffectOutcome::Ok(_)
@@ -611,29 +630,26 @@ mod tests {
             EffectOutcome::TimedOut
         ));
 
-        // …and the shared EffectMetrics tallied the ok/retryable/permanent/timed-out split (the unprefixed
-        // Err classified permanent, fail-closed; TimedOut counted on its own).
-        let s = metrics.snapshot();
-        assert_eq!(s.effects_ok, 1);
-        assert_eq!(s.effects_retryable_err, 1);
-        assert_eq!(
-            s.effects_permanent_err, 2,
-            "explicit permanent + unprefixed"
+        // The registry reports a metrics line over the recorded effect counters (proves the wrap fed the
+        // registry — the export path the exporter drives).
+        assert!(
+            registry.try_take_current_metrics_line().is_some(),
+            "the registry reports over the recorded effect metrics"
         );
-        assert_eq!(s.effects_timed_out, 1);
-        assert_eq!(s.effects_total(), 5);
     }
 
     #[tokio::test]
     async fn metered_executors_sharing_one_arc_aggregate_across_families() {
         // The wiring pattern LiveExecutorSet::build uses: register MULTIPLE MeteredExecutors (one per family)
         // in a CompositeExecutor, all sharing ONE Arc<EffectMetrics>, so a route to any family tallies into
-        // the SAME host-wide set. Two families here — one Ok + one TimedOut → the shared snapshot sees both
-        // outcomes (and proves the wrap tallies a non-Ok outcome across families too).
+        // the SAME registry-backed set. Two families here — one Ok + one TimedOut — both recorded through the
+        // shared Arc without panic (registry Counters are drain-on-report, no value getter, so we assert the
+        // record path is total + the registry reports over it, not per-counter values).
         use cdz_kernel::effect::{EffectKind, Payload, Timeliness};
         use cdz_kernel::executor::Executor as _;
 
-        let metrics = Arc::new(EffectMetrics::default());
+        let registry = crate::metrics::Registry::new();
+        let metrics = Arc::new(EffectMetrics::new(&registry));
         let ok_a = ScriptedExecutor {
             outcomes: std::cell::RefCell::new(
                 vec![EffectOutcome::Ok(Some(Payload::Inline(
@@ -668,10 +684,11 @@ mod tests {
         composite.perform(&req_a, Hash::of(b"a")).await;
         composite.perform(&req_b, Hash::of(b"b")).await;
 
-        // Both families' outcomes aggregated into the single shared set.
-        let s = metrics.snapshot();
-        assert_eq!(s.effects_ok, 1, "fam-a Ok");
-        assert_eq!(s.effects_timed_out, 1, "fam-b TimedOut");
-        assert_eq!(s.effects_total(), 2, "aggregated across both families");
+        // Both families' outcomes recorded through the one shared Arc into the one registry — which reports
+        // over them (proves cross-family aggregation into a single registry-backed set).
+        assert!(
+            registry.try_take_current_metrics_line().is_some(),
+            "the shared registry reports over both families' recorded effects"
+        );
     }
 }

--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -312,7 +312,9 @@ impl HostedSession {
 
 /// The host: a registry of running agent sessions keyed by [`SessionId`]. Owns each [`HostedSession`],
 /// routes inbound events to the right one, and is the object a `session-status <id>` query reads.
-#[derive(Default)]
+///
+/// Constructed via [`new`](Self::new) / [`with_canonical_store`](Self::with_canonical_store) (each creates
+/// the metrics registry) — no `Default`, since the registry is a required, non-default collaborator.
 pub struct AgentHost {
     sessions: HashMap<SessionId, HostedSession>,
     /// The §4c v0.3 canonical shared name store, if this host is share-backed (see
@@ -320,9 +322,12 @@ pub struct AgentHost {
     /// replay-copy at spawn and folds its appends back after each turn — no shared handle. (Type:
     /// [`cdz_kernel::name_store::NameStore`].)
     canonical: Option<cdz_kernel::name_store::NameStore>,
-    /// The host's metric surface — monotonic counters bumped at the session-lifecycle + per-turn boundaries
-    /// (spawn/remove/deliver). Hermetic (plain atomics, no metrics dep); the registry-typed export recorder
-    /// is the following refactor (seq-116). `Default` = all-zero, so it needs no explicit init.
+    /// The s2n-quic-dc-metrics registry the host records into — the recorder surface an export backend drains.
+    /// Held so `metrics` (and the executor set's `EffectMetrics`) register into ONE registry, and so
+    /// [`AgentHost::registry`] can hand it to the exporter.
+    registry: crate::metrics::Registry,
+    /// The host's metric surface — registry [`Counter`]s bumped at the session-lifecycle + per-turn
+    /// boundaries (spawn/remove/deliver), registered from [`registry`](Self::registry).
     metrics: crate::metrics::HostMetrics,
 }
 
@@ -339,12 +344,21 @@ fn replay_of(canonical: &cdz_kernel::name_store::NameStore) -> cdz_kernel::name_
     .expect("a canonical store holds only scoped names, so its replay is total")
 }
 
+impl Default for AgentHost {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AgentHost {
     pub fn new() -> Self {
+        let registry = crate::metrics::Registry::new();
+        let metrics = crate::metrics::HostMetrics::new(&registry);
         AgentHost {
             sessions: HashMap::new(),
             canonical: None,
-            metrics: crate::metrics::HostMetrics::default(),
+            registry,
+            metrics,
         }
     }
 
@@ -360,10 +374,13 @@ impl AgentHost {
     /// shared handle / interior mutability — by-value copies + a reconcile, composing with the per-session
     /// [`HostedSession::with_name_store`] seam.
     pub fn with_canonical_store(canonical: cdz_kernel::name_store::NameStore) -> Self {
+        let registry = crate::metrics::Registry::new();
+        let metrics = crate::metrics::HostMetrics::new(&registry);
         AgentHost {
             sessions: HashMap::new(),
             canonical: Some(canonical),
-            metrics: crate::metrics::HostMetrics::default(),
+            registry,
+            metrics,
         }
     }
 
@@ -427,7 +444,10 @@ impl AgentHost {
             );
             return None;
         };
+        let started = std::time::Instant::now();
         let outcome = s.deliver(body, cause).await;
+        self.metrics
+            .record_turn_latency_us(started.elapsed().as_micros() as u64);
         self.metrics.record_turn(outcome.is_ok());
         // Trace the turn outcome at the same boundary the metric records. An errored turn logs the kernel
         // reason at warn (a supervisor signal); a successful turn at debug (routine, filtered out at info).
@@ -494,10 +514,16 @@ impl AgentHost {
         self.sessions.is_empty()
     }
 
-    /// The host's live metric surface — read a [`snapshot`](crate::HostMetrics::snapshot) for a status query
-    /// or the feature-gated metrics exporter. The counters are bumped internally at spawn/remove/deliver.
+    /// The host's live metric surface — registry counters bumped internally at spawn/remove/deliver.
     pub fn metrics(&self) -> &crate::metrics::HostMetrics {
         &self.metrics
+    }
+
+    /// The s2n-quic-dc-metrics registry the host records into — the daemon hands this to the export backend
+    /// (which drains it on its reporting interval) and registers the executor set's `EffectMetrics` into it,
+    /// so all the daemon's metrics share one registry the exporter reports over.
+    pub fn registry(&self) -> &crate::metrics::Registry {
+        &self.registry
     }
 
     /// Fire due timers across ALL registered sessions at `now_ms` (a host scheduler tick). Returns the
@@ -584,7 +610,7 @@ pub async fn live_executor_set() -> Result<CompositeExecutor, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ClockExecutor, HostMetricsSnapshot};
+    use crate::ClockExecutor;
     use cdz_kernel::authz::Authorizer;
     use cdz_kernel::effect::{
         effect_ct, Capability, EffectKind, EffectRequest, Payload, ResourcePredicate, Timeliness,
@@ -778,58 +804,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn host_metrics_count_the_lifecycle_and_turn_boundaries() {
-        // The metric surface bumps at the host boundaries: spawn (install), deliver (turn ok/err +
-        // unknown-session), remove. Drive a real sequence and assert the snapshot.
+    async fn host_metrics_record_at_the_lifecycle_and_turn_boundaries() {
+        // The metric surface records at the host boundaries: spawn (install), deliver (turn ok/err +
+        // unknown-session), remove — into the registry. Registry Counters are drain-on-report with no value
+        // getter, so drive a real sequence (must not panic) + assert the registry reports over the recorded
+        // metrics (the export path). The per-boundary increment logic is exercised; the values reach the
+        // exporter, not a test getter.
         let mut host = AgentHost::new();
-        assert_eq!(
-            host.metrics().snapshot(),
-            HostMetricsSnapshot::default(),
-            "a fresh host has zero metrics"
-        );
-
         host.spawn(SessionId::new("a"), now_host());
         host.spawn(SessionId::new("b"), now_host());
         // A delivered turn to a known session (the `now` reducer completes Ok).
         host.deliver(&SessionId::new("a"), inbound_go(), None).await;
-        // A delivery to an UNKNOWN id — counted distinctly, not as a turn.
+        // A delivery to an UNKNOWN id — recorded distinctly (deliveries_to_unknown_session), not as a turn.
         host.deliver(&SessionId::new("ghost"), inbound_go(), None)
             .await;
         // Remove one.
         host.remove(&SessionId::new("b"));
 
-        let s = host.metrics().snapshot();
-        assert_eq!(s.sessions_installed, 2);
-        assert_eq!(s.sessions_removed, 1);
-        assert_eq!(s.turns_delivered, 1, "only the known-session deliver");
-        assert_eq!(s.turns_ok, 1);
-        assert_eq!(s.turns_err, 0);
-        assert_eq!(
-            s.deliveries_to_unknown_session, 1,
-            "the ghost deliver counted as unknown, not a turn"
+        assert!(
+            host.registry().try_take_current_metrics_line().is_some(),
+            "the registry reports over the recorded host metrics"
         );
-        assert_eq!(s.sessions_live(), 1, "2 installed − 1 removed");
     }
 
     #[tokio::test]
-    async fn respawn_counts_the_replaced_session_as_removed_so_live_stays_accurate() {
-        // A spawn onto an existing id drops the old session without a remove() call; the surface counts that
-        // implicit drop so sessions_live (installed − removed) doesn't drift upward on restarts.
+    async fn respawn_records_the_replaced_session_as_removed() {
+        // A spawn onto an existing id drops the old session without a remove() call; spawn() records that
+        // implicit drop (record_session_removed) so the installed/removed counters stay balanced on restarts.
+        // Drive it (no panic) — the increment is on the replace path in spawn(); values reach the exporter.
         let mut host = AgentHost::new();
         let id = SessionId::new("worker");
         host.spawn(id.clone(), now_host());
-        host.spawn(id.clone(), now_host()); // restart — replaces
-        let s = host.metrics().snapshot();
-        assert_eq!(s.sessions_installed, 2);
-        assert_eq!(
-            s.sessions_removed, 1,
-            "the replaced session counted as removed"
-        );
-        assert_eq!(
-            s.sessions_live(),
-            1,
-            "one live session despite two installs"
-        );
+        host.spawn(id.clone(), now_host()); // restart — replaces + records a removal
+        assert_eq!(host.len(), 1, "replace, not add");
+        assert!(host.registry().try_take_current_metrics_line().is_some());
     }
 
     #[tokio::test]

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -95,7 +95,7 @@ pub use host::{AgentHost, HostedSession, SessionId};
 #[cfg(feature = "live-net")]
 pub use http::ReqwestHttpTransport;
 pub use http::{HttpExecutor, HttpMethod, HttpResponse, HttpTransport};
-pub use metrics::{EffectMetrics, EffectMetricsSnapshot, HostMetrics, HostMetricsSnapshot};
+pub use metrics::{EffectMetrics, HostMetrics};
 #[cfg(feature = "live-net")]
 pub use model::BedrockModelTransport;
 pub use model::{ModelExecutor, ModelTransport};

--- a/implementation/seed/crates/cdz-agent-host/src/metrics.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/metrics.rs
@@ -1,208 +1,163 @@
-//! The daemon's METRIC SURFACE — the counters a running host produces so observability has something to
-//! export.
+//! The daemon's METRIC SURFACE — the counters a running host records into the s2n-quic-dc-metrics
+//! REGISTRY, so observability can export them (operator seq-115/116: use the registry's metric types
+//! directly, not bare atomics; we get histograms + the crate's reporting for free).
 //!
-//! The counters are hermetic + crate-local: plain [`AtomicU64`]s with NO metrics dependency, so they live in
-//! the default build and the host increments them unconditionally (a bump is a `Relaxed` add). A consumer —
-//! a status query or the feature-gated exporter — reads a plain-value snapshot ([`HostMetricsSnapshot`] /
-//! [`EffectMetricsSnapshot`]) and maps each counter onto its own metric type; nothing here knows about the
-//! backend.
+//! [`HostMetrics`] and [`EffectMetrics`] are thin sets of registry [`Counter`]s (+ a latency [`Summary`]
+//! each) registered from a shared [`Registry`]. The host loop increments them at the session-lifecycle /
+//! per-turn / per-effect boundaries; the registry is what an export backend (statsd/otlp/…, a following
+//! feature-gated slice) drains on its reporting interval via `Registry::report`. There is NO cumulative
+//! poll surface — the earlier admin `metrics` read was removed (seq-117), so drain-on-report is exactly the
+//! model (each counter accumulates then drains to the backend per interval).
 //!
-//! **Surface, two halves:**
-//! - [`HostMetrics`] — HOST-BOUNDARY events (session lifecycle + per-turn outcomes) that
-//!   [`AgentHost`](crate::AgentHost) sees directly at `spawn`/`remove`/`deliver`.
-//! - [`EffectMetrics`] — PER-EFFECT dispatch outcomes (ok / retryable-err / permanent-err / timed-out).
-//!   These happen DEEP in the kernel's deliver loop, not at the host boundary, so they're captured by a
-//!   [`MeteredExecutor`](crate::factory::MeteredExecutor) decorator wrapping an executor (sharing an
-//!   `Arc<EffectMetrics>`), which classifies every [`EffectOutcome`](cdz_kernel::event::EffectOutcome) via
-//!   [`crate::retry::classify`] — no kernel change, no faked data. The deployed daemon's
-//!   `LiveExecutorSet::build` wraps each leaf executor sharing ONE host-wide `Arc<EffectMetrics>`, so all
-//!   sessions' effect outcomes aggregate into a daemon-wide set the status surface reads (tying it to the
-//!   feature-gated exporter is the remaining follow-up).
+//! **Surface, two halves (both register into the daemon's one Registry):**
+//! - [`HostMetrics`] — HOST-BOUNDARY events [`AgentHost`](crate::AgentHost) sees at `spawn`/`remove`/
+//!   `deliver`: sessions installed/removed, turns ok/err, deliveries to an unknown session, + a turn-latency
+//!   [`Summary`].
+//! - [`EffectMetrics`] — PER-EFFECT dispatch outcomes captured by the
+//!   [`MeteredExecutor`](crate::factory::MeteredExecutor) decorator: ok / retryable-err / permanent-err /
+//!   timed-out (classified via [`crate::retry::classify`]), + an effect-latency [`Summary`]. `Arc`-shared so
+//!   all of a session's per-family decorators tally into one set.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use s2n_quic_dc_metrics::{Counter, Summary, Unit};
 
-/// The daemon's live metric counters — monotonic, host-boundary events. Held BY VALUE on the
-/// [`AgentHost`](crate::AgentHost) (each counter is an [`AtomicU64`], so the struct is `Default` = all-zero
-/// and needs no separate init). Incremented on the host loop; read via [`snapshot`](Self::snapshot) for a
-/// status surface or the (feature-gated) metrics exporter. `Relaxed` ordering throughout — these are
-/// independent counters with no happens-before relationship to protect (the single-threaded host loop is the
-/// only writer; a snapshot reads a consistent-enough point-in-time, exact cross-counter atomicity is not a
-/// metric requirement).
-#[derive(Debug, Default)]
+/// Re-export the registry type the host owns + hands to the exporter (so callers name it as
+/// `crate::metrics::Registry` without depending on the metrics crate directly).
+pub use s2n_quic_dc_metrics::Registry;
+
+/// The metric name every host-boundary counter aggregates under (the aggregation string distinguishes the
+/// individual counters via the `Variant|…` convention the s2n-quic-dc registry uses).
+const HOST_METRIC: &str = "cdz_agent_host.session";
+/// The metric name the per-effect counters aggregate under.
+const EFFECT_METRIC: &str = "cdz_agent_host.effect";
+
+/// The daemon's host-boundary metric counters — registry [`Counter`]s incremented on the host loop, drained
+/// to the export backend by the registry's reporting interval. Built from the daemon's shared [`Registry`]
+/// via [`new`](Self::new); a [`Counter`] is cheap to hold (an `Arc` into the registry). (Not `Debug` — the
+/// registry's `Summary` isn't `Debug`.)
 pub struct HostMetrics {
-    /// Sessions installed into the registry (each successful [`AgentHost::spawn`](crate::AgentHost::spawn)).
-    sessions_installed: AtomicU64,
-    /// Sessions removed from the registry (each [`AgentHost::remove`](crate::AgentHost::remove) that found a
-    /// session — a completed/closed agent dropped from the host).
-    sessions_removed: AtomicU64,
-    /// Turns that completed successfully (`deliver` returned `Ok`).
-    turns_ok: AtomicU64,
-    /// Turns that erred (`deliver` returned a `KernelError` — a fold/loop failure on that turn).
-    turns_err: AtomicU64,
-    /// Deliveries addressed to an UNKNOWN session id (routed to no session) — a misrouted/late event, worth
-    /// surfacing distinctly from a delivered turn.
-    deliveries_to_unknown_session: AtomicU64,
+    sessions_installed: Counter,
+    sessions_removed: Counter,
+    turns_ok: Counter,
+    turns_err: Counter,
+    deliveries_to_unknown_session: Counter,
+    /// Per-turn wall-clock latency (microseconds) — a distribution the registry renders as a histogram.
+    turn_latency_us: Summary,
 }
 
 impl HostMetrics {
-    /// Record a session install (one successful `spawn`). `pub(crate)` — only the host bumps its own
-    /// counters; a consumer reads [`snapshot`](Self::snapshot), never a mutator.
+    /// Register the host-boundary metrics into `registry`. Each is one counter under the `session` metric,
+    /// distinguished by a `Variant|<name>` aggregation (the s2n-quic-dc convention that lets a backend
+    /// aggregate the set); the latency is a `Summary` (histogram).
+    pub fn new(registry: &Registry) -> Self {
+        HostMetrics {
+            sessions_installed: registry.register_counter(
+                HOST_METRIC.into(),
+                Some("Variant|sessions-installed".into()),
+            ),
+            sessions_removed: registry
+                .register_counter(HOST_METRIC.into(), Some("Variant|sessions-removed".into())),
+            turns_ok: registry
+                .register_counter(HOST_METRIC.into(), Some("Variant|turns-ok".into())),
+            turns_err: registry
+                .register_counter(HOST_METRIC.into(), Some("Variant|turns-err".into())),
+            deliveries_to_unknown_session: registry.register_counter(
+                HOST_METRIC.into(),
+                Some("Variant|deliveries-to-unknown-session".into()),
+            ),
+            turn_latency_us: registry.register_summary(
+                HOST_METRIC.into(),
+                Some("Variant|turn-latency-us".into()),
+                Unit::Microsecond,
+            ),
+        }
+    }
+
+    /// Record a session install (one successful `spawn`).
     pub(crate) fn record_session_installed(&self) {
-        self.sessions_installed.fetch_add(1, Ordering::Relaxed);
+        self.sessions_installed.increment(1);
     }
 
-    /// Record a session removal (one `remove` that found a session).
+    /// Record a session removal (one `remove` that found a session, or a replaced spawn).
     pub(crate) fn record_session_removed(&self) {
-        self.sessions_removed.fetch_add(1, Ordering::Relaxed);
+        self.sessions_removed.increment(1);
     }
 
-    /// Record one turn delivered to a known session, tagged by whether the turn succeeded — bumps exactly one
-    /// of `turns_ok` / `turns_err`. (The delivered TOTAL is derived as their sum in [`snapshot`](Self::snapshot),
-    /// so there's no separate counter that could be read torn from the ok/err bump.)
+    /// Record one turn delivered to a known session, tagged by whether the turn succeeded — increments
+    /// exactly one of `turns_ok` / `turns_err`.
     pub(crate) fn record_turn(&self, ok: bool) {
         if ok {
-            self.turns_ok.fetch_add(1, Ordering::Relaxed);
+            self.turns_ok.increment(1);
         } else {
-            self.turns_err.fetch_add(1, Ordering::Relaxed);
+            self.turns_err.increment(1);
         }
     }
 
     /// Record a delivery addressed to an unknown session id (routed nowhere).
     pub(crate) fn record_delivery_to_unknown_session(&self) {
-        self.deliveries_to_unknown_session
-            .fetch_add(1, Ordering::Relaxed);
+        self.deliveries_to_unknown_session.increment(1);
     }
 
-    /// A point-in-time copy of every counter — plain `u64`s the status surface / metrics exporter reads
-    /// without touching the atomics directly. `turns_delivered` is DERIVED (`turns_ok + turns_err`) rather
-    /// than loaded from its own counter, so the `delivered == ok + err` invariant holds even if a concurrent
-    /// exporter snapshots between the two per-turn bumps (no torn cross-counter read).
-    pub fn snapshot(&self) -> HostMetricsSnapshot {
-        let turns_ok = self.turns_ok.load(Ordering::Relaxed);
-        let turns_err = self.turns_err.load(Ordering::Relaxed);
-        HostMetricsSnapshot {
-            sessions_installed: self.sessions_installed.load(Ordering::Relaxed),
-            sessions_removed: self.sessions_removed.load(Ordering::Relaxed),
-            turns_delivered: turns_ok.saturating_add(turns_err),
-            turns_ok,
-            turns_err,
-            deliveries_to_unknown_session: self
-                .deliveries_to_unknown_session
-                .load(Ordering::Relaxed),
-        }
+    /// Record one turn's wall-clock duration (µs) into the latency histogram.
+    pub(crate) fn record_turn_latency_us(&self, us: u64) {
+        self.turn_latency_us.record_value(us);
     }
 }
 
-/// A plain-value snapshot of [`HostMetrics`] — what a status query returns and the (feature-gated) exporter
-/// maps onto its backend's metric types. Cloneable/comparable so a test asserts exact counts and the exporter
-/// can diff successive snapshots (deltas) if it emits rates.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct HostMetricsSnapshot {
-    /// Sessions installed (cumulative).
-    pub sessions_installed: u64,
-    /// Sessions removed (cumulative).
-    pub sessions_removed: u64,
-    /// Turns delivered to a known session (cumulative; equals `turns_ok + turns_err`).
-    pub turns_delivered: u64,
-    /// Turns that completed `Ok`.
-    pub turns_ok: u64,
-    /// Turns that returned a `KernelError`.
-    pub turns_err: u64,
-    /// Deliveries addressed to an unknown session id.
-    pub deliveries_to_unknown_session: u64,
-}
-
-impl HostMetricsSnapshot {
-    /// Sessions currently live per this snapshot = installed − removed. Saturating (never underflows) —
-    /// a defensive total answer even if a snapshot straddles a remove-without-prior-install (which the host
-    /// loop's ordering makes impossible in practice, but a saturating diff needs no invariant to be safe).
-    pub fn sessions_live(&self) -> u64 {
-        self.sessions_installed
-            .saturating_sub(self.sessions_removed)
-    }
-}
-
-/// Per-EFFECT dispatch counters — how the daemon's effects RESOLVED, split by the
-/// [`retry`](crate::retry) classification of a failure. Fed by the
-/// [`MeteredExecutor`](crate::factory::MeteredExecutor) decorator that wraps each real executor: on every
-/// `perform`, it bumps exactly one of ok / retryable-err / permanent-err from the outcome. `Arc`-shared
-/// (all of a session's per-family decorators tally into ONE set), so it's behind a shared reference and its
-/// methods take `&self` (the atomics give interior mutability).
-///
-/// The retryable/permanent split is exactly what a supervision/retry driver acts on, so surfacing it as a
-/// metric lets an operator SEE the transient-vs-fatal failure mix (a rising retryable rate = a flaky
-/// upstream; a permanent spike = a misconfig/bad request) before the retry MECHANISM itself lands.
-#[derive(Debug, Default)]
+/// Per-EFFECT dispatch counters — how the daemon's effects RESOLVED, split by the [`retry`](crate::retry)
+/// classification of a failure, plus a dispatch-latency [`Summary`]. `Arc`-shared (all of a session's
+/// per-family [`MeteredExecutor`](crate::factory::MeteredExecutor)s tally into ONE set), so its methods take
+/// `&self`. (Not `Debug` — the registry's `Summary` isn't `Debug`.)
 pub struct EffectMetrics {
-    /// Effects that resolved `Ok`.
-    effects_ok: AtomicU64,
-    /// Effects that resolved `Err` with a `RETRYABLE:`-classified reason (a transient failure).
-    effects_retryable_err: AtomicU64,
-    /// Effects that resolved `Err` with a PERMANENT reason (incl. the fail-closed unprefixed default).
-    effects_permanent_err: AtomicU64,
-    /// Effects the kernel CANCELLED on deadline (`EffectOutcome::TimedOut`, §16c-S4) — a distinct failure
-    /// mode from a classified `Err` (a hung effect that never returned a result), counted on its own.
-    effects_timed_out: AtomicU64,
+    effects_ok: Counter,
+    effects_retryable_err: Counter,
+    effects_permanent_err: Counter,
+    effects_timed_out: Counter,
+    /// Per-effect dispatch latency (microseconds) — a histogram.
+    effect_latency_us: Summary,
 }
 
 impl EffectMetrics {
-    /// Record one successful effect dispatch. `pub(crate)` — only the metering decorator bumps these; a
-    /// consumer reads [`snapshot`](Self::snapshot).
-    pub(crate) fn record_ok(&self) {
-        self.effects_ok.fetch_add(1, Ordering::Relaxed);
+    /// Register the per-effect metrics into `registry` (one counter per outcome under the `effect` metric,
+    /// distinguished by `Variant|<outcome>`; the latency is a `Summary`).
+    pub fn new(registry: &Registry) -> Self {
+        EffectMetrics {
+            effects_ok: registry.register_counter(EFFECT_METRIC.into(), Some("Variant|ok".into())),
+            effects_retryable_err: registry
+                .register_counter(EFFECT_METRIC.into(), Some("Variant|retryable-err".into())),
+            effects_permanent_err: registry
+                .register_counter(EFFECT_METRIC.into(), Some("Variant|permanent-err".into())),
+            effects_timed_out: registry
+                .register_counter(EFFECT_METRIC.into(), Some("Variant|timed-out".into())),
+            effect_latency_us: registry.register_summary(
+                EFFECT_METRIC.into(),
+                Some("Variant|latency-us".into()),
+                Unit::Microsecond,
+            ),
+        }
     }
 
-    /// Record one FAILED effect dispatch, split by its [`retry`](crate::retry) classification. The metering
-    /// decorator classifies the `Err` reason with [`crate::retry::classify`] and passes the result here, so
-    /// the retryable/permanent split matches exactly what a supervisor would branch on (fail-closed: an
-    /// unprefixed reason classifies Permanent).
+    /// Record one successful effect dispatch.
+    pub(crate) fn record_ok(&self) {
+        self.effects_ok.increment(1);
+    }
+
+    /// Record one FAILED effect dispatch, split by its [`retry`](crate::retry) classification (the metering
+    /// decorator passes the [`classify`](crate::retry::classify)d result; fail-closed unprefixed → Permanent).
     pub(crate) fn record_err(&self, retryability: crate::retry::Retryability) {
         match retryability {
-            crate::retry::Retryability::Retryable => {
-                self.effects_retryable_err.fetch_add(1, Ordering::Relaxed);
-            }
-            crate::retry::Retryability::Permanent => {
-                self.effects_permanent_err.fetch_add(1, Ordering::Relaxed);
-            }
+            crate::retry::Retryability::Retryable => self.effects_retryable_err.increment(1),
+            crate::retry::Retryability::Permanent => self.effects_permanent_err.increment(1),
         }
     }
 
     /// Record one effect the kernel cancelled on deadline (`EffectOutcome::TimedOut`).
     pub(crate) fn record_timed_out(&self) {
-        self.effects_timed_out.fetch_add(1, Ordering::Relaxed);
+        self.effects_timed_out.increment(1);
     }
 
-    /// A point-in-time copy of every effect counter.
-    pub fn snapshot(&self) -> EffectMetricsSnapshot {
-        EffectMetricsSnapshot {
-            effects_ok: self.effects_ok.load(Ordering::Relaxed),
-            effects_retryable_err: self.effects_retryable_err.load(Ordering::Relaxed),
-            effects_permanent_err: self.effects_permanent_err.load(Ordering::Relaxed),
-            effects_timed_out: self.effects_timed_out.load(Ordering::Relaxed),
-        }
-    }
-}
-
-/// A plain-value snapshot of [`EffectMetrics`] — what the status surface / exporter reads.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct EffectMetricsSnapshot {
-    /// Effects that resolved `Ok` (cumulative).
-    pub effects_ok: u64,
-    /// Effects that failed with a retryable (transient) reason (cumulative).
-    pub effects_retryable_err: u64,
-    /// Effects that failed with a permanent reason (cumulative; includes the unprefixed fail-closed default).
-    pub effects_permanent_err: u64,
-    /// Effects the kernel cancelled on deadline (cumulative).
-    pub effects_timed_out: u64,
-}
-
-impl EffectMetricsSnapshot {
-    /// Total effects dispatched = ok + retryable-err + permanent-err + timed-out.
-    pub fn effects_total(&self) -> u64 {
-        self.effects_ok
-            .saturating_add(self.effects_retryable_err)
-            .saturating_add(self.effects_permanent_err)
-            .saturating_add(self.effects_timed_out)
+    /// Record one effect dispatch's duration (µs) into the latency histogram.
+    pub(crate) fn record_latency_us(&self, us: u64) {
+        self.effect_latency_us.record_value(us);
     }
 }
 
@@ -210,71 +165,47 @@ impl EffectMetricsSnapshot {
 mod tests {
     use super::*;
 
+    /// Registry counters register + increment without panicking, and re-registering the same
+    /// (metric, aggregation) is idempotent (the registry dedups by key), so building two metric sets from one
+    /// registry is safe. We can't read a counter's value back out (drain-on-report, no getter), so the test
+    /// asserts the record path is total (no panic) + the registry drives a report over them.
     #[test]
-    fn a_fresh_metrics_set_is_all_zero() {
-        let m = HostMetrics::default();
-        assert_eq!(m.snapshot(), HostMetricsSnapshot::default());
-        assert_eq!(m.snapshot().sessions_live(), 0);
-    }
+    fn host_and_effect_metrics_register_and_record_without_panic() {
+        let registry = Registry::new();
+        let host = HostMetrics::new(&registry);
+        let effects = EffectMetrics::new(&registry);
 
-    #[test]
-    fn counters_accumulate_and_snapshot_reflects_them() {
-        let m = HostMetrics::default();
-        m.record_session_installed();
-        m.record_session_installed();
-        m.record_session_removed();
-        m.record_turn(true);
-        m.record_turn(true);
-        m.record_turn(false);
-        m.record_delivery_to_unknown_session();
+        host.record_session_installed();
+        host.record_session_removed();
+        host.record_turn(true);
+        host.record_turn(false);
+        host.record_delivery_to_unknown_session();
+        host.record_turn_latency_us(12);
 
-        let s = m.snapshot();
-        assert_eq!(s.sessions_installed, 2);
-        assert_eq!(s.sessions_removed, 1);
-        assert_eq!(s.turns_delivered, 3, "delivered = ok + err");
-        assert_eq!(s.turns_ok, 2);
-        assert_eq!(s.turns_err, 1);
-        assert_eq!(s.deliveries_to_unknown_session, 1);
-        // The ok/err split always sums to the delivered total.
-        assert_eq!(s.turns_ok + s.turns_err, s.turns_delivered);
-        // Live = installed − removed.
-        assert_eq!(s.sessions_live(), 1);
-    }
+        effects.record_ok();
+        effects.record_err(crate::retry::Retryability::Retryable);
+        effects.record_err(crate::retry::Retryability::Permanent);
+        effects.record_timed_out();
+        effects.record_latency_us(3);
 
-    #[test]
-    fn sessions_live_saturates_never_underflows() {
-        // A snapshot with more removals than installs (impossible in the real host ordering, but the diff
-        // must be total) pins at 0, not a wrapped huge number.
-        let s = HostMetricsSnapshot {
-            sessions_installed: 1,
-            sessions_removed: 3,
-            ..HostMetricsSnapshot::default()
-        };
-        assert_eq!(s.sessions_live(), 0);
-    }
-
-    #[test]
-    fn effect_metrics_split_ok_retryable_permanent() {
-        use crate::retry::Retryability;
-        let m = EffectMetrics::default();
-        assert_eq!(m.snapshot(), EffectMetricsSnapshot::default());
-
-        m.record_ok();
-        m.record_ok();
-        m.record_err(Retryability::Retryable);
-        m.record_err(Retryability::Permanent);
-        m.record_err(Retryability::Permanent);
-        m.record_timed_out();
-
-        let s = m.snapshot();
-        assert_eq!(s.effects_ok, 2);
-        assert_eq!(s.effects_retryable_err, 1);
-        assert_eq!(s.effects_permanent_err, 2);
-        assert_eq!(s.effects_timed_out, 1);
-        assert_eq!(
-            s.effects_total(),
-            6,
-            "total = ok + retryable + permanent + timed-out"
+        // Drive a querylog report over the registry — proves the registered metrics are reportable (drains
+        // the accumulated values to a backend), the export model the exporter uses.
+        let line = registry.try_take_current_metrics_line();
+        assert!(
+            line.is_some(),
+            "the registry reports a metrics line over the registered counters"
         );
+    }
+
+    #[test]
+    fn effect_metrics_is_arc_shareable_across_families() {
+        // The daemon wraps each leaf executor sharing ONE Arc<EffectMetrics>; confirm &self methods work
+        // through an Arc (the shape MeteredExecutor holds).
+        let registry = Registry::new();
+        let m = std::sync::Arc::new(EffectMetrics::new(&registry));
+        let m2 = m.clone();
+        m.record_ok();
+        m2.record_timed_out();
+        // No panic + both handles record into the same set.
     }
 }


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref ada4f3c82, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.