### PR TITLE
cdz-agent-host: metrics EXPORT emitter — statsd UDP sink + report_once over the registry (metrics-export feature)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/Cargo.toml
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.toml
@@ -46,6 +46,15 @@ live-net = ["dep:reqwest", "dep:aws-config", "dep:aws-sdk-bedrockruntime"]
 # egress, so this is not the same concern as `live-net`; gating it keeps the default build listener-free.
 admin = ["tokio/net", "tokio/io-util", "tokio/signal"]
 
+# `metrics-export` gates the observability EXPORT emitter — the daemon periodically reports the metrics
+# registry to a backend (statsd first) over the network. OFF by default so the hermetic gate never sends UDP
+# / opens a socket: the metric RECORDING (registry Counters, always-on since seq-116) stays hermetic; only
+# the periodic EXPORT to a collector is feature-gated. The statsd sink uses std::net::UdpSocket (a blocking
+# send off the periodic timer tick — not hot-path — so no tokio `net` is needed). No extra deps: the
+# s2n-quic-dc-metrics StatsdBackend is already in the always-on dep; this feature just compiles the sink +
+# the report task. (OTLP/prometheus backends slot in behind this same feature later.)
+metrics-export = []
+
 [dependencies]
 # The kernel whose Executor/Authorize traits + effect/event types we implement. Path dep across the
 # workspace boundary (both are their own workspaces). We CONSUME these traits; we never edit its src.

--- a/implementation/seed/crates/cdz-agent-host/src/export.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/export.rs
@@ -1,0 +1,109 @@
+//! Metrics EXPORT — the emitter that periodically reports the daemon's metrics [`Registry`] to a backend
+//! (statsd first) over the network. Behind the `metrics-export` cargo feature (OFF by default): the metric
+//! RECORDING (the registry Counters/Summaries in [`crate::metrics`]) is always-on + hermetic, but the
+//! EXPORT — sending to a collector — is gated so the default build never opens a socket / sends UDP.
+//!
+//! The registry Counters are DRAIN-ON-REPORT: each [`Registry::report`] emits the per-interval delta and
+//! clears the counters, so the report cadence (`[observability].report_interval_secs`) IS the aggregation
+//! window — exactly the statsd/otlp PUSH model (the collector does the time-series aggregation). The daemon
+//! runs [`report_once`] on a periodic timer per configured target.
+//!
+//! The statsd sink uses a blocking [`std::net::UdpSocket`] (the send happens off the periodic timer tick,
+//! not on any hot path, so a sync send is fine + avoids pulling tokio's `net` feature).
+
+#![cfg(feature = "metrics-export")]
+
+use s2n_quic_dc_metrics::Registry;
+
+/// A statsd [`StatsdSink`](s2n_quic_dc_metrics::backend::StatsdSink) that sends each UDP payload to a
+/// collector address. Holds a connected [`std::net::UdpSocket`]; `send_batch` fires one datagram per payload.
+/// A send error is dropped (metrics export is best-effort — a dropped stat must never fail the daemon).
+#[derive(Debug)]
+pub struct UdpStatsdSink {
+    socket: std::net::UdpSocket,
+}
+
+impl UdpStatsdSink {
+    /// Bind an ephemeral local UDP socket connected to `endpoint` (`host:port`). `Err` if the address is
+    /// unparseable / unreachable at bind time — surfaced to the caller (a bad statsd endpoint is a config
+    /// error worth reporting at export setup, not a silent no-op).
+    pub fn connect(endpoint: &str) -> Result<Self, String> {
+        // Bind to an OS-chosen local port on the unspecified address, then connect to the target so
+        // subsequent `send` (no addr) routes to the collector.
+        let socket = std::net::UdpSocket::bind(("0.0.0.0", 0))
+            .map_err(|e| format!("statsd sink could not bind a local UDP socket: {e}"))?;
+        socket
+            .connect(endpoint)
+            .map_err(|e| format!("statsd sink could not connect to {endpoint}: {e}"))?;
+        Ok(UdpStatsdSink { socket })
+    }
+}
+
+impl s2n_quic_dc_metrics::backend::StatsdSink for UdpStatsdSink {
+    fn send_batch<'a>(&mut self, payloads: impl Iterator<Item = &'a str>) {
+        for payload in payloads {
+            // Best-effort: a UDP send failure (collector down, buffer full) is dropped — export must never
+            // fail the daemon or the report loop.
+            let _ = self.socket.send(payload.as_bytes());
+        }
+    }
+}
+
+/// Report the current metrics from `registry` to the statsd collector at `endpoint` ONCE (a single flush).
+/// Builds a fresh [`StatsdBackend`](s2n_quic_dc_metrics::backend::StatsdBackend) over a UDP sink to
+/// `endpoint` + drives [`Registry::report`] into it — draining the per-interval deltas to the collector.
+/// `prefix` optionally namespaces every metric name (e.g. `"cdz.agent"`). `Err` only if the sink can't be
+/// set up (bad endpoint); a per-datagram send failure is swallowed inside the sink (best-effort).
+///
+/// The daemon calls this on each tick of its `report_interval_secs` timer, per configured statsd target.
+pub fn report_once(
+    registry: &Registry,
+    endpoint: &str,
+    prefix: Option<String>,
+) -> Result<(), String> {
+    use s2n_quic_dc_metrics::backend::StatsdBackend;
+    let sink = UdpStatsdSink::connect(endpoint)?;
+    let mut backend = StatsdBackend::new(sink, prefix);
+    registry.report(&mut backend);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::HostMetrics;
+
+    #[test]
+    fn report_once_sends_to_a_bound_collector_without_error() {
+        // Bind a real UDP socket as the "collector", record some metrics into a registry, then report_once
+        // to that socket's addr — proves the sink connects + the registry drives the StatsdBackend + a
+        // datagram is sent, all without error. (We don't assert the payload bytes — statsd wire format is the
+        // crate's concern; this proves the export path is wired + total.)
+        let collector = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind collector");
+        collector
+            .set_read_timeout(Some(std::time::Duration::from_millis(200)))
+            .unwrap();
+        let addr = collector.local_addr().unwrap().to_string();
+
+        let registry = Registry::new();
+        let host = HostMetrics::new(&registry);
+        host.record_session_installed();
+        host.record_turn(true);
+
+        report_once(&registry, &addr, Some("cdz.agent".into())).expect("report_once ok");
+
+        // A datagram arrived at the collector (the statsd export actually sent something).
+        let mut buf = [0u8; 4096];
+        let got = collector.recv(&mut buf);
+        assert!(got.is_ok(), "collector received a statsd datagram: {got:?}");
+        assert!(got.unwrap() > 0, "the datagram was non-empty");
+    }
+
+    #[test]
+    fn connect_to_a_bad_endpoint_is_a_clean_error() {
+        // An unparseable endpoint is a clean Err (not a panic) — a bad [observability] statsd target surfaces
+        // at export setup.
+        let err = UdpStatsdSink::connect("not a socket addr").unwrap_err();
+        assert!(err.contains("statsd sink"), "{err}");
+    }
+}

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -60,6 +60,8 @@ pub mod admin_wire;
 pub mod async_host;
 pub mod clock;
 pub mod config;
+#[cfg(feature = "metrics-export")]
+pub mod export;
 pub mod factory;
 pub mod host;
 pub mod http;
@@ -83,6 +85,8 @@ pub use config::{
     AdminConfig, BlobConfig, DaemonConfig, LogConfig, MetricsTarget, ObservabilityConfig,
     RetryConfig, TracingConfig, TracingFormat, TracingOutput,
 };
+#[cfg(feature = "metrics-export")]
+pub use export::{report_once, UdpStatsdSink};
 #[cfg(feature = "live-net")]
 pub use factory::LiveExecutorSet;
 pub use factory::{


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref ffd613a43, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.