### PR TITLE
cdz-agent-host: review nits — micros_u64 test + report_interval_secs doc (#2100/#2105) + statsd sink v6-family bind, borrowed prefix, staging doc (#2112)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/config.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/config.rs
@@ -93,8 +93,9 @@ pub struct ObservabilityConfig {
     /// How often (seconds) the daemon reports/flushes metrics to the backends — the exporter's periodic
     /// `Registry::report` cadence. Default 60 (the conventional statsd/otlp push interval). Since the
     /// registry Counters are DRAIN-ON-REPORT, this interval IS the aggregation window (each report emits the
-    /// per-interval delta — standard push semantics). Min-clamped to 1 (validated below) so a misconfig
-    /// can't spin a tight flush loop. Applies to all targets (a per-target override could be added later).
+    /// per-interval delta — standard push semantics). Validated ONLY when `enabled`: 0 is REJECTED (a config
+    /// error — a 0 interval would spin a tight flush loop); when disabled it isn't checked (nothing reports).
+    /// Applies to all targets (a per-target override could be added later).
     #[serde(default = "ObservabilityConfig::default_report_interval_secs")]
     pub report_interval_secs: u64,
 }

--- a/implementation/seed/crates/cdz-agent-host/src/export.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/export.rs
@@ -5,8 +5,10 @@
 //!
 //! The registry Counters are DRAIN-ON-REPORT: each [`Registry::report`] emits the per-interval delta and
 //! clears the counters, so the report cadence (`[observability].report_interval_secs`) IS the aggregation
-//! window — exactly the statsd/otlp PUSH model (the collector does the time-series aggregation). The daemon
-//! runs [`report_once`] on a periodic timer per configured target.
+//! window — exactly the statsd/otlp PUSH model (the collector does the time-series aggregation). The intended
+//! caller is the daemon's periodic export task: it will run [`report_once`] on a `report_interval_secs` timer
+//! per configured target (that timer-loop wiring is a following slice — this module provides the flush
+//! primitive it drives).
 //!
 //! The statsd sink uses a blocking [`std::net::UdpSocket`] (the send happens off the periodic timer tick,
 //! not on any hot path, so a sync send is fine + avoids pulling tokio's `net` feature).
@@ -28,12 +30,26 @@ impl UdpStatsdSink {
     /// unparseable / unreachable at bind time — surfaced to the caller (a bad statsd endpoint is a config
     /// error worth reporting at export setup, not a silent no-op).
     pub fn connect(endpoint: &str) -> Result<Self, String> {
-        // Bind to an OS-chosen local port on the unspecified address, then connect to the target so
-        // subsequent `send` (no addr) routes to the collector.
-        let socket = std::net::UdpSocket::bind(("0.0.0.0", 0))
+        use std::net::ToSocketAddrs;
+        // Resolve the endpoint FIRST so the ephemeral local socket can be bound in the MATCHING address
+        // family: a v4-bound socket (`0.0.0.0:0`) cannot `connect` to an IPv6 peer (EAFNOSUPPORT), so a
+        // statsd collector that resolves to / is configured as IPv6 would fail even when reachable over v6
+        // (#2112 review). Bind `[::]:0` for a v6 target, `0.0.0.0:0` for v4, then connect so subsequent
+        // `send` (no addr) routes to the collector.
+        let target = endpoint
+            .to_socket_addrs()
+            .map_err(|e| format!("statsd sink could not resolve {endpoint}: {e}"))?
+            .next()
+            .ok_or_else(|| format!("statsd sink: {endpoint} resolved to no address"))?;
+        let bind_addr: std::net::SocketAddr = if target.is_ipv6() {
+            (std::net::Ipv6Addr::UNSPECIFIED, 0).into()
+        } else {
+            (std::net::Ipv4Addr::UNSPECIFIED, 0).into()
+        };
+        let socket = std::net::UdpSocket::bind(bind_addr)
             .map_err(|e| format!("statsd sink could not bind a local UDP socket: {e}"))?;
         socket
-            .connect(endpoint)
+            .connect(target)
             .map_err(|e| format!("statsd sink could not connect to {endpoint}: {e}"))?;
         Ok(UdpStatsdSink { socket })
     }
@@ -52,18 +68,20 @@ impl s2n_quic_dc_metrics::backend::StatsdSink for UdpStatsdSink {
 /// Report the current metrics from `registry` to the statsd collector at `endpoint` ONCE (a single flush).
 /// Builds a fresh [`StatsdBackend`](s2n_quic_dc_metrics::backend::StatsdBackend) over a UDP sink to
 /// `endpoint` + drives [`Registry::report`] into it — draining the per-interval deltas to the collector.
-/// `prefix` optionally namespaces every metric name (e.g. `"cdz.agent"`). `Err` only if the sink can't be
-/// set up (bad endpoint); a per-datagram send failure is swallowed inside the sink (best-effort).
+/// `prefix` optionally namespaces every metric name (e.g. `"cdz.agent"`). Borrowed (`Option<&str>`) so the
+/// periodic-flush caller passes its configured prefix each tick WITHOUT cloning; the one owned `String` the
+/// backend needs is allocated inside (#2112 review). `Err` only if the sink can't be set up (bad endpoint); a
+/// per-datagram send failure is swallowed inside the sink (best-effort).
 ///
 /// The daemon calls this on each tick of its `report_interval_secs` timer, per configured statsd target.
 pub fn report_once(
     registry: &Registry,
     endpoint: &str,
-    prefix: Option<String>,
+    prefix: Option<&str>,
 ) -> Result<(), String> {
     use s2n_quic_dc_metrics::backend::StatsdBackend;
     let sink = UdpStatsdSink::connect(endpoint)?;
-    let mut backend = StatsdBackend::new(sink, prefix);
+    let mut backend = StatsdBackend::new(sink, prefix.map(str::to_owned));
     registry.report(&mut backend);
     Ok(())
 }
@@ -90,13 +108,40 @@ mod tests {
         host.record_session_installed();
         host.record_turn(true);
 
-        report_once(&registry, &addr, Some("cdz.agent".into())).expect("report_once ok");
+        report_once(&registry, &addr, Some("cdz.agent")).expect("report_once ok");
 
         // A datagram arrived at the collector (the statsd export actually sent something).
         let mut buf = [0u8; 4096];
         let got = collector.recv(&mut buf);
         assert!(got.is_ok(), "collector received a statsd datagram: {got:?}");
         assert!(got.unwrap() > 0, "the datagram was non-empty");
+    }
+
+    #[test]
+    fn report_once_reaches_an_ipv6_collector() {
+        // The #2112-review fix: a v6 statsd endpoint must work (a v4-bound socket can't connect to a v6
+        // peer). Bind a v6 loopback collector + report to it — proves connect() binds the MATCHING family.
+        let collector = match std::net::UdpSocket::bind(("::1", 0)) {
+            Ok(s) => s,
+            // Skip cleanly on a runner with no IPv6 loopback (some sandboxes) — the v4 test covers the path.
+            Err(_) => return,
+        };
+        collector
+            .set_read_timeout(Some(std::time::Duration::from_millis(200)))
+            .unwrap();
+        let addr = collector.local_addr().unwrap().to_string();
+
+        let registry = Registry::new();
+        let host = HostMetrics::new(&registry);
+        host.record_turn(true);
+
+        report_once(&registry, &addr, None).expect("report_once to a v6 collector ok");
+
+        let mut buf = [0u8; 4096];
+        assert!(
+            collector.recv(&mut buf).is_ok(),
+            "the v6 collector received a statsd datagram"
+        );
     }
 
     #[test]

--- a/implementation/seed/crates/cdz-agent-host/src/metrics.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/metrics.rs
@@ -216,4 +216,16 @@ mod tests {
         m2.record_timed_out();
         // No panic + both handles record into the same set.
     }
+
+    #[test]
+    fn micros_u64_converts_exactly_and_saturates() {
+        use std::time::Duration;
+        // A normal duration converts exactly (µs).
+        assert_eq!(micros_u64(Duration::from_micros(0)), 0);
+        assert_eq!(micros_u64(Duration::from_micros(1234)), 1234);
+        assert_eq!(micros_u64(Duration::from_millis(5)), 5_000);
+        // An absurd duration whose µs exceed u64::MAX SATURATES (does not wrap to a small value) — the
+        // #2084-review concern the helper exists for. Duration::from_secs(u64::MAX) has ~1.8e25 µs >> u64::MAX.
+        assert_eq!(micros_u64(Duration::from_secs(u64::MAX)), u64::MAX);
+    }
 }


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 3c182b3bd, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.