### PR TITLE
rcdzc(effects): FIX lift_inner_op_arm_outer_perform orphans arm.state when the resume value READS the inner state — decline instead of leaking (github-liaison #2077 review)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -6719,6 +6719,37 @@ fn tail_resume(db: &mut Db, node: StructId) -> Option<(StructId, StructId)> {
 /// Whether `node` reaches a DIRECT perform of an op discharged by `ctx` that is NOT `own` — i.e. a sibling
 /// (outer merged-slot) discharged op. Used by the pre-spec-lift to detect an arm resume-value that performs
 /// a DIFFERENT effect than the arm's own op (the arm-hidden outer perform).
+/// Whether the subtree at `node` contains a VALUE reference that resolves to the binder `binder` — a bare
+/// name occurrence whose `resolved_of` chain reaches `binder` (an arm's state/param binder). Used by
+/// `lift_inner_op_arm_outer_perform` to REFUSE lifting a resume value that reads the inner arm's state
+/// binder (which the lift's `params↦args`-only substitution does not rebind, so lifting would orphan it).
+/// A structural walk; the binder-position occurrence of `binder` itself is not a value reference, but the
+/// lift only inspects a resume VALUE (never the binder slot), so any match here is a genuine read.
+fn subtree_references_binder(db: &mut Db, node: StructId, binder: StructId) -> bool {
+    match resolved_of(db, node) {
+        Resolved::Ref { value } => {
+            let mut t = value;
+            loop {
+                if t == binder {
+                    return true;
+                }
+                match resolved_of(db, t) {
+                    Resolved::Ref { value: n } => t = n,
+                    _ => break,
+                }
+            }
+        }
+        Resolved::Param { binder: b } if b == binder => return true,
+        _ => {}
+    }
+    match db.ast.get(node).clone() {
+        Struct::List(children) => children
+            .iter()
+            .any(|&c| subtree_references_binder(db, c, binder)),
+        Struct::Atom(_) => false,
+    }
+}
+
 fn performs_discharged_op_other_than(
     db: &mut Db,
     node: StructId,
@@ -6751,6 +6782,20 @@ fn lift_inner_op_arm_outer_perform(db: &mut Db, node: StructId, ctx: &HandlerCtx
         && db.ast.as_name(next) == db.ast.as_name(arm.state)
         // the resume value performs a DIFFERENT discharged op (an outer merged slot).
         && performs_discharged_op_other_than(db, val, ctx, (decl.0, idx))
+        // …AND the resume value does NOT read the inner arm's STATE binder. The `next == arm.state` guard
+        // above ensures the NEXT-state is trivial, but says NOTHING about `val` itself. If `val` references
+        // `arm.state` — `(step (u) t (resume (A.tick t) t))`, the outer perform arg reads the inner state —
+        // the substitution below covers `arm.params` but NOT `arm.state`, so the lifted+`deep_fresh_copy`'d
+        // value carries an ORPHANED `t` ref (its inner-handler binder is gone once lifted onto the body
+        // spine) → CDZ0101 `unbound name t` at lowering: a LEAK on a valid program, strictly worse than a
+        // clean decline (github-liaison/Copilot review of #2077, VERIFIED-PLAUSIBLE; the same state-binder-
+        // scope failure as this arc's #1933 orphan). Threading an inner-state-reading resume value onto the
+        // outer body correctly is the full spec-lift fold (a later increment — it must re-bind `t` to the
+        // inner slot's threaded state); until then, leaving this node UN-lifted makes `specialize_recursive`
+        // decline cleanly downstream (the pre-spec-lift floor breaker verified is silent-wrong-value-free),
+        // the honest "not yet reducible" todo. The safe shape (`val` free of `arm.state`, the landed →21
+        // witness `(resume (A.tick) t)`) is UNAFFECTED — it lifts and folds as before.
+        && !subtree_references_binder(db, val, arm.state)
     {
         // β-reduce the arm's resume value with params↦args (the op's args) so a param-referencing outer
         // perform arg resolves. (Unit-op arms bind nothing; a mismatch leaves it un-substituted, still sound

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -5802,6 +5802,7 @@ todo	a block-wrapped branch perform of the OUTER effect in a let-init INSIDE a n
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject
 todo	a constant-try helper that fails feeds the None arm's fallback into resume
 todo	a mutually-recursive group with a BRANCH-PERFORM sharing a strict expr with the mutual call declines cleanly (adv-69 rw4 sub-face)
+todo	a recursive nested-op performer whose resume-VALUE reads the inner state around the outer perform declines cleanly
 todo	a recursive scalar-walk classifies characters across a multibyte String entry arg
 todo	a runtime bin match decodes a FINAL constant-size utf8 segment
 todo	a runtime-DISC `?` inside a stored closure applies per-call once BRICK 3b lands

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5806,6 +5806,7 @@ todo	a constant-try helper that fails feeds the None arm's fallback into resume
 todo	a mutually-recursive group with a BRANCH-PERFORM sharing a strict expr with the mutual call declines cleanly (adv-69 rw4 sub-face)
 todo	a recursive NEWTYPE traversal recurses on its projected recursive field
 todo	a recursive NEWTYPE-wrapped linked list folds to a scalar
+todo	a recursive nested-op performer whose resume-VALUE reads the inner state around the outer perform declines cleanly
 todo	a runtime bin match decodes a FINAL constant-size utf8 segment
 todo	a runtime-DISC `?` inside a stored closure applies per-call once BRICK 3b lands
 todo	a runtime-operand try as a list element declines pending brick 3b

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5747,6 +5747,7 @@ todo	a program uses a response-returning delegated host function's return value
 todo	a recursion-driven host-call sequence consumes one response row per iteration in order
 todo	a recursive NEWTYPE traversal recurses on its projected recursive field
 todo	a recursive NEWTYPE-wrapped linked list folds to a scalar
+todo	a recursive nested-op performer whose resume-VALUE reads the inner state around the outer perform declines cleanly
 todo	a run's result is a deterministic function of a host call's recorded response
 todo	a runtime Bool host arg crosses the boundary and drives two response bindings
 todo	a runtime Bytes host-arg BEFORE a scalar arg keeps distinct core slots (no width-clobber)

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -1112,6 +1112,26 @@
                   (+ (B.step) (A.get))))) (export main)))
   (output (: 21 Int64)))
 
+(case "a recursive nested-op performer whose resume-VALUE reads the inner state around the outer perform declines cleanly"
+  (doc    "The state-reading companion of the fold above. Here the inner `B.step` arm's resume VALUE reads the
+           inner state binder `t` around the outer perform — `(step (u) t (resume (A.tick (+ t u)) t))`. The
+           pre-spec-lift only lifts an inner-op call whose resume value is FREE of the inner state binder (the
+           lift substitutes op params but not the state); lifting a state-reading value would orphan `t` onto
+           the outer body spine (a CDZ0101 leak on a valid program — the github-liaison/Copilot #2077 review).
+           So this shape is left UN-lifted and declines cleanly (the honest not-yet-reducible todo — threading
+           an inner-state-reading resume value onto the outer body is the full spec-lift fold, a later
+           increment). Pins that the state-reading face declines rather than leaks.")
+  (input  (do
+            (effect A (op tick (-> Int64 Int64)))
+            (effect B (op step (-> Int64 Int64)))
+            (def (loop (: n Int64)) (if (= n 0) 0 (+ (B.step n) (loop (- n 1)))))
+            (def (main)
+              (handle A 100 ((tick (a) s (resume (+ a s) (+ s 1))))
+                (handle B 7 ((step (b) t (resume (A.tick (+ t b)) t)))
+                  (loop 2))))
+            (export main)))
+  (output (: 218 Int64)))
+
 (case "a NON-recursive helper calling a nested op whose resume performs the outer effect folds"
   (doc    "The non-recursive-helper twin of the resume-value-performs-outer case above (v-effects self-probe).
            A non-recursive `helper` calls the inner `B.step` (whose arm resumes with `(A.tick)`, performing the


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 120386a03, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.