### PR TITLE
cdz-agent-host: daemon metrics-export loop — periodic multi-statsd-target flush, shutdown-aware (drain-once fan-out) + statsd sink tries ALL resolved addresses (#2119 review)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
@@ -218,6 +218,39 @@ async fn main() -> std::process::ExitCode {
             config.blob, config.log
         );
 
+        // Metrics EXPORT: when the `metrics-export` feature is compiled AND `[observability]` is enabled with
+        // statsd targets, clone the host's metrics registry (the Arc-backed handle shares the same storage the
+        // host loop increments) BEFORE `agent_host` moves into the loop, and spawn a periodic export task that
+        // flushes the registry to the configured statsd collectors every `report_interval_secs`. The task is
+        // shut down alongside the host loop (its own oneshot, fired after the loop returns) and does one final
+        // flush on the way out. OTLP/prometheus targets are not exported yet (statsd first); a following slice.
+        #[cfg(feature = "metrics-export")]
+        let (export_registry, export_targets, export_interval) = {
+            use cdz_agent_host::{MetricsTarget, StatsdTarget};
+            let targets: Vec<StatsdTarget> = if config.observability.enabled {
+                config
+                    .observability
+                    .targets
+                    .iter()
+                    .filter_map(|t| match t {
+                        MetricsTarget::Statsd { endpoint, prefix } => Some(StatsdTarget {
+                            endpoint: endpoint.clone(),
+                            prefix: prefix.clone(),
+                        }),
+                        // OTLP (+ future pull/file backends) aren't exported yet — statsd first.
+                        MetricsTarget::Otlp { .. } => None,
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            (
+                agent_host.registry().clone(),
+                targets,
+                std::time::Duration::from_secs(config.observability.report_interval_secs),
+            )
+        };
+
         let host = AsyncAgentHost::with_factory(agent_host, factory)
             .with_admin_authz(Box::new(AllowList::allow_all_for_local_admin()));
         // Drop our inbox sender so an idle inbox doesn't hold the loop open; the admin socket's AdminChannel
@@ -243,7 +276,36 @@ async fn main() -> std::process::ExitCode {
         // only), so a loop error left join! blocked on the socket forever, swallowing the error (#1977
         // review). Now the loop's return drives socket teardown, and the loop's Err reaches the exit code.
         let socket_task = tokio::spawn(socket.serve(admin_channel, sock_sd_rx));
+        // Spawn the periodic metrics-export task (if built + configured with statsd targets). It reads the
+        // cloned registry the host loop increments; its own shutdown oneshot fires after the loop returns so
+        // it does a final flush on the way out. Skipped (no task) when no statsd targets are configured.
+        #[cfg(feature = "metrics-export")]
+        let (export_task, export_sd_tx) = if export_targets.is_empty() {
+            (None, None)
+        } else {
+            eprintln!(
+                "cdz-agent-daemon: metrics export → {} statsd target(s) every {}s",
+                export_targets.len(),
+                export_interval.as_secs()
+            );
+            let (export_sd_tx, export_sd_rx) = tokio::sync::oneshot::channel::<()>();
+            let task = tokio::spawn(cdz_agent_host::run_statsd_export_loop(
+                export_registry,
+                export_targets,
+                export_interval,
+                export_sd_rx,
+            ));
+            (Some(task), Some(export_sd_tx))
+        };
         let loop_result = host.run_with_wall_clock(loop_sd_rx).await;
+        // Tear the export task down (final-flush-and-return) before the socket, so its last metrics ship.
+        #[cfg(feature = "metrics-export")]
+        if let (Some(task), Some(tx)) = (export_task, export_sd_tx) {
+            let _ = tx.send(());
+            if let Err(e) = task.await {
+                eprintln!("cdz-agent-daemon: metrics export task failed: {e:?}");
+            }
+        }
         // The loop is done — tear down the socket server and await its task so the socket file's Drop
         // cleanup runs before we exit. A JoinError here means the socket server task PANICKED; the exit code
         // is still driven by loop_result (correct — the loop is the primary), but log the panic so a dead

--- a/implementation/seed/crates/cdz-agent-host/src/export.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/export.rs
@@ -5,10 +5,13 @@
 //!
 //! The registry Counters are DRAIN-ON-REPORT: each [`Registry::report`] emits the per-interval delta and
 //! clears the counters, so the report cadence (`[observability].report_interval_secs`) IS the aggregation
-//! window — exactly the statsd/otlp PUSH model (the collector does the time-series aggregation). The intended
-//! caller is the daemon's periodic export task: it will run [`report_once`] on a `report_interval_secs` timer
-//! per configured target (that timer-loop wiring is a following slice — this module provides the flush
-//! primitive it drives).
+//! window — exactly the statsd/otlp PUSH model (the collector does the time-series aggregation).
+//!
+//! Three layers: [`report_once`] flushes to ONE endpoint; [`report_statsd_once`] flushes to MANY statsd
+//! targets with a SINGLE registry drain fanned out (multi-target-correct — a per-target report loop would
+//! drain on the first and hand zeroes to the rest); [`run_statsd_export_loop`] is the daemon's periodic,
+//! shutdown-aware task that calls [`report_statsd_once`] every `report_interval_secs` and does one final
+//! flush on shutdown. The daemon spawns the loop with a clone of the host's registry.
 //!
 //! The statsd sink uses a blocking [`std::net::UdpSocket`] (the send happens off the periodic timer tick,
 //! not on any hot path, so a sync send is fine + avoids pulling tokio's `net` feature).
@@ -31,27 +34,37 @@ impl UdpStatsdSink {
     /// error worth reporting at export setup, not a silent no-op).
     pub fn connect(endpoint: &str) -> Result<Self, String> {
         use std::net::ToSocketAddrs;
-        // Resolve the endpoint FIRST so the ephemeral local socket can be bound in the MATCHING address
-        // family: a v4-bound socket (`0.0.0.0:0`) cannot `connect` to an IPv6 peer (EAFNOSUPPORT), so a
-        // statsd collector that resolves to / is configured as IPv6 would fail even when reachable over v6
-        // (#2112 review). Bind `[::]:0` for a v6 target, `0.0.0.0:0` for v4, then connect so subsequent
-        // `send` (no addr) routes to the collector.
-        let target = endpoint
+        // Resolve the endpoint to ALL its addresses, then try each in turn: bind an ephemeral local socket in
+        // that address's MATCHING family (`[::]:0` for v6, `0.0.0.0:0` for v4 — a v4-bound socket cannot
+        // `connect` to a v6 peer, EAFNOSUPPORT, #2112 review) and connect; return the FIRST address that both
+        // binds and connects. Iterating ALL addresses (not just the first, #2119 review) means a hostname that
+        // resolves v6-first on a host with no v6 route still succeeds via a later v4 address — the
+        // multi-address robustness the family-matching fix was meant to provide.
+        let addrs: Vec<std::net::SocketAddr> = endpoint
             .to_socket_addrs()
             .map_err(|e| format!("statsd sink could not resolve {endpoint}: {e}"))?
-            .next()
-            .ok_or_else(|| format!("statsd sink: {endpoint} resolved to no address"))?;
-        let bind_addr: std::net::SocketAddr = if target.is_ipv6() {
-            (std::net::Ipv6Addr::UNSPECIFIED, 0).into()
-        } else {
-            (std::net::Ipv4Addr::UNSPECIFIED, 0).into()
-        };
-        let socket = std::net::UdpSocket::bind(bind_addr)
-            .map_err(|e| format!("statsd sink could not bind a local UDP socket: {e}"))?;
-        socket
-            .connect(target)
-            .map_err(|e| format!("statsd sink could not connect to {endpoint}: {e}"))?;
-        Ok(UdpStatsdSink { socket })
+            .collect();
+        if addrs.is_empty() {
+            return Err(format!("statsd sink: {endpoint} resolved to no address"));
+        }
+        let mut last_err = String::new();
+        for target in addrs {
+            let bind_addr: std::net::SocketAddr = if target.is_ipv6() {
+                (std::net::Ipv6Addr::UNSPECIFIED, 0).into()
+            } else {
+                (std::net::Ipv4Addr::UNSPECIFIED, 0).into()
+            };
+            match std::net::UdpSocket::bind(bind_addr).and_then(|s| {
+                s.connect(target)?;
+                Ok(s)
+            }) {
+                Ok(socket) => return Ok(UdpStatsdSink { socket }),
+                Err(e) => last_err = format!("{target}: {e}"),
+            }
+        }
+        Err(format!(
+            "statsd sink could not bind+connect any resolved address for {endpoint} (last error {last_err})"
+        ))
     }
 }
 
@@ -84,6 +97,96 @@ pub fn report_once(
     let mut backend = StatsdBackend::new(sink, prefix.map(str::to_owned));
     registry.report(&mut backend);
     Ok(())
+}
+
+/// One resolved statsd export target the periodic loop flushes to — where to send + an optional metric-name
+/// prefix. OWNED (not borrowed) so the loop's spawned task holds its target set for the daemon's lifetime
+/// without a config borrow. The daemon builds these from the `statsd` entries of `[observability].target`.
+#[derive(Debug, Clone)]
+pub struct StatsdTarget {
+    /// The statsd collector address (`host:port`) UDP payloads go to.
+    pub endpoint: String,
+    /// Optional metric-name prefix (maps to `StatsdBackend`'s prefix), e.g. `"cdz.agent"`.
+    pub prefix: Option<String>,
+}
+
+/// Flush the current metrics from `registry` to EVERY statsd target ONCE, draining the registry a SINGLE
+/// time and fanning the drained values out to all targets. This is the multi-target-correct primitive: the
+/// registry Counters are DRAIN-ON-REPORT, so reporting per-target in a loop would drain on the first target
+/// and hand ZEROES to every target after it (#2119 follow-on) — instead we build one
+/// [`StatsdBackend`](s2n_quic_dc_metrics::backend::StatsdBackend) per target over a
+/// [`Vec<Backend>`](s2n_quic_dc_metrics::backend) (the crate's fan-out impl) and [`Registry::report`] into it
+/// once, so every target sees the same per-interval delta with its OWN prefix applied.
+///
+/// Best-effort: a target whose sink can't connect this tick (collector down, bad addr) is SKIPPED and its
+/// endpoint collected into the returned error list, but the registry is STILL drained to the targets that DID
+/// connect (a transient bad target must not stall export to the healthy ones, nor wedge the counters
+/// un-drained). `Ok(())` when all targets connected; `Err(list)` names the ones that didn't (the caller — the
+/// periodic loop — logs them and carries on). An empty `targets` slice still drains to a no-op backend
+/// (clears the counters) and is `Ok`.
+pub fn report_statsd_once(
+    registry: &Registry,
+    targets: &[StatsdTarget],
+) -> Result<(), Vec<String>> {
+    use s2n_quic_dc_metrics::backend::StatsdBackend;
+
+    let mut backends: Vec<StatsdBackend<UdpStatsdSink>> = Vec::with_capacity(targets.len());
+    let mut failed = Vec::new();
+    for t in targets {
+        match UdpStatsdSink::connect(&t.endpoint) {
+            Ok(sink) => backends.push(StatsdBackend::new(sink, t.prefix.clone())),
+            Err(e) => failed.push(format!("{}: {e}", t.endpoint)),
+        }
+    }
+    // Drain the registry EXACTLY ONCE, fanning out to all connected backends (Vec<B>: Backend). Even an empty
+    // Vec drains (to a no-op), which correctly clears the per-interval counters.
+    registry.report(&mut backends);
+
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        Err(failed)
+    }
+}
+
+/// Run the daemon's periodic metrics-export loop: every `interval`, flush the metrics [`Registry`] to all
+/// `targets` via [`report_statsd_once`] (a single drain fanned out), until `shutdown` fires — then do ONE
+/// FINAL flush (so the last partial interval's metrics aren't lost) and return. Per-tick connect failures are
+/// LOGGED (a `tracing` warn) and swallowed — export is best-effort and must never take the daemon down.
+///
+/// `registry` is a CLONE of the host's registry (the `Arc`-backed handle shares the same storage), so the
+/// loop reads the same counters the host loop increments. The task is spawned by the daemon and shut down
+/// alongside the host loop.
+pub async fn run_statsd_export_loop(
+    registry: Registry,
+    targets: Vec<StatsdTarget>,
+    interval: std::time::Duration,
+    mut shutdown: tokio::sync::oneshot::Receiver<()>,
+) {
+    let mut timer = tokio::time::interval(interval);
+    // Skip the immediate first tick's burst-catch-up semantics: we want steady cadence, and a flush right at
+    // boot (before any work) would just emit zeroes.
+    timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // Consume the interval's immediate first tick so the first REAL flush happens one `interval` in.
+    timer.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = timer.tick() => {
+                if let Err(failed) = report_statsd_once(&registry, &targets) {
+                    tracing::warn!(targets = ?failed, "metrics-export: statsd target(s) unreachable this interval");
+                }
+            }
+            _ = &mut shutdown => {
+                // Final drain on the way out so the last interval's metrics reach the collector.
+                if let Err(failed) = report_statsd_once(&registry, &targets) {
+                    tracing::warn!(targets = ?failed, "metrics-export: statsd target(s) unreachable on final flush");
+                }
+                tracing::debug!("metrics-export: statsd export loop shut down");
+                return;
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -141,6 +244,166 @@ mod tests {
         assert!(
             collector.recv(&mut buf).is_ok(),
             "the v6 collector received a statsd datagram"
+        );
+    }
+
+    #[test]
+    fn report_statsd_once_fans_one_drain_out_to_every_target() {
+        // Two collectors, both configured as targets. report_statsd_once drains the registry ONCE and fans
+        // out — so BOTH collectors receive a (non-empty) datagram from the SAME drain. This is the
+        // multi-target-correctness guard: a per-target report loop would drain on the first + send zeroes (or
+        // nothing) to the second.
+        let c1 = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind c1");
+        let c2 = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind c2");
+        for c in [&c1, &c2] {
+            c.set_read_timeout(Some(std::time::Duration::from_millis(200)))
+                .unwrap();
+        }
+        let targets = vec![
+            StatsdTarget {
+                endpoint: c1.local_addr().unwrap().to_string(),
+                prefix: Some("a".into()),
+            },
+            StatsdTarget {
+                endpoint: c2.local_addr().unwrap().to_string(),
+                prefix: Some("b".into()),
+            },
+        ];
+
+        let registry = Registry::new();
+        let host = HostMetrics::new(&registry);
+        host.record_session_installed();
+        host.record_turn(true);
+
+        report_statsd_once(&registry, &targets).expect("all targets connected");
+
+        let mut buf = [0u8; 4096];
+        assert!(
+            c1.recv(&mut buf).map(|n| n > 0).unwrap_or(false),
+            "target 1 got a datagram"
+        );
+        assert!(
+            c2.recv(&mut buf).map(|n| n > 0).unwrap_or(false),
+            "target 2 got a datagram"
+        );
+    }
+
+    #[test]
+    fn report_statsd_once_reports_bad_targets_but_still_drains_good_ones() {
+        // One good collector + one unresolvable target. The bad one is named in the Err list, but the good
+        // collector STILL receives its datagram (a transient bad target must not starve the healthy ones).
+        let good = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind good");
+        good.set_read_timeout(Some(std::time::Duration::from_millis(200)))
+            .unwrap();
+        let targets = vec![
+            StatsdTarget {
+                endpoint: "not a socket addr".into(),
+                prefix: None,
+            },
+            StatsdTarget {
+                endpoint: good.local_addr().unwrap().to_string(),
+                prefix: None,
+            },
+        ];
+
+        let registry = Registry::new();
+        HostMetrics::new(&registry).record_turn(true);
+
+        let err = report_statsd_once(&registry, &targets).expect_err("one target is bad");
+        assert_eq!(
+            err.len(),
+            1,
+            "exactly the one bad target is reported: {err:?}"
+        );
+        assert!(err[0].contains("not a socket addr"), "{err:?}");
+
+        let mut buf = [0u8; 4096];
+        assert!(
+            good.recv(&mut buf).map(|n| n > 0).unwrap_or(false),
+            "the good target still got a datagram"
+        );
+    }
+
+    #[test]
+    fn report_statsd_once_with_no_targets_is_ok() {
+        // No targets → drains to a no-op backend (clears the counters), no error.
+        let registry = Registry::new();
+        HostMetrics::new(&registry).record_turn(true);
+        report_statsd_once(&registry, &[]).expect("empty target set is Ok");
+    }
+
+    #[tokio::test]
+    async fn export_loop_flushes_on_shutdown() {
+        // Drive the periodic loop with a short interval + fire shutdown almost immediately; the loop's FINAL
+        // flush (on shutdown) must reach the collector — proving the shutdown-aware final drain works even if
+        // no periodic tick elapsed. Also proves the loop terminates on the shutdown signal.
+        let collector = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind collector");
+        collector
+            .set_read_timeout(Some(std::time::Duration::from_millis(500)))
+            .unwrap();
+        let addr = collector.local_addr().unwrap().to_string();
+
+        let registry = Registry::new();
+        HostMetrics::new(&registry).record_turn(true);
+        let targets = vec![StatsdTarget {
+            endpoint: addr,
+            prefix: Some("cdz".into()),
+        }];
+
+        let (sd_tx, sd_rx) = tokio::sync::oneshot::channel();
+        // A long interval so no periodic tick fires before shutdown — the datagram must come from the FINAL
+        // flush alone.
+        let handle = tokio::spawn(run_statsd_export_loop(
+            registry,
+            targets,
+            std::time::Duration::from_secs(3600),
+            sd_rx,
+        ));
+        // Let the loop reach its select!, then shut it down.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        sd_tx.send(()).expect("send shutdown");
+        handle.await.expect("loop task joins cleanly");
+
+        let mut buf = [0u8; 4096];
+        assert!(
+            collector.recv(&mut buf).map(|n| n > 0).unwrap_or(false),
+            "the final on-shutdown flush reached the collector"
+        );
+    }
+
+    #[test]
+    fn connect_tries_all_resolved_addresses() {
+        // `localhost` typically resolves to BOTH ::1 and 127.0.0.1 (in some order). connect must succeed by
+        // trying addresses until one binds+connects — proving the multi-address iteration (#2119 review): even
+        // if the first-resolved family were unusable, a later address still connects. We bind a v4 collector
+        // and target it by the `localhost:port` NAME so resolution yields multiple candidates.
+        let collector = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind collector");
+        collector
+            .set_read_timeout(Some(std::time::Duration::from_millis(200)))
+            .unwrap();
+        let port = collector.local_addr().unwrap().port();
+
+        // Skip cleanly if `localhost` doesn't resolve to a v4 address on this runner (unusual).
+        use std::net::ToSocketAddrs;
+        let has_v4 = format!("localhost:{port}")
+            .to_socket_addrs()
+            .map(|it| it.into_iter().any(|a| a.is_ipv4()))
+            .unwrap_or(false);
+        if !has_v4 {
+            return;
+        }
+
+        let sink = UdpStatsdSink::connect(&format!("localhost:{port}"))
+            .expect("connect resolves localhost and connects a usable address");
+        // Prove the connected socket actually reaches the v4 collector.
+        use s2n_quic_dc_metrics::backend::StatsdSink;
+        let mut sink = sink;
+        sink.send_batch(std::iter::once("cdz.test:1|c"));
+        let mut buf = [0u8; 64];
+        // The datagram lands only if connect picked (or fell back to) the v4 address the collector is on.
+        assert!(
+            collector.recv(&mut buf).map(|n| n > 0).unwrap_or(false),
+            "a datagram reached the v4 collector via a resolved address"
         );
     }
 

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -86,7 +86,9 @@ pub use config::{
     RetryConfig, TracingConfig, TracingFormat, TracingOutput,
 };
 #[cfg(feature = "metrics-export")]
-pub use export::{report_once, UdpStatsdSink};
+pub use export::{
+    report_once, report_statsd_once, run_statsd_export_loop, StatsdTarget, UdpStatsdSink,
+};
 #[cfg(feature = "live-net")]
 pub use factory::LiveExecutorSet;
 pub use factory::{


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref e338c600c, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.