### PR TITLE
cdz-agent-host: daemon metrics-export — BACKEND-AGNOSTIC periodic reporter (one drain fans out to all backends), shutdown-aware + connect tries all resolved addresses

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
@@ -218,6 +218,45 @@ async fn main() -> std::process::ExitCode {
             config.blob, config.log
         );
 
+        // Metrics EXPORT: when the `metrics-export` feature is compiled AND `[observability]` is enabled,
+        // clone the host's metrics registry (the Arc-backed handle shares the same storage the host loop
+        // increments) BEFORE `agent_host` moves into the loop, and build a BACKEND-AGNOSTIC MetricsReporter
+        // with every configured export backend PUSHED INTO it — so a single periodic drain fans out to all of
+        // them at once (reporting is destructive; a per-backend report would starve later backends — operator
+        // review on #2124). The periodic loop is shut down alongside the host loop (its own oneshot, fired
+        // after the loop returns) and does one final report on the way out. OTLP/prometheus backends push in
+        // here too once built (statsd first; a following slice).
+        #[cfg(feature = "metrics-export")]
+        let (export_registry, export_reporter, export_interval) = {
+            use cdz_agent_host::{MetricsReporter, MetricsTarget, StatsdTarget};
+            let statsd_targets: Vec<StatsdTarget> = if config.observability.enabled {
+                config
+                    .observability
+                    .targets
+                    .iter()
+                    .filter_map(|t| match t {
+                        MetricsTarget::Statsd { endpoint, prefix } => Some(StatsdTarget {
+                            endpoint: endpoint.clone(),
+                            prefix: prefix.clone(),
+                        }),
+                        // OTLP (+ future pull/file backends) aren't exported yet — statsd first.
+                        MetricsTarget::Otlp { .. } => None,
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            let (reporter, failed) = MetricsReporter::from_statsd_targets(&statsd_targets);
+            for f in &failed {
+                eprintln!("cdz-agent-daemon: metrics export target unavailable at boot: {f}");
+            }
+            (
+                agent_host.registry().clone(),
+                reporter,
+                std::time::Duration::from_secs(config.observability.report_interval_secs),
+            )
+        };
+
         let host = AsyncAgentHost::with_factory(agent_host, factory)
             .with_admin_authz(Box::new(AllowList::allow_all_for_local_admin()));
         // Drop our inbox sender so an idle inbox doesn't hold the loop open; the admin socket's AdminChannel
@@ -243,7 +282,36 @@ async fn main() -> std::process::ExitCode {
         // only), so a loop error left join! blocked on the socket forever, swallowing the error (#1977
         // review). Now the loop's return drives socket teardown, and the loop's Err reaches the exit code.
         let socket_task = tokio::spawn(socket.serve(admin_channel, sock_sd_rx));
+        // Spawn the periodic metrics-export task (if built + at least one backend was registered). It reads
+        // the cloned registry the host loop increments; its own shutdown oneshot fires after the loop returns
+        // so it does a final report on the way out. Skipped (no task) when no backends registered.
+        #[cfg(feature = "metrics-export")]
+        let (export_task, export_sd_tx) = if export_reporter.backend_count() == 0 {
+            (None, None)
+        } else {
+            eprintln!(
+                "cdz-agent-daemon: metrics export → {} backend(s) every {}s",
+                export_reporter.backend_count(),
+                export_interval.as_secs()
+            );
+            let (export_sd_tx, export_sd_rx) = tokio::sync::oneshot::channel::<()>();
+            let task = tokio::spawn(cdz_agent_host::run_export_loop(
+                export_registry,
+                export_reporter,
+                export_interval,
+                export_sd_rx,
+            ));
+            (Some(task), Some(export_sd_tx))
+        };
         let loop_result = host.run_with_wall_clock(loop_sd_rx).await;
+        // Tear the export task down (final-flush-and-return) before the socket, so its last metrics ship.
+        #[cfg(feature = "metrics-export")]
+        if let (Some(task), Some(tx)) = (export_task, export_sd_tx) {
+            let _ = tx.send(());
+            if let Err(e) = task.await {
+                eprintln!("cdz-agent-daemon: metrics export task failed: {e:?}");
+            }
+        }
         // The loop is done — tear down the socket server and await its task so the socket file's Drop
         // cleanup runs before we exit. A JoinError here means the socket server task PANICKED; the exit code
         // is still driven by loop_result (correct — the loop is the primary), but log the panic so a dead

--- a/implementation/seed/crates/cdz-agent-host/src/export.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/export.rs
@@ -4,11 +4,18 @@
 //! EXPORT — sending to a collector — is gated so the default build never opens a socket / sends UDP.
 //!
 //! The registry Counters are DRAIN-ON-REPORT: each [`Registry::report`] emits the per-interval delta and
-//! clears the counters, so the report cadence (`[observability].report_interval_secs`) IS the aggregation
-//! window — exactly the statsd/otlp PUSH model (the collector does the time-series aggregation). The intended
-//! caller is the daemon's periodic export task: it will run [`report_once`] on a `report_interval_secs` timer
-//! per configured target (that timer-loop wiring is a following slice — this module provides the flush
-//! primitive it drives).
+//! CLEARS the counters, so the report cadence (`[observability].report_interval_secs`) IS the aggregation
+//! window — exactly the statsd/otlp PUSH model (the collector does the time-series aggregation).
+//!
+//! Because reporting is DESTRUCTIVE, the exporter is BACKEND-AGNOSTIC (operator review on #2124): all export
+//! backends are PUSHED INTO a [`MetricsReporter`] at config time, and each cycle drains the registry EXACTLY
+//! ONCE and fans that single snapshot out to EVERY backend at the same time (the crate's `Vec<B>: Backend`
+//! composition). Reporting to backends sequentially would drain on the first and hand every later backend
+//! zeroes — so the reporter never does per-backend report calls. [`run_export_loop`] is the daemon's
+//! periodic, shutdown-aware task that drives one [`MetricsReporter::report`] cycle every
+//! `report_interval_secs` (plus one final report on shutdown); it knows nothing about which backends the
+//! reporter holds. The daemon builds the reporter from `[observability].target` and spawns the loop with a
+//! clone of the host's registry.
 //!
 //! The statsd sink uses a blocking [`std::net::UdpSocket`] (the send happens off the periodic timer tick,
 //! not on any hot path, so a sync send is fine + avoids pulling tokio's `net` feature).
@@ -31,27 +38,37 @@ impl UdpStatsdSink {
     /// error worth reporting at export setup, not a silent no-op).
     pub fn connect(endpoint: &str) -> Result<Self, String> {
         use std::net::ToSocketAddrs;
-        // Resolve the endpoint FIRST so the ephemeral local socket can be bound in the MATCHING address
-        // family: a v4-bound socket (`0.0.0.0:0`) cannot `connect` to an IPv6 peer (EAFNOSUPPORT), so a
-        // statsd collector that resolves to / is configured as IPv6 would fail even when reachable over v6
-        // (#2112 review). Bind `[::]:0` for a v6 target, `0.0.0.0:0` for v4, then connect so subsequent
-        // `send` (no addr) routes to the collector.
-        let target = endpoint
+        // Resolve the endpoint to ALL its addresses, then try each in turn: bind an ephemeral local socket in
+        // that address's MATCHING family (`[::]:0` for v6, `0.0.0.0:0` for v4 — a v4-bound socket cannot
+        // `connect` to a v6 peer, EAFNOSUPPORT, #2112 review) and connect; return the FIRST address that both
+        // binds and connects. Iterating ALL addresses (not just the first, #2119 review) means a hostname that
+        // resolves v6-first on a host with no v6 route still succeeds via a later v4 address — the
+        // multi-address robustness the family-matching fix was meant to provide.
+        let addrs: Vec<std::net::SocketAddr> = endpoint
             .to_socket_addrs()
             .map_err(|e| format!("statsd sink could not resolve {endpoint}: {e}"))?
-            .next()
-            .ok_or_else(|| format!("statsd sink: {endpoint} resolved to no address"))?;
-        let bind_addr: std::net::SocketAddr = if target.is_ipv6() {
-            (std::net::Ipv6Addr::UNSPECIFIED, 0).into()
-        } else {
-            (std::net::Ipv4Addr::UNSPECIFIED, 0).into()
-        };
-        let socket = std::net::UdpSocket::bind(bind_addr)
-            .map_err(|e| format!("statsd sink could not bind a local UDP socket: {e}"))?;
-        socket
-            .connect(target)
-            .map_err(|e| format!("statsd sink could not connect to {endpoint}: {e}"))?;
-        Ok(UdpStatsdSink { socket })
+            .collect();
+        if addrs.is_empty() {
+            return Err(format!("statsd sink: {endpoint} resolved to no address"));
+        }
+        let mut last_err = String::new();
+        for target in addrs {
+            let bind_addr: std::net::SocketAddr = if target.is_ipv6() {
+                (std::net::Ipv6Addr::UNSPECIFIED, 0).into()
+            } else {
+                (std::net::Ipv4Addr::UNSPECIFIED, 0).into()
+            };
+            match std::net::UdpSocket::bind(bind_addr).and_then(|s| {
+                s.connect(target)?;
+                Ok(s)
+            }) {
+                Ok(socket) => return Ok(UdpStatsdSink { socket }),
+                Err(e) => last_err = format!("{target}: {e}"),
+            }
+        }
+        Err(format!(
+            "statsd sink could not bind+connect any resolved address for {endpoint} (last error {last_err})"
+        ))
     }
 }
 
@@ -65,25 +82,106 @@ impl s2n_quic_dc_metrics::backend::StatsdSink for UdpStatsdSink {
     }
 }
 
-/// Report the current metrics from `registry` to the statsd collector at `endpoint` ONCE (a single flush).
-/// Builds a fresh [`StatsdBackend`](s2n_quic_dc_metrics::backend::StatsdBackend) over a UDP sink to
-/// `endpoint` + drives [`Registry::report`] into it — draining the per-interval deltas to the collector.
-/// `prefix` optionally namespaces every metric name (e.g. `"cdz.agent"`). Borrowed (`Option<&str>`) so the
-/// periodic-flush caller passes its configured prefix each tick WITHOUT cloning; the one owned `String` the
-/// backend needs is allocated inside (#2112 review). `Err` only if the sink can't be set up (bad endpoint); a
-/// per-datagram send failure is swallowed inside the sink (best-effort).
+/// One resolved statsd export target — where to send + an optional metric-name prefix. OWNED (not borrowed)
+/// so the reporter holds its target set for the daemon's lifetime without a config borrow. The daemon builds
+/// these from the `statsd` entries of `[observability].target`.
+#[derive(Debug, Clone)]
+pub struct StatsdTarget {
+    /// The statsd collector address (`host:port`) UDP payloads go to.
+    pub endpoint: String,
+    /// Optional metric-name prefix (maps to `StatsdBackend`'s prefix), e.g. `"cdz.agent"`.
+    pub prefix: Option<String>,
+}
+
+/// A BACKEND-AGNOSTIC periodic metrics reporter: it holds the set of registered export backends (statsd
+/// today; otlp/prometheus later) and, each report cycle, drains the [`Registry`] EXACTLY ONCE and fans the
+/// drained snapshot out to ALL of them at the same time.
 ///
-/// The daemon calls this on each tick of its `report_interval_secs` timer, per configured statsd target.
-pub fn report_once(
-    registry: &Registry,
-    endpoint: &str,
-    prefix: Option<&str>,
-) -> Result<(), String> {
-    use s2n_quic_dc_metrics::backend::StatsdBackend;
-    let sink = UdpStatsdSink::connect(endpoint)?;
-    let mut backend = StatsdBackend::new(sink, prefix.map(str::to_owned));
-    registry.report(&mut backend);
-    Ok(())
+/// This is the correctness-critical shape (operator review on #2124): [`Registry::report`] is DESTRUCTIVE —
+/// each report drains the counters and clears them. So reporting to backends SEQUENTIALLY (a per-backend or
+/// per-target report call) would drain on the FIRST backend and hand every later backend ZEROES. Instead all
+/// backends are PUSHED IN (at config time), held here as one `Vec<Box<dyn Backend + Send>>`, and a single
+/// [`report`](Self::report) drives ONE [`Registry::report`] into the whole set (the crate's `Vec<B>: Backend`
+/// fan-out), so every backend receives the SAME complete per-interval delta. The reporter itself is unaware
+/// of WHICH backends it holds — it just drives "report now"; adding a backend kind is a new push at build
+/// time, not a change to the loop.
+///
+/// Backends are built ONCE (a UDP sink's socket, an HTTP client's pool, …) and reused across reports — the
+/// crate's [`Backend::report_start`](s2n_quic_dc_metrics::backend::Backend) resets per-report state, so reuse
+/// is the intended model. A target whose sink can't be set up at build time is dropped (surfaced by the
+/// constructor) rather than retried per tick.
+pub struct MetricsReporter {
+    backends: Vec<Box<dyn s2n_quic_dc_metrics::backend::Backend + Send>>,
+}
+
+impl MetricsReporter {
+    /// Build a reporter from the configured statsd targets. Each target that connects becomes a
+    /// [`StatsdBackend`](s2n_quic_dc_metrics::backend::StatsdBackend) pushed into the set; a target that can't
+    /// connect (bad/unresolvable endpoint) is SKIPPED and its endpoint collected into the returned failure
+    /// list (the daemon logs it at boot). The reporter is usable even with an empty backend set — a report
+    /// then just drains the counters to nothing (keeping the drain-on-report window honest). (OTLP/prometheus
+    /// backends will be pushed in by their own constructors/`push_*` in a following slice.)
+    pub fn from_statsd_targets(targets: &[StatsdTarget]) -> (Self, Vec<String>) {
+        use s2n_quic_dc_metrics::backend::StatsdBackend;
+        let mut backends: Vec<Box<dyn s2n_quic_dc_metrics::backend::Backend + Send>> =
+            Vec::with_capacity(targets.len());
+        let mut failed = Vec::new();
+        for t in targets {
+            match UdpStatsdSink::connect(&t.endpoint) {
+                Ok(sink) => backends.push(Box::new(StatsdBackend::new(sink, t.prefix.clone()))),
+                Err(e) => failed.push(format!("{}: {e}", t.endpoint)),
+            }
+        }
+        (MetricsReporter { backends }, failed)
+    }
+
+    /// How many backends are registered — the daemon skips spawning the export loop when this is 0.
+    pub fn backend_count(&self) -> usize {
+        self.backends.len()
+    }
+
+    /// Drive ONE report cycle: drain `registry` a SINGLE time and fan the drained snapshot out to every
+    /// registered backend at once (the crate's `Vec<B>: Backend` composition). Because the drain is
+    /// destructive, this is the ONLY correct multi-backend shape — one drain, all backends. An empty backend
+    /// set still drains (to a no-op), which correctly clears the per-interval counters.
+    pub fn report(&mut self, registry: &Registry) {
+        registry.report(&mut self.backends);
+    }
+}
+
+/// Run the daemon's periodic, BACKEND-AGNOSTIC metrics-export loop: every `interval`, drive ONE
+/// [`MetricsReporter::report`] cycle (a single registry drain fanned out to every registered backend), until
+/// `shutdown` fires — then do ONE FINAL report (so the last partial interval's metrics aren't lost) and
+/// return. The loop knows NOTHING about which backends the reporter holds; it just drives the periodic
+/// "report now". Export is best-effort — a backend's own send failure is swallowed inside that backend's sink
+/// and never takes the daemon down.
+///
+/// `registry` is a CLONE of the host's registry (the `Arc`-backed handle shares the same storage), so the
+/// loop reads the same counters the host loop increments. The task is spawned by the daemon and shut down
+/// alongside the host loop.
+pub async fn run_export_loop(
+    registry: Registry,
+    mut reporter: MetricsReporter,
+    interval: std::time::Duration,
+    mut shutdown: tokio::sync::oneshot::Receiver<()>,
+) {
+    let mut timer = tokio::time::interval(interval);
+    // Steady cadence, not burst-catch-up; and consume the interval's immediate first tick so the first REAL
+    // report happens one `interval` in (a report right at boot, before any work, would just emit zeroes).
+    timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    timer.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = timer.tick() => reporter.report(&registry),
+            _ = &mut shutdown => {
+                // Final drain on the way out so the last interval's metrics reach the backends.
+                reporter.report(&registry);
+                tracing::debug!("metrics-export: export loop shut down");
+                return;
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -92,11 +190,11 @@ mod tests {
     use crate::metrics::HostMetrics;
 
     #[test]
-    fn report_once_sends_to_a_bound_collector_without_error() {
-        // Bind a real UDP socket as the "collector", record some metrics into a registry, then report_once
-        // to that socket's addr — proves the sink connects + the registry drives the StatsdBackend + a
-        // datagram is sent, all without error. (We don't assert the payload bytes — statsd wire format is the
-        // crate's concern; this proves the export path is wired + total.)
+    fn reporter_reaches_a_bound_collector_without_error() {
+        // Bind a real UDP socket as the "collector", record some metrics, build a reporter from one statsd
+        // target, and report ONCE — proves the backend connects + the registry drives it + a datagram is
+        // sent, all without error. (We don't assert the payload bytes — statsd wire format is the crate's
+        // concern; this proves the export path is wired + total.)
         let collector = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind collector");
         collector
             .set_read_timeout(Some(std::time::Duration::from_millis(200)))
@@ -108,7 +206,13 @@ mod tests {
         host.record_session_installed();
         host.record_turn(true);
 
-        report_once(&registry, &addr, Some("cdz.agent")).expect("report_once ok");
+        let (mut reporter, failed) = MetricsReporter::from_statsd_targets(&[StatsdTarget {
+            endpoint: addr,
+            prefix: Some("cdz.agent".into()),
+        }]);
+        assert!(failed.is_empty(), "the target connected: {failed:?}");
+        assert_eq!(reporter.backend_count(), 1);
+        reporter.report(&registry);
 
         // A datagram arrived at the collector (the statsd export actually sent something).
         let mut buf = [0u8; 4096];
@@ -118,7 +222,7 @@ mod tests {
     }
 
     #[test]
-    fn report_once_reaches_an_ipv6_collector() {
+    fn reporter_reaches_an_ipv6_collector() {
         // The #2112-review fix: a v6 statsd endpoint must work (a v4-bound socket can't connect to a v6
         // peer). Bind a v6 loopback collector + report to it — proves connect() binds the MATCHING family.
         let collector = match std::net::UdpSocket::bind(("::1", 0)) {
@@ -132,15 +236,204 @@ mod tests {
         let addr = collector.local_addr().unwrap().to_string();
 
         let registry = Registry::new();
-        let host = HostMetrics::new(&registry);
-        host.record_turn(true);
+        HostMetrics::new(&registry).record_turn(true);
 
-        report_once(&registry, &addr, None).expect("report_once to a v6 collector ok");
+        let (mut reporter, failed) = MetricsReporter::from_statsd_targets(&[StatsdTarget {
+            endpoint: addr,
+            prefix: None,
+        }]);
+        assert!(failed.is_empty(), "v6 target connected: {failed:?}");
+        reporter.report(&registry);
 
         let mut buf = [0u8; 4096];
         assert!(
             collector.recv(&mut buf).is_ok(),
             "the v6 collector received a statsd datagram"
+        );
+    }
+
+    #[test]
+    fn reporter_fans_one_drain_out_to_every_backend() {
+        // Two collectors, both registered as backends. ONE report drains the registry once and fans out — so
+        // BOTH collectors receive a (non-empty) datagram from the SAME drain. This is the correctness guard
+        // the operator flagged on #2124: reporting per-backend would drain on the first and hand the second
+        // ZEROES, because Registry::report is destructive.
+        let c1 = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind c1");
+        let c2 = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind c2");
+        for c in [&c1, &c2] {
+            c.set_read_timeout(Some(std::time::Duration::from_millis(200)))
+                .unwrap();
+        }
+        let (mut reporter, failed) = MetricsReporter::from_statsd_targets(&[
+            StatsdTarget {
+                endpoint: c1.local_addr().unwrap().to_string(),
+                prefix: Some("a".into()),
+            },
+            StatsdTarget {
+                endpoint: c2.local_addr().unwrap().to_string(),
+                prefix: Some("b".into()),
+            },
+        ]);
+        assert!(failed.is_empty(), "both targets connected: {failed:?}");
+        assert_eq!(reporter.backend_count(), 2);
+
+        let registry = Registry::new();
+        let host = HostMetrics::new(&registry);
+        host.record_session_installed();
+        host.record_turn(true);
+
+        reporter.report(&registry);
+
+        let mut buf = [0u8; 4096];
+        assert!(
+            c1.recv(&mut buf).map(|n| n > 0).unwrap_or(false),
+            "backend 1 got a datagram"
+        );
+        assert!(
+            c2.recv(&mut buf).map(|n| n > 0).unwrap_or(false),
+            "backend 2 got a datagram"
+        );
+    }
+
+    #[test]
+    fn one_drain_then_a_second_report_sees_no_new_metrics() {
+        // Guard the DRAIN-ON-REPORT semantics that motivate the fan-out design: after one report drains the
+        // counters, a SECOND report (no new activity) still succeeds but carries the (now-zero) delta. This
+        // pins WHY per-backend sequential reporting would starve later backends — the first drain empties the
+        // counters. Both reports reach the collector without error; we assert the path stays total.
+        let collector = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind collector");
+        collector
+            .set_read_timeout(Some(std::time::Duration::from_millis(200)))
+            .unwrap();
+        let addr = collector.local_addr().unwrap().to_string();
+
+        let registry = Registry::new();
+        HostMetrics::new(&registry).record_turn(true);
+
+        let (mut reporter, _) = MetricsReporter::from_statsd_targets(&[StatsdTarget {
+            endpoint: addr,
+            prefix: None,
+        }]);
+        reporter.report(&registry); // drains the recorded turn
+        reporter.report(&registry); // second drain — counters already cleared, still total
+    }
+
+    #[test]
+    fn reporter_reports_bad_targets_at_build_but_still_registers_good_ones() {
+        // One good collector + one unresolvable target. The bad one is named in the build-time failure list,
+        // but the good collector is still registered and a report reaches it (a bad target must not starve the
+        // healthy ones).
+        let good = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind good");
+        good.set_read_timeout(Some(std::time::Duration::from_millis(200)))
+            .unwrap();
+        let (mut reporter, failed) = MetricsReporter::from_statsd_targets(&[
+            StatsdTarget {
+                endpoint: "not a socket addr".into(),
+                prefix: None,
+            },
+            StatsdTarget {
+                endpoint: good.local_addr().unwrap().to_string(),
+                prefix: None,
+            },
+        ]);
+        assert_eq!(failed.len(), 1, "exactly the one bad target: {failed:?}");
+        assert!(failed[0].contains("not a socket addr"), "{failed:?}");
+        assert_eq!(reporter.backend_count(), 1, "the good target registered");
+
+        let registry = Registry::new();
+        HostMetrics::new(&registry).record_turn(true);
+        reporter.report(&registry);
+
+        let mut buf = [0u8; 4096];
+        assert!(
+            good.recv(&mut buf).map(|n| n > 0).unwrap_or(false),
+            "the good backend still got a datagram"
+        );
+    }
+
+    #[test]
+    fn reporter_with_no_backends_is_total() {
+        // No targets → zero backends → a report drains to a no-op (clears the counters), no panic.
+        let registry = Registry::new();
+        HostMetrics::new(&registry).record_turn(true);
+        let (mut reporter, failed) = MetricsReporter::from_statsd_targets(&[]);
+        assert!(failed.is_empty());
+        assert_eq!(reporter.backend_count(), 0);
+        reporter.report(&registry);
+    }
+
+    #[tokio::test]
+    async fn export_loop_reports_on_shutdown() {
+        // Drive the periodic loop with a long interval + fire shutdown almost immediately; the loop's FINAL
+        // report (on shutdown) must reach the collector — proving the shutdown-aware final drain works even if
+        // no periodic tick elapsed. Also proves the loop terminates on the shutdown signal.
+        let collector = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind collector");
+        collector
+            .set_read_timeout(Some(std::time::Duration::from_millis(500)))
+            .unwrap();
+        let addr = collector.local_addr().unwrap().to_string();
+
+        let registry = Registry::new();
+        HostMetrics::new(&registry).record_turn(true);
+        let (reporter, _) = MetricsReporter::from_statsd_targets(&[StatsdTarget {
+            endpoint: addr,
+            prefix: Some("cdz".into()),
+        }]);
+
+        let (sd_tx, sd_rx) = tokio::sync::oneshot::channel();
+        // A long interval so no periodic tick fires before shutdown — the datagram must come from the FINAL
+        // report alone.
+        let handle = tokio::spawn(run_export_loop(
+            registry,
+            reporter,
+            std::time::Duration::from_secs(3600),
+            sd_rx,
+        ));
+        // Let the loop reach its select!, then shut it down.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        sd_tx.send(()).expect("send shutdown");
+        handle.await.expect("loop task joins cleanly");
+
+        let mut buf = [0u8; 4096];
+        assert!(
+            collector.recv(&mut buf).map(|n| n > 0).unwrap_or(false),
+            "the final on-shutdown report reached the collector"
+        );
+    }
+
+    #[test]
+    fn connect_tries_all_resolved_addresses() {
+        // `localhost` typically resolves to BOTH ::1 and 127.0.0.1 (in some order). connect must succeed by
+        // trying addresses until one binds+connects — proving the multi-address iteration (#2119 review): even
+        // if the first-resolved family were unusable, a later address still connects. We bind a v4 collector
+        // and target it by the `localhost:port` NAME so resolution yields multiple candidates.
+        let collector = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind collector");
+        collector
+            .set_read_timeout(Some(std::time::Duration::from_millis(200)))
+            .unwrap();
+        let port = collector.local_addr().unwrap().port();
+
+        // Skip cleanly if `localhost` doesn't resolve to a v4 address on this runner (unusual).
+        use std::net::ToSocketAddrs;
+        let has_v4 = format!("localhost:{port}")
+            .to_socket_addrs()
+            .map(|it| it.into_iter().any(|a| a.is_ipv4()))
+            .unwrap_or(false);
+        if !has_v4 {
+            return;
+        }
+
+        let sink = UdpStatsdSink::connect(&format!("localhost:{port}"))
+            .expect("connect resolves localhost and connects a usable address");
+        // Prove the connected socket actually reaches the v4 collector.
+        use s2n_quic_dc_metrics::backend::StatsdSink;
+        let mut sink = sink;
+        sink.send_batch(std::iter::once("cdz.test:1|c"));
+        let mut buf = [0u8; 64];
+        // The datagram lands only if connect picked (or fell back to) the v4 address the collector is on.
+        assert!(
+            collector.recv(&mut buf).map(|n| n > 0).unwrap_or(false),
+            "a datagram reached the v4 collector via a resolved address"
         );
     }
 

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -86,7 +86,7 @@ pub use config::{
     RetryConfig, TracingConfig, TracingFormat, TracingOutput,
 };
 #[cfg(feature = "metrics-export")]
-pub use export::{report_once, UdpStatsdSink};
+pub use export::{run_export_loop, MetricsReporter, StatsdTarget, UdpStatsdSink};
 #[cfg(feature = "live-net")]
 pub use factory::LiveExecutorSet;
 pub use factory::{


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref d3cfa6b81, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.