### PR TITLE
rcdzc: eval-diagnostic no longer lists Bytes as non-reifiable (Ast.Bytes reifies now)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/infer.rs
+++ b/implementation/seed/crates/rcdzc/src/infer.rs
@@ -11724,9 +11724,11 @@ fn map_duplicate_const_key(db: &mut Db, entries: &[(StructId, StructId)]) -> Opt
 fn first_non_reifiable_leaf(db: &Db, node: crate::ast::StructId) -> Option<&'static str> {
     match db.ast.get(node) {
         crate::ast::Struct::Atom(l) => match db.ast.leaf(*l) {
+            // Sym/Char have no `Ast` variant yet, so `quote` bails on them (reject-don't-miscompile).
+            // NOT `Bytes` — it reifies to `Ast.Bytes` (operator seq 113), so a `b"…"` is reifiable and
+            // must not be flagged here.
             crate::ast::Leaf::Sym(_) => Some("a `#\"…\"` symbol literal"),
             crate::ast::Leaf::Char(_) => Some("a `#\\…` char literal"),
-            crate::ast::Leaf::Bytes(_) => Some("a `b\"…\"` bytes literal"),
             _ => None,
         },
         crate::ast::Struct::List(kids) => {
@@ -11767,10 +11769,10 @@ fn enrich_unbound(db: &mut Db, id: crate::ast::StructId, r: Reject) -> Reject {
     {
         // A `(quote …)` argument IS compile-time-visible, so "nothing to reconstruct" is the WRONG
         // reason when it declined because it carries a leaf kind the `Ast` sum has no variant for — a
-        // `#"…"` symbol, a `#\c` char, or a `b"…"` bytes literal (`quote`'s reify bails on those, so the
-        // whole quote — and the enclosing `eval` — declines). Name the actual offending literal instead
-        // of the misleading runtime/non-constant phrasing. (These reify once the corresponding `Ast`
-        // variant lands — e.g. `Ast.Symbol` with the symbols vertical.)
+        // `#"…"` symbol or a `#\c` char (`quote`'s reify bails on those, so the whole quote — and the
+        // enclosing `eval` — declines). Name the actual offending literal instead of the misleading
+        // runtime/non-constant phrasing. (These reify once the corresponding `Ast` variant lands — e.g.
+        // `Ast.Symbol` with the symbols vertical; `Ast.Bytes` already landed, so `b"…"` is NOT flagged.)
         if let Some(kind) = eval_args
             .iter()
             .find_map(|&a| first_non_reifiable_leaf(db, a))
@@ -11780,9 +11782,9 @@ fn enrich_unbound(db: &mut Db, id: crate::ast::StructId, r: Reject) -> Reject {
                 format!(
                     "`eval` reconstructs a compile-time-visible AST to source, but this one contains \
                      {kind}, which has no `Ast` leaf variant to reconstruct (the `Ast` sum covers \
-                     integers, floats, booleans, strings, names, and lists). `quote` cannot reify such \
-                     a literal, so the whole `(quote …)` — and this `eval` — declines. Use a reifiable \
-                     literal, or compute the value outside `quote`."
+                     integers, floats, booleans, strings, names, byte sequences, and lists). `quote` \
+                     cannot reify such a literal, so the whole `(quote …)` — and this `eval` — declines. \
+                     Use a reifiable literal, or compute the value outside `quote`."
                 ),
             )
             .at(id);

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -47316,9 +47316,10 @@ mod match_engine {
     fn eval_of_a_quote_with_a_non_reifiable_leaf_names_the_literal_not_nothing_to_reconstruct() {
         // A `(quote …)` IS compile-time-visible, so the generic "nothing to reconstruct" (runtime / non-
         // constant) phrasing is WRONG when the quote declined only because it carries a leaf the `Ast` sum
-        // has no variant for: a `#"…"` symbol, a `#\c` char, or a `b"…"` bytes literal. The message must
-        // NAME the offending literal kind so the author knows WHY, not imply a runtime argument. (v-diag /
-        // concierge routed this; the root — no `Ast.Symbol`/`Ast.Char`/`Ast.Bytes` variant — is intended
+        // has no variant for: a `#"…"` symbol or a `#\c` char (NOT a `b"…"` bytes literal — that reifies
+        // to `Ast.Bytes` now, operator seq 113). The message must NAME the offending literal kind so the
+        // author knows WHY, not imply a runtime argument. (v-diag / concierge routed this; the root — no
+        // `Ast.Symbol`/`Ast.Char` variant — is intended
         // until the symbols vertical, so the fix is the DIAGNOSTIC, not the decline.)
         let msg = |src: &str| -> String {
             crate::diagnostics(&mut crate::db::Db::load(parse(src)))
@@ -47355,6 +47356,17 @@ mod match_engine {
             msg("(module m (def (f (: a Ast)) (eval a)) (export f))")
                 .contains("nothing to reconstruct"),
             "a runtime Ast argument keeps the reconstruct-nothing message"
+        );
+        // A `b"…"` bytes literal is NOT non-reifiable: it reifies to `Ast.Bytes` (operator seq 113), so
+        // `(eval (quote b"hi"))` reconstructs + runs — NO CDZ0101 at all. Pins that `first_non_reifiable_leaf`
+        // does NOT flag Bytes (a regression re-adding a Bytes arm would surface a spurious CDZ0101 here).
+        assert!(
+            crate::diagnostics(&mut crate::db::Db::load(parse(
+                "(module m (def (main) (eval (quote b\"hi\"))) (export main))"
+            )))
+            .iter()
+            .all(|d| d.code.as_deref() != Some("CDZ0101")),
+            "eval of a quoted bytes literal must NOT be a CDZ0101 — Ast.Bytes reifies"
         );
     }
 


### PR DESCRIPTION
Candidate PR for v-metaprogramming's merge-request (ref 509ebec8b, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.