### PR TITLE
cdz-agent-host: #2084 review — pin s2n-quic-dc-metrics rev (reproducibility), saturating micros helper, AgentHost Default doc

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/Cargo.lock
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.lock
@@ -2049,7 +2049,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 [[package]]
 name = "s2n-quic-dc-metrics"
 version = "0.76.0"
-source = "git+https://github.com/camshaft/s2n-quic?branch=main#7ec9f027424badd576436d29d05f75c8d8594133"
+source = "git+https://github.com/camshaft/s2n-quic?rev=7ec9f027424badd576436d29d05f75c8d8594133#7ec9f027424badd576436d29d05f75c8d8594133"
 dependencies = [
  "chrono",
  "crossbeam-queue",

--- a/implementation/seed/crates/cdz-agent-host/Cargo.toml
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.toml
@@ -98,7 +98,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 # registry. Verified network-egress-FREE base (no QUIC/reqwest/TLS; the arrow/otel backends are opt-in
 # features of the crate, NOT enabled here) — so it honors the hermetic-default-gate (hermetic = no NETWORK,
 # not no-deps). Git dep = the operator's fork; branch=main HEAD tracks their metrics work.
-s2n-quic-dc-metrics = { git = "https://github.com/camshaft/s2n-quic", branch = "main" }
+# Pinned to an exact rev (not a bare branch=main) for a REPRODUCIBLE build (#2084 review): a moving branch
+# would let `cargo update` drift the seed off the locked rev + can break when upstream main moves. The rev is
+# the lock's pinned HEAD; bump it deliberately when adopting new metrics-crate work. (Also keeps v-nix's
+# importCargoLock outputHashes key stable — the lock source names this exact rev.)
+s2n-quic-dc-metrics = { git = "https://github.com/camshaft/s2n-quic", rev = "7ec9f027424badd576436d29d05f75c8d8594133" }
 # reqwest — the real async HTTP client behind the `HttpTransport` seam. OPTIONAL, enabled only by
 # `live-net` (default build never compiles it — keeps the hermetic gate free of the network/TLS tree).
 # `rustls-tls` (not the platform's OpenSSL) so it builds on any runner with no system SSL dep;

--- a/implementation/seed/crates/cdz-agent-host/src/factory.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/factory.rs
@@ -87,7 +87,7 @@ impl Executor for MeteredExecutor {
         let started = std::time::Instant::now();
         let outcome = self.inner.perform(req, idempotency_key).await;
         self.metrics
-            .record_latency_us(started.elapsed().as_micros() as u64);
+            .record_latency_us(crate::metrics::micros_u64(started.elapsed()));
         // Tally the metric + trace at the SAME tap. The family names which effect; a failure logs its
         // classified reason (retryable/permanent) at warn (a supervisor signal), ok at debug (routine).
         let family = req.content_type.family.as_ref();

--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -314,7 +314,8 @@ impl HostedSession {
 /// routes inbound events to the right one, and is the object a `session-status <id>` query reads.
 ///
 /// Constructed via [`new`](Self::new) / [`with_canonical_store`](Self::with_canonical_store) (each creates
-/// the metrics registry) — no `Default`, since the registry is a required, non-default collaborator.
+/// the metrics registry). `Default` delegates to `new` (it can't be derived — the metrics registry is a
+/// required collaborator, not a `Default` field — so the impl forwards to `new`).
 pub struct AgentHost {
     sessions: HashMap<SessionId, HostedSession>,
     /// The §4c v0.3 canonical shared name store, if this host is share-backed (see
@@ -447,7 +448,7 @@ impl AgentHost {
         let started = std::time::Instant::now();
         let outcome = s.deliver(body, cause).await;
         self.metrics
-            .record_turn_latency_us(started.elapsed().as_micros() as u64);
+            .record_turn_latency_us(crate::metrics::micros_u64(started.elapsed()));
         self.metrics.record_turn(outcome.is_ok());
         // Trace the turn outcome at the same boundary the metric records. An errored turn logs the kernel
         // reason at warn (a supervisor signal); a successful turn at debug (routine, filtered out at info).

--- a/implementation/seed/crates/cdz-agent-host/src/metrics.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/metrics.rs
@@ -24,6 +24,14 @@ use s2n_quic_dc_metrics::{Counter, Summary, Unit};
 /// `crate::metrics::Registry` without depending on the metrics crate directly).
 pub use s2n_quic_dc_metrics::Registry;
 
+/// Saturating `Duration`-micros → `u64` for a latency [`Summary`] record. `Duration::as_micros` returns
+/// `u128`; the `as u64` truncation is unreachable in practice (`u64::MAX` µs ≈ 584k years), but saturate
+/// rather than silently wrap so an absurd/monotonic-clock-glitch duration clamps to the max instead of
+/// wrapping to a small value (#2084 review; one helper for the host + effect latency sites).
+pub(crate) fn micros_u64(d: std::time::Duration) -> u64 {
+    u64::try_from(d.as_micros()).unwrap_or(u64::MAX)
+}
+
 /// The metric name every host-boundary counter aggregates under (the aggregation string distinguishes the
 /// individual counters via the `Variant|…` convention the s2n-quic-dc registry uses).
 const HOST_METRIC: &str = "cdz_agent_host.session";


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref fcf34f03a, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.