### PR TITLE
cdz-agent-host: #2129 review — warn when observability enabled but no exportable (statsd) targets + make connect test deterministic

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
@@ -229,6 +229,9 @@ async fn main() -> std::process::ExitCode {
         #[cfg(feature = "metrics-export")]
         let (export_registry, export_reporter, export_interval) = {
             use cdz_agent_host::{MetricsReporter, MetricsTarget, StatsdTarget};
+            // How many configured targets we CAN'T export yet (OTLP etc.) — so an observability config that is
+            // enabled but has ONLY unexportable targets gets a loud diagnostic instead of a silent no-op.
+            let mut unexportable = 0usize;
             let statsd_targets: Vec<StatsdTarget> = if config.observability.enabled {
                 config
                     .observability
@@ -240,12 +243,24 @@ async fn main() -> std::process::ExitCode {
                             prefix: prefix.clone(),
                         }),
                         // OTLP (+ future pull/file backends) aren't exported yet — statsd first.
-                        MetricsTarget::Otlp { .. } => None,
+                        MetricsTarget::Otlp { .. } => {
+                            unexportable += 1;
+                            None
+                        }
                     })
                     .collect()
             } else {
                 Vec::new()
             };
+            // Enabled but nothing we can export → warn (not a silent skip). The common trip is an OTLP-only
+            // config in a build where OTLP export isn't wired yet (#2129 review).
+            if config.observability.enabled && statsd_targets.is_empty() {
+                eprintln!(
+                    "cdz-agent-daemon: [observability] enabled but no exportable (statsd) targets configured \
+                     — nothing will be exported ({unexportable} non-statsd target(s) present; OTLP export not \
+                     yet wired)."
+                );
+            }
             let (reporter, failed) = MetricsReporter::from_statsd_targets(&statsd_targets);
             for f in &failed {
                 eprintln!("cdz-agent-daemon: metrics export target unavailable at boot: {f}");

--- a/implementation/seed/crates/cdz-agent-host/src/export.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/export.rs
@@ -402,38 +402,46 @@ mod tests {
     }
 
     #[test]
-    fn connect_tries_all_resolved_addresses() {
-        // `localhost` typically resolves to BOTH ::1 and 127.0.0.1 (in some order). connect must succeed by
-        // trying addresses until one binds+connects — proving the multi-address iteration (#2119 review): even
-        // if the first-resolved family were unusable, a later address still connects. We bind a v4 collector
-        // and target it by the `localhost:port` NAME so resolution yields multiple candidates.
+    fn connect_resolves_a_multi_address_name() {
+        // connect must accept a NAME that resolves to multiple addresses and succeed by trying them until one
+        // binds+connects (the #2119 multi-address iteration). `localhost` typically resolves to both ::1 and
+        // 127.0.0.1. We assert only that connect SUCCEEDS on the name — NOT which family it picks: a UDP
+        // `connect` does not validate the receiver, so asserting a datagram arrives at a single-family
+        // collector would be flaky (if the name resolves v6-first + v6 is usable, connect correctly picks ::1
+        // and a v4-only collector never receives it — the test would fail though connect behaved correctly,
+        // #2129 review). Datagram DELIVERY is proven deterministically in the explicit-family test below.
+        use std::net::ToSocketAddrs;
+        // Skip cleanly on a runner where `localhost` doesn't resolve at all (unusual sandbox) — the
+        // explicit-family test still covers the connect+deliver path.
+        if "localhost:65000".to_socket_addrs().is_err() {
+            return;
+        }
+        let sink = UdpStatsdSink::connect("localhost:65000");
+        assert!(
+            sink.is_ok(),
+            "connect resolves a multi-address name and connects a usable address: {sink:?}"
+        );
+    }
+
+    #[test]
+    fn connect_delivers_to_an_explicit_family_collector() {
+        // Datagram delivery, made DETERMINISTIC by targeting 127.0.0.1 EXPLICITLY (a single v4 address, not
+        // the ambiguous `localhost` name) so connect binds v4 and the v4 collector always receives (#2129
+        // review). This is the family-matched bind (#2112) + actual send end-to-end.
         let collector = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind collector");
         collector
             .set_read_timeout(Some(std::time::Duration::from_millis(200)))
             .unwrap();
-        let port = collector.local_addr().unwrap().port();
+        let addr = collector.local_addr().unwrap().to_string();
 
-        // Skip cleanly if `localhost` doesn't resolve to a v4 address on this runner (unusual).
-        use std::net::ToSocketAddrs;
-        let has_v4 = format!("localhost:{port}")
-            .to_socket_addrs()
-            .map(|it| it.into_iter().any(|a| a.is_ipv4()))
-            .unwrap_or(false);
-        if !has_v4 {
-            return;
-        }
-
-        let sink = UdpStatsdSink::connect(&format!("localhost:{port}"))
-            .expect("connect resolves localhost and connects a usable address");
-        // Prove the connected socket actually reaches the v4 collector.
+        let mut sink = UdpStatsdSink::connect(&addr).expect("connect to the explicit v4 collector");
         use s2n_quic_dc_metrics::backend::StatsdSink;
-        let mut sink = sink;
         sink.send_batch(std::iter::once("cdz.test:1|c"));
+
         let mut buf = [0u8; 64];
-        // The datagram lands only if connect picked (or fell back to) the v4 address the collector is on.
         assert!(
             collector.recv(&mut buf).map(|n| n > 0).unwrap_or(false),
-            "a datagram reached the v4 collector via a resolved address"
+            "the datagram reached the explicit v4 collector"
         );
     }
 


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 1d9645c88, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.