### PR TITLE
rcdzc(effects): FIX cross-handler inline op-arg-performs-outer — op-arg let-lift (completeness gap, breaker xh1/xh2)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -4517,14 +4517,44 @@ fn thread_bounded(
             // mirrors the applied-lambda pre-reduction's pure-args soundness guard. (`arg_reaches_any_perform`
             // is used, NOT `body_reaches_foreign_perform`, because the latter over-reports a record literal's
             // field-pair as an unresolvable call — spuriously declining a pure record argument.)
+            // OP-ARG LET-LIFT (cross-handler inline-arg-position completeness fix, breaker xh1/xh2). A
+            // MULTI-USE param whose arg PERFORMS would duplicate the effect on substitution (the guard below).
+            // For a FOREIGN perform arg — an op THIS handler does not discharge, e.g. `(B.put (A.get))` under
+            // B where `A.get` homes to the enclosing A — the sound rewrite is to BIND it once to a fresh
+            // `#cv` let and duplicate the pure ref, exactly the Site-5 hoist for performing conditions (verified
+            // by xh2: the hand-let-bound spelling `(let ((x (A.get))) (B.put x))` FOLDS while the inline arg
+            // declines). Lift each such arg BEFORE building the arm body: replace the arg with a `#cv` ref and
+            // remember the binding, then wrap the whole arm result in the `let`s (the perform runs once, in
+            // arg-evaluation order, then B's arm reads the pure `#cv` twice). Gated to FOREIGN performs (a
+            // perform of THIS handler's OWN op as a multi-use arg still declines — it needs threading, not a
+            // plain let-bind; a distinct, harder shape). A single-use or pure arg is untouched.
+            let mut arg_lifts: Vec<(StructId, StructId)> = Vec::new(); // (#cv binder, arg)
             if arm.params.len() == rewritten_args.len() {
-                for (&p, &a) in arm.params.iter().zip(&rewritten_args) {
-                    if !is_unit_param(db, p)
-                        && arg_reaches_any_perform(db, a, ctx)
-                        && count_param_refs(db, arm.body, p) > 1
+                // Collect indices of multi-use params whose arg performs; decide lift-vs-decline per arg.
+                let mut to_lift: Vec<usize> = Vec::new();
+                for (i, &p) in arm.params.iter().enumerate() {
+                    let a = rewritten_args[i];
+                    if is_unit_param(db, p)
+                        || !arg_reaches_any_perform(db, a, ctx)
+                        || count_param_refs(db, arm.body, p) <= 1
                     {
+                        continue;
+                    }
+                    // A multi-use param with a performing arg. If the arg performs a FOREIGN op (none of it
+                    // is THIS handler's discharged op that would need threading), LET-LIFT it; else decline.
+                    if arg_performs_only_foreign(db, a, ctx) {
+                        to_lift.push(i);
+                    } else {
                         return None;
                     }
+                }
+                for i in to_lift {
+                    let a = rewritten_args[i];
+                    let cv_name = format!("#cv{}", a.0);
+                    let cv_binder = db.push_atom(Leaf::Name(cv_name.clone()));
+                    let cv_ref = db.push_atom(Leaf::Name(cv_name));
+                    arg_lifts.push((cv_binder, a));
+                    rewritten_args[i] = cv_ref;
                 }
             }
             // The arm binds its params to the args and its state binder to THIS SLOT's current state.
@@ -4610,6 +4640,22 @@ fn thread_bounded(
             let value = deep_fresh_copy(db, value);
             let next_state = deep_fresh_copy(db, next_state);
             cur[slot] = next_state;
+            // Wrap the perform's result VALUE in the op-arg `#cv` let-lifts (innermost binding = last lifted
+            // arg, so bindings evaluate in arg order): `(let ((#cv (A.get))) <value with v↦#cv>)`. The foreign
+            // perform now runs ONCE as the let-init (the enclosing fold discharges it), and B's arm reads the
+            // pure `#cv` however many times. Nothing lifted → `value` unchanged (byte-identical common case).
+            let value = if arg_lifts.is_empty() {
+                value
+            } else {
+                let mut wrapped = value;
+                for (binder, arg) in arg_lifts.into_iter().rev() {
+                    let let_head = db.push_atom(Leaf::Name("let".to_string()));
+                    let pair = db.push_list(vec![binder, arg]);
+                    let bindings = db.push_list(vec![pair]);
+                    wrapped = db.push_list(vec![let_head, bindings, wrapped]);
+                }
+                wrapped
+            };
             Some((value, cur))
         }
         // A `do` sequence — `(do e0 e1 … en)`. Evaluate each in EVALUATION ORDER, threading state; the
@@ -7610,6 +7656,47 @@ fn arg_reaches_any_perform(db: &mut Db, node: StructId, ctx: &HandlerCtx) -> boo
     // ctx-free core is `reaches_any_perform` so callers without a `HandlerCtx` can reuse the same walk.
     let _ = ctx;
     reaches_any_perform(db, node)
+}
+
+/// Whether the argument subtree at `node` reaches a perform but performs NONE of THIS handler's discharged
+/// ops — i.e. every perform in it is FOREIGN (an outer handler's / host op that the enclosing fold handles).
+/// The op-arg let-lift gate: such an arg can be bound to a `#cv` let and left intact (the perform runs once
+/// as the let-init, the enclosing fold discharges it); an arg that performs THIS handler's OWN op needs
+/// threading (not a plain let-bind), so it is NOT lifted (returns false → the caller declines). CONSERVATIVE:
+/// requires it DOES reach a perform (else there's nothing to lift) AND reaches no discharged-op perform.
+fn arg_performs_only_foreign(db: &mut Db, node: StructId, ctx: &HandlerCtx) -> bool {
+    reaches_any_perform(db, node) && !subtree_reaches_discharged_op(db, node, ctx)
+}
+
+/// Whether `node` reaches a perform of one of THIS ctx's DISCHARGED ops (in `ctx.arms`), following non-
+/// recursive callee bodies (bounded). Narrower than `arg_reaches_any_perform` (which counts foreign performs
+/// too) — used by the op-arg let-lift to exclude an arg that performs the handler's own op.
+fn subtree_reaches_discharged_op(db: &mut Db, node: StructId, ctx: &HandlerCtx) -> bool {
+    fn walk(db: &mut Db, node: StructId, ctx: &HandlerCtx, depth: u32) -> bool {
+        if depth > 16 {
+            return true; // too deep — assume it may (safe over-report → decline, not mis-lift)
+        }
+        if let Resolved::Apply { head, args } = resolved_of(db, node) {
+            if is_perform(db, head, ctx).is_some() {
+                return true;
+            }
+            if crate::eval::effect_op_of(db, head).is_none()
+                && !is_pure_operator_head(db, head)
+                && let Some(callee) = crate::eval::lambda_body(db, head)
+                    .or_else(|| crate::eval::lambda_body_of_nullary(db, head))
+                && !crate::eval::is_recursive(db, callee)
+                && walk(db, callee, ctx, depth + 1)
+            {
+                return true;
+            }
+            return args.iter().any(|&a| walk(db, a, ctx, depth + 1));
+        }
+        match db.ast.get(node).clone() {
+            Struct::List(children) => children.iter().any(|&c| walk(db, c, ctx, depth + 1)),
+            Struct::Atom(_) => false,
+        }
+    }
+    walk(db, node, ctx, 0)
 }
 
 /// Whether the subtree at `node` transitively reaches ANY perform (this handler's discharged op, a foreign

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -592,6 +592,7 @@ pass	a CONSTANT signed truncation of an all-ones Int 12 is -1
 pass	a CONSTANT signed truncation sign-extends at a WIDER storage width (Int 12, i16 storage)
 pass	a CONTINUED FRACTION evaluates bottom-up through recursive Rational division (a + 1/rest)
 pass	a CONTRACTED fn consumes perform results — @requires fires on a handler-produced value
+pass	a CROSS-handler op whose inline ARG performs an OUTER handler's op folds (op-arg let-lift)
 pass	a CURRIED closure capturing an inner-handled perform result closes over it through partial application
 pass	a Char-payload sum value escapes across the boundary in its canonical form
 pass	a DEFERRED resume-thunk escaping to another function re-installs the handler at apply, over a re-performing do-continuation
@@ -1433,6 +1434,7 @@ pass	a contradictory arrow annotation on a function in a runtime Map value is re
 pass	a contradictory arrow annotation on a function stored as a Map KEY is rejected
 pass	a correctly-annotated function parameter is accepted
 pass	a cross-function recursive fold's out-state threads to a later perform in the caller's continuation
+pass	a cross-handler op-arg performing an outer effect runs EXACTLY ONCE though the arm uses it thrice
 pass	a cross-type constructor pattern NESTED in a matching outer payload is rejected
 pass	a cross-type variant pattern of the SAME payload width and colliding tag is rejected
 pass	a cross-type variant pattern whose payload width differs is rejected, not miscompiled

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -597,6 +597,7 @@ pass	a CONSTANT signed truncation of an all-ones Int 12 is -1
 pass	a CONSTANT signed truncation sign-extends at a WIDER storage width (Int 12, i16 storage)
 pass	a CONTINUED FRACTION evaluates bottom-up through recursive Rational division (a + 1/rest)
 pass	a CONTRACTED fn consumes perform results — @requires fires on a handler-produced value
+pass	a CROSS-handler op whose inline ARG performs an OUTER handler's op folds (op-arg let-lift)
 pass	a CURRIED closure capturing an inner-handled perform result closes over it through partial application
 pass	a Char-payload sum value escapes across the boundary in its canonical form
 pass	a DEFERRED resume-thunk escaping to another function re-installs the handler at apply, over a re-performing do-continuation
@@ -1445,6 +1446,7 @@ pass	a contradictory arrow annotation on a function in a runtime Map value is re
 pass	a contradictory arrow annotation on a function stored as a Map KEY is rejected
 pass	a correctly-annotated function parameter is accepted
 pass	a cross-function recursive fold's out-state threads to a later perform in the caller's continuation
+pass	a cross-handler op-arg performing an outer effect runs EXACTLY ONCE though the arm uses it thrice
 pass	a cross-type constructor pattern NESTED in a matching outer payload is rejected
 pass	a cross-type variant pattern of the SAME payload width and colliding tag is rejected
 pass	a cross-type variant pattern whose payload width differs is rejected, not miscompiled

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -580,6 +580,7 @@ pass	a CONSTANT signed truncation of an all-ones Int 12 is -1
 pass	a CONSTANT signed truncation sign-extends at a WIDER storage width (Int 12, i16 storage)
 pass	a CONTINUED FRACTION evaluates bottom-up through recursive Rational division (a + 1/rest)
 pass	a CONTRACTED fn consumes perform results — @requires fires on a handler-produced value
+pass	a CROSS-handler op whose inline ARG performs an OUTER handler's op folds (op-arg let-lift)
 pass	a CURRIED closure capturing an inner-handled perform result closes over it through partial application
 pass	a Char-payload sum value escapes across the boundary in its canonical form
 pass	a DEFERRED resume-thunk escaping to another function re-installs the handler at apply, over a re-performing do-continuation
@@ -1414,6 +1415,7 @@ pass	a contradictory arrow annotation on a function in a runtime Map value is re
 pass	a contradictory arrow annotation on a function stored as a Map KEY is rejected
 pass	a correctly-annotated function parameter is accepted
 pass	a cross-function recursive fold's out-state threads to a later perform in the caller's continuation
+pass	a cross-handler op-arg performing an outer effect runs EXACTLY ONCE though the arm uses it thrice
 pass	a cross-type constructor pattern NESTED in a matching outer payload is rejected
 pass	a cross-type variant pattern of the SAME payload width and colliding tag is rejected
 pass	a cross-type variant pattern whose payload width differs is rejected, not miscompiled

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -4069,6 +4069,44 @@
                 (Acc.step (Acc.step 1)))) (export main)))
   (output (: 202 Int64)))
 
+(case "a CROSS-handler op whose inline ARG performs an OUTER handler's op folds (op-arg let-lift)"
+  (doc    "The cross-handler analogue of the same-handler nested-perform-arg case above (Acc.step (Acc.step 1)):
+           a NESTED handler's op whose INLINE argument performs an OUTER handler's op — `(B.put (A.get))` under
+           `handle A (handle B …)`, where `A.get` homes to the enclosing `A` (foreign to `B`). B's arm uses its
+           param `v` TWICE (`(resume (+ s v) (+ s v))`), so substituting the performing `(A.get)` inline would
+           duplicate it (effect-duplication guard). Fixed by the op-arg LET-LIFT: bind the foreign-perform arg
+           to a fresh `#cv` once, then B's arm reads the pure ref twice — exactly the WORKING let-bound spelling
+           `(let ((x (A.get))) (B.put x))`. `A.get`=7 (no advance), `B.put(7)` = `0+7` = 7. Pins that an inline
+           cross-handler op-arg-performs-outer folds (was a clean decline — the inline-arg-position completeness
+           gap; the let-bound spelling always folded).")
+  (input  (do
+            (effect A (op get (-> Unit Int64)))
+            (effect B (op put (-> Int64 Int64)))
+            (def (main)
+              (handle A 7 ((get (u) s (resume s s)))
+                (handle B 0 ((put (v) s (resume (+ s v) (+ s v))))
+                  (B.put (A.get)))))
+            (export main)))
+  (output (: 7 Int64)))
+
+(case "a cross-handler op-arg performing an outer effect runs EXACTLY ONCE though the arm uses it thrice"
+  (doc    "The soundness control for the op-arg let-lift: the foreign-perform arg must run ONCE (an op arg is
+           evaluated once, before the call, regardless of how many times the arm reads its param). `(B.put
+           (A.tick))` where `A.tick` ADVANCES the outer A-state, and B's arm reads `v` THREE times
+           (`(resume (+ (+ v v) v) s)`). If the lift wrongly duplicated the perform, A would advance 3× and the
+           reads would differ; correctly it advances ONCE (10→11), all three reads see 10 → `v+v+v` = 30, then
+           the outer `(A.get)` reads the once-advanced 11 → `(+ 30 11)` = 41. Pins that the `#cv` let-bind
+           runs the foreign perform exactly once and the arm reads the pure ref — no effect duplication.")
+  (input  (do
+            (effect A (op tick (-> Unit Int64)) (op get (-> Unit Int64)))
+            (effect B (op put (-> Int64 Int64)))
+            (def (main)
+              (handle A 10 ((tick (u) s (resume s (+ s 1))) (get (u) s (resume s s)))
+                (let ((b (handle B 0 ((put (v) s (resume (+ (+ v v) v) s))) (B.put (A.tick)))))
+                  (+ b (A.get)))))
+            (export main)))
+  (output (: 41 Int64)))
+
 (case "two performs as the two ARGUMENTS of a pure USER function thread the state left-to-right"
   (doc    "The performs sit in the argument list of a non-primitive, effect-free USER function, whose call
            evaluates its arguments left-to-right before applying — so the two reads are sequenced by the


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref c4ea51302, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.