### PR TITLE
rcdzc(effects): FIX E5 lexical-ctl k→resume rewrite leaks arm binders — selective binder-pin (breaker ek1 + ek5, supersedes 054c693f80)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -1707,6 +1707,46 @@ fn host_effect_decl(db: &mut Db, e: StructId) -> Option<u32> {
     }
 }
 
+/// Selectively RESOLVE-PIN every name occurrence in `node` whose resolution chain reaches one of `binders`
+/// (an arm's state/param/cont binders), so a following `copy_pure`/`substitute_nodes` of the arm body SHARES
+/// those occurrences (eval.rs's `resolved_subtrees` captured-free-variable share-path) with their memoized
+/// resolution intact — the ref keeps reaching its arm binder even in the detached rebuilt tree. Deliberately
+/// does NOT pin a ref to a BODY-LOCAL binder (a `let`/`do`-def inside `node`): that must re-resolve against
+/// the rebuilt tree's own (possibly rewritten) local init. Fills `db.resolved` (via `resolved_of`) AND marks
+/// the node in `db.resolved_subtrees` — both are required for the share-path to fire. Bounded to `node`.
+fn pin_refs_to_binders(db: &mut Db, node: StructId, binders: &[StructId]) {
+    // A bare name whose resolution reaches one of `binders` → pin it (memo + walk-guard membership).
+    if db.ast.as_name(node).is_some() {
+        let reaches = match resolved_of(db, node) {
+            Resolved::Param { binder } => binders.contains(&binder),
+            Resolved::Ref { value } => {
+                let mut t = value;
+                loop {
+                    if binders.contains(&t) {
+                        break true;
+                    }
+                    match resolved_of(db, t) {
+                        Resolved::Ref { value: n } => t = n,
+                        _ => break false,
+                    }
+                }
+            }
+            _ => false,
+        };
+        if reaches {
+            // `resolved_of` above already filled `db.resolved`; add the walk-guard membership so
+            // `beta_reduce`'s share-path (eval.rs) returns this pinned occurrence as-is.
+            db.resolved_subtrees.insert(node);
+        }
+        return;
+    }
+    if let Struct::List(children) = db.ast.get(node).clone() {
+        for c in children {
+            pin_refs_to_binders(db, c, binders);
+        }
+    }
+}
+
 /// E5 STEP 2 — WITHIN-ACTIVATION lexical `k`. A `ctl`-style arm binds the continuation `k` (`arm.cont =
 /// Some(k)`) and applies it as `(k v)`. When `k` is used ONLY as the HEAD of applications — never bare,
 /// never passed as an argument, never stored — the continuation does NOT escape: each `(k v)` returns into
@@ -1809,6 +1849,26 @@ fn ctl_arm_lexical_k_to_resume(db: &mut Db, arm: &HandleArm) -> Option<StructId>
         sub.insert(app, resume);
     }
     // Splice the rewritten resume nodes in place of the `(k v)` applications (a node→node substitution).
+    // SELECTIVELY PIN the arm body's ARM-BINDER references before `substitute_nodes`'s `copy_pure` re-pushes
+    // every non-`(k v)` atom into the DETACHED rebuilt tree (root parent `None`). Two classes of name ref
+    // need OPPOSITE treatment:
+    //   • A ref to an ARM binder — the state binder `s`, an op-param `x` — resolves OUTSIDE the arm body
+    //     (up the parent chain to `handle_arm_binds`). In the detached copy that parent walk is gone, so the
+    //     ref must keep its pinned resolution (else the pure-one-hole reify's `beta_reduce({state↦init,
+    //     params↦args})` can't match it and it leaks `unbound name s` — the bare-position `(+ s (k x))`
+    //     leak, breaker ek1).
+    //   • A ref to a BODY-LOCAL binder — a `let`/`do`-def `r` in `(let ((r (k x))) (+ r s))` — resolves
+    //     INSIDE the arm body (down to the local `(def r …)`). It must NOT be pinned: after the rewrite the
+    //     init changes `(k x)`→`(resume x s)`, and a pinned `r` would keep pointing at the ORIGINAL, now-
+    //     orphaned `(k x)` init (a bare k-application) → "value is not applyable" (breaker ek5). Left
+    //     unpinned, `r` re-resolves within the rebuilt tree to the REWRITTEN `(def r (resume x s))` init —
+    //     correct (the explicit-resume twin `(let ((r (resume x s))) (+ r s))` already folds this way).
+    // A blunt `resolve_subtree` pins BOTH (breaks ek5); a blunt `forget` pins NEITHER (re-leaks ek1). So
+    // pin ONLY refs whose resolution chain reaches one of THIS arm's binders. Idempotent + bounded.
+    let mut arm_binders: Vec<StructId> = vec![arm.state];
+    arm_binders.extend(arm.params.iter().copied());
+    arm_binders.push(k_binder);
+    pin_refs_to_binders(db, arm.body, &arm_binders);
     Some(substitute_nodes(db, arm.body, &sub))
 }
 

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -924,6 +924,42 @@
             (def (main) (handle Amb 0 ((flip () s k (+ (k 10) 1))) (Amb.flip))) (export main)))
   (output (: 11 Int64)))
 
+(case "a ctl-style arm that reads the STATE binder AROUND its continuation application folds"
+  (doc    "The state-referencing companion of the lexical-`ctl` fold above: the 5-part arm body references
+           the STATE binder `s` (and could reference an op parameter) in a position OUTSIDE the `(k v)`
+           application — `(+ s (k x))`, where the `+`'s LEFT operand is the state and the RIGHT is the
+           continuation result. When `k` is applied lexically, `(k v)` = `(resume v s)`, so the arm becomes
+           `(+ s (resume x s))` — a NON-tail resume with a live `s`/`x` sibling. Seeded 100 over `(G.y 5)`:
+           `x` = 5, `C = □` (the whole body is the perform), so `(k 5)` = 5 and the arm value is `(+ 100 5)`
+           = 105. Pins that the lexical-`ctl`→`resume` rewrite preserves the arm's state/param binder
+           resolution for references OUTSIDE the `(k v)` call — the rewrite rebuilds the arm body, and
+           without pinning those sibling references first they were re-pushed UNPINNED into a detached tree,
+           lost their parent-walk to the arm binder, and leaked `unbound name s`/`x` at lowering (a CDZ0101
+           on a valid program — strictly worse than a clean decline). A reference INSIDE the `(k v)` argument
+           (`(k (+ x s))`) was spliced verbatim and always folded; this is the sibling-position face.")
+  (input  (do
+            (effect G (op y (-> Int64 Int64)))
+            (def (main) (handle G 100 ((y (x) s k (+ s (k x)))) (G.y 5))) (export main)))
+  (output (: 105 Int64)))
+
+(case "a ctl-style arm that LET-BINDS its continuation result then reads the state binder folds"
+  (doc    "The let/do-bound-continuation companion of the two folds above. The arm binds the continuation
+           result in a local `let` (or `do`-def) and reads it alongside the STATE binder in the let body —
+           `(let ((r (k x))) (+ r s))`. When `k` is applied lexically, `(k v)` = `(resume v s)`, so the arm
+           becomes `(let ((r (resume x s))) (+ r s))` — a NON-tail resume BOUND IN A LET-INIT, with the
+           body-local `r` and the arm's state `s` both live. Seeded 100 over `(G.y 5)`: `r` = `(k 5)` = 5,
+           `(+ r s)` = `(+ 5 100)` = 105. Pins that the lexical-`ctl`→`resume` rewrite handles a `(k v)`
+           bound in a `let`/`do`-def INIT (not just an operand): the rewrite must pin the arm's STATE/param
+           binder references (which resolve OUTSIDE the rebuilt tree) while leaving the BODY-LOCAL binder `r`
+           unpinned (so it re-resolves to the REWRITTEN local init) — a blunt whole-body pin kept `r` pointing
+           at the orphaned original `(k x)` init (`value is not applyable`), a blunt no-pin re-leaked the
+           state binder. The explicit-resume twin `(let ((r (resume x s))) (+ r s))` already folded; this
+           makes the lexical-`k` spelling match it.")
+  (input  (do
+            (effect G (op y (-> Int64 Int64)))
+            (def (main) (handle G 100 ((y (x) s k (let ((r (k x))) (+ r s)))) (G.y 5))) (export main)))
+  (output (: 105 Int64)))
+
 (case "an abortive handler arm performed with a RUNTIME argument abandons the computation and returns it"
   (doc    "The runtime-argument companion of the constant-abort case. An abortive arm `(bail (n) s n)` never
            resumes, so performing `(Bail.bail k)` — with `k` a RUNTIME parameter, not a constant — abandons


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref d131d137, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.