### PR TITLE
cdz-agent-host: OTLP metrics-export backend — sync-send via bounded channel + async HTTP forwarder (metrics-export-otlp feature)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/Cargo.lock
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.lock
@@ -1727,6 +1727,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pulley-interpreter"
 version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,6 +2080,7 @@ dependencies = [
  "libc",
  "pin-project-lite",
  "portable-atomic",
+ "prost",
  "serde_json",
  "tokio",
 ]

--- a/implementation/seed/crates/cdz-agent-host/Cargo.toml
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.toml
@@ -52,8 +52,19 @@ admin = ["tokio/net", "tokio/io-util", "tokio/signal"]
 # the periodic EXPORT to a collector is feature-gated. The statsd sink uses std::net::UdpSocket (a blocking
 # send off the periodic timer tick — not hot-path — so no tokio `net` is needed). No extra deps: the
 # s2n-quic-dc-metrics StatsdBackend is already in the always-on dep; this feature just compiles the sink +
-# the report task. (OTLP/prometheus backends slot in behind this same feature later.)
+# the report task. The BASE feature stays DEP-FREE — the statsd path pulls nothing beyond std.
 metrics-export = []
+
+# `metrics-export-otlp` adds the OTLP export backend on top of `metrics-export`. STRICTLY opt-in + kept
+# SEPARATE from the base so the hermetic default (and a statsd-only `metrics-export` build) NEVER links the
+# HTTP tree (concierge guard 1: verify `cargo tree` on the default build shows no reqwest AND no prost). It
+# enables (a) `dep:reqwest` — the async HTTP client the OTLP forwarder POSTs protobuf payloads with (already
+# optional for `live-net`, so this is additive), and (b) `s2n-quic-dc-metrics/otel` — the metrics crate's own
+# OTLP feature (`otel = ["dep:prost"]`, OFF by default) that unlocks `backend::OtlpBackend`/`OtlpSink`. The
+# OTLP sink is a NON-blocking channel push (its `send` runs inside the sync report cycle, so it must not
+# block); a separate async forwarder task drains the bounded channel and POSTs, dropping + logging on
+# backpressure or a failed POST (guard 2: telemetry is best-effort, must never block/panic the report loop).
+metrics-export-otlp = ["metrics-export", "dep:reqwest", "s2n-quic-dc-metrics/otel"]
 
 [dependencies]
 # The kernel whose Executor/Authorize traits + effect/event types we implement. Path dep across the

--- a/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
@@ -227,11 +227,11 @@ async fn main() -> std::process::ExitCode {
         // after the loop returns) and does one final report on the way out. OTLP/prometheus backends push in
         // here too once built (statsd first; a following slice).
         #[cfg(feature = "metrics-export")]
-        let (export_registry, export_reporter, export_interval) = {
+        let (export_registry, export_reporter, export_interval, otlp_forwarders) = {
             use cdz_agent_host::{MetricsReporter, MetricsTarget, StatsdTarget};
-            // How many configured targets we CAN'T export yet (OTLP etc.) — so an observability config that is
-            // enabled but has ONLY unexportable targets gets a loud diagnostic instead of a silent no-op.
-            let mut unexportable = 0usize;
+            // Collect the statsd targets. OTLP targets are exportable only when the `metrics-export-otlp`
+            // feature is compiled; otherwise they're counted as unexportable so an enabled config with only
+            // such targets warns instead of silently no-op'ing.
             let statsd_targets: Vec<StatsdTarget> = if config.observability.enabled {
                 config
                     .observability
@@ -242,33 +242,83 @@ async fn main() -> std::process::ExitCode {
                             endpoint: endpoint.clone(),
                             prefix: prefix.clone(),
                         }),
-                        // OTLP (+ future pull/file backends) aren't exported yet — statsd first.
-                        MetricsTarget::Otlp { .. } => {
-                            unexportable += 1;
-                            None
-                        }
+                        MetricsTarget::Otlp { .. } => None,
                     })
                     .collect()
             } else {
                 Vec::new()
             };
-            // Enabled but nothing we can export → warn (not a silent skip). The common trip is an OTLP-only
-            // config in a build where OTLP export isn't wired yet (#2129 review).
-            if config.observability.enabled && statsd_targets.is_empty() {
-                eprintln!(
-                    "cdz-agent-daemon: [observability] enabled but no exportable (statsd) targets configured \
-                     — nothing will be exported ({unexportable} non-statsd target(s) present; OTLP export not \
-                     yet wired)."
-                );
-            }
+            // OTLP targets are exportable with the feature, unexportable without it. Counted (not per-loop
+            // mutated) so the warning below can name how many targets this build can't handle.
+            #[cfg(feature = "metrics-export-otlp")]
+            let otlp_targets: Vec<cdz_agent_host::OtlpTarget> = if config.observability.enabled {
+                config
+                    .observability
+                    .targets
+                    .iter()
+                    .filter_map(|t| match t {
+                        MetricsTarget::Otlp {
+                            endpoint,
+                            scope_name,
+                            scope_version,
+                        } => Some(cdz_agent_host::OtlpTarget {
+                            endpoint: endpoint.clone(),
+                            scope_name: scope_name.clone(),
+                            scope_version: scope_version.clone(),
+                        }),
+                        MetricsTarget::Statsd { .. } => None,
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            #[cfg(not(feature = "metrics-export-otlp"))]
+            let unexportable = config
+                .observability
+                .targets
+                .iter()
+                .filter(|t| matches!(t, MetricsTarget::Otlp { .. }))
+                .count();
+            // `mut` only needed when OTLP pushes into the reporter below (statsd-only builds never mutate it).
+            #[cfg(feature = "metrics-export-otlp")]
+            let (mut reporter, failed) = MetricsReporter::from_statsd_targets(&statsd_targets);
+            #[cfg(not(feature = "metrics-export-otlp"))]
             let (reporter, failed) = MetricsReporter::from_statsd_targets(&statsd_targets);
             for f in &failed {
                 eprintln!("cdz-agent-daemon: metrics export target unavailable at boot: {f}");
+            }
+            // Push each OTLP target into the SAME reporter (one drain fans out to statsd + otlp together) and
+            // keep its (endpoint, receiver) so we can spawn a forwarder task per target below.
+            #[cfg(feature = "metrics-export-otlp")]
+            let otlp_forwarders: Vec<(String, tokio::sync::mpsc::Receiver<Vec<u8>>)> = otlp_targets
+                .iter()
+                .map(|t| (t.endpoint.clone(), reporter.push_otlp(t)))
+                .collect();
+            #[cfg(not(feature = "metrics-export-otlp"))]
+            let otlp_forwarders: Vec<((), ())> = Vec::new();
+            // Enabled but NOTHING we can export → warn (not a silent skip). The common trip is an OTLP-only
+            // config in a build where the OTLP feature isn't compiled (#2129 review).
+            if config.observability.enabled
+                && reporter.backend_count() == 0
+                && !config.observability.targets.is_empty()
+            {
+                #[cfg(not(feature = "metrics-export-otlp"))]
+                eprintln!(
+                    "cdz-agent-daemon: [observability] enabled but no exportable targets in this build \
+                     — nothing will be exported ({unexportable} target(s) need a feature not compiled, e.g. \
+                     metrics-export-otlp)."
+                );
+                #[cfg(feature = "metrics-export-otlp")]
+                eprintln!(
+                    "cdz-agent-daemon: [observability] enabled but no export backend could be set up \
+                     — nothing will be exported (all configured targets failed to initialize)."
+                );
             }
             (
                 agent_host.registry().clone(),
                 reporter,
                 std::time::Duration::from_secs(config.observability.report_interval_secs),
+                otlp_forwarders,
             )
         };
 
@@ -297,6 +347,18 @@ async fn main() -> std::process::ExitCode {
         // only), so a loop error left join! blocked on the socket forever, swallowing the error (#1977
         // review). Now the loop's return drives socket teardown, and the loop's Err reaches the exit code.
         let socket_task = tokio::spawn(socket.serve(admin_channel, sock_sd_rx));
+        // Spawn one async OTLP forwarder per OTLP target. Each drains its bounded channel + POSTs off the
+        // report path (the sink's send only enqueues). A forwarder self-terminates when its channel closes —
+        // which happens when the reporter (owning the sinks) is dropped as run_export_loop returns at
+        // shutdown. Detached: they hold only a Receiver, so we don't need to join them (best-effort telemetry).
+        #[cfg(feature = "metrics-export-otlp")]
+        for (endpoint, rx) in otlp_forwarders {
+            eprintln!("cdz-agent-daemon: metrics export → OTLP forwarder for {endpoint}");
+            tokio::spawn(cdz_agent_host::run_otlp_forwarder(endpoint, rx));
+        }
+        // Bind the non-otlp placeholder so the value is consumed in a build without the OTLP feature.
+        #[cfg(all(feature = "metrics-export", not(feature = "metrics-export-otlp")))]
+        let _ = otlp_forwarders;
         // Spawn the periodic metrics-export task (if built + at least one backend was registered). It reads
         // the cloned registry the host loop increments; its own shutdown oneshot fires after the loop returns
         // so it does a final report on the way out. Skipped (no task) when no backends registered.

--- a/implementation/seed/crates/cdz-agent-host/src/export.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/export.rs
@@ -184,6 +184,185 @@ pub async fn run_export_loop(
     }
 }
 
+// ─── OTLP backend (feature `metrics-export-otlp`) ──────────────────────────────────────────────────────
+//
+// OTLP is a PUSH backend like statsd, but its payload is an OTLP protobuf `ExportMetricsServiceRequest` that
+// must be sent over HTTP — and the crate's `OtlpSink::send(&[u8])` is SYNCHRONOUS, called inside
+// `Backend::report_end`, which runs inside the SYNC `MetricsReporter::report`. So the sink CANNOT block or
+// `.await` on the report path. The shape (concierge-approved): the sink's `send` does a NON-BLOCKING push of
+// the payload onto a BOUNDED channel and returns immediately; a separate async FORWARDER task drains the
+// channel and does the HTTP POST off the report path. Backpressure / a failed POST is DROP + log — telemetry
+// is best-effort and must never block or crash the agent host (guard 2).
+
+/// One resolved OTLP export target. OWNED so the reporter/forwarder hold it for the daemon's lifetime.
+#[cfg(feature = "metrics-export-otlp")]
+#[derive(Debug, Clone)]
+pub struct OtlpTarget {
+    /// The OTLP collector base endpoint; the forwarder POSTs to `{endpoint}/v1/metrics`.
+    pub endpoint: String,
+    /// OTLP `InstrumentationScope` name embedded in every payload (falls back to the crate name if empty).
+    pub scope_name: Option<String>,
+    /// OTLP `InstrumentationScope` version (falls back to empty if unset).
+    pub scope_version: Option<String>,
+}
+
+/// The bound on the OTLP hand-off channel. Small: a report every `report_interval_secs` produces one payload,
+/// so a healthy forwarder keeps this near-empty; the bound only matters when the collector is down/slow, and
+/// then we WANT to drop (best-effort) rather than grow unbounded. Holds a few intervals of slack.
+#[cfg(feature = "metrics-export-otlp")]
+const OTLP_CHANNEL_BOUND: usize = 8;
+
+/// A synchronous [`OtlpSink`](s2n_quic_dc_metrics::backend::OtlpSink) that hands each protobuf payload off to
+/// the async forwarder over a BOUNDED channel WITHOUT blocking. `send` runs inside the sync report cycle, so
+/// it must return immediately: it `try_send`s and, if the channel is full (the collector is backpressured) or
+/// closed (forwarder gone), DROPS the payload + logs — never blocks, never panics (guard 2).
+#[cfg(feature = "metrics-export-otlp")]
+pub struct ChannelOtlpSink {
+    tx: tokio::sync::mpsc::Sender<Vec<u8>>,
+}
+
+#[cfg(feature = "metrics-export-otlp")]
+impl s2n_quic_dc_metrics::backend::OtlpSink for ChannelOtlpSink {
+    fn send(&mut self, payload: &[u8]) {
+        // Non-blocking hand-off. `try_send` never awaits; on Full/Closed we drop + log (best-effort telemetry
+        // must not stall the report cycle waiting on a slow/down collector).
+        match self.tx.try_send(payload.to_vec()) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                tracing::warn!(
+                    "metrics-export otlp: forwarder channel full — dropping this report's payload"
+                );
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                tracing::debug!("metrics-export otlp: forwarder gone — dropping payload");
+            }
+        }
+    }
+}
+
+/// An [`OtlpBackend`](s2n_quic_dc_metrics::backend::OtlpBackend) wrapper that stamps the per-report wall-clock
+/// timestamps OTLP data points need (`start_time_unix_nano`/`time_unix_nano`). The inner backend's timestamp
+/// setters aren't reachable once it's boxed as `dyn Backend` in the reporter, so this wrapper sets them in
+/// [`report_start`](s2n_quic_dc_metrics::backend::Backend::report_start) — the per-report hook — before
+/// delegating every trait method to the inner backend. `start` is the previous report's end (process start for
+/// the first), `time` is now; both Unix nanoseconds (statsd needed no timestamps — this is OTLP-specific).
+#[cfg(feature = "metrics-export-otlp")]
+struct TimestampedOtlpBackend {
+    inner: s2n_quic_dc_metrics::backend::OtlpBackend<ChannelOtlpSink>,
+    /// End of the PREVIOUS report interval (Unix ns) → the next report's start. 0 until the first report.
+    last_report_ns: u64,
+}
+
+#[cfg(feature = "metrics-export-otlp")]
+impl TimestampedOtlpBackend {
+    fn now_unix_ns() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX))
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(feature = "metrics-export-otlp")]
+impl s2n_quic_dc_metrics::backend::Backend for TimestampedOtlpBackend {
+    fn report_start(&mut self, options: &s2n_quic_dc_metrics::backend::ReportOptions) {
+        let now = Self::now_unix_ns();
+        // First report: start == now (a zero-length interval) so we never emit a start after the end.
+        let start = if self.last_report_ns == 0 {
+            now
+        } else {
+            self.last_report_ns
+        };
+        self.inner.set_start_time_ns(start);
+        self.inner.set_time_ns(now);
+        self.last_report_ns = now;
+        self.inner.report_start(options);
+    }
+    fn record_counter(&mut self, info: &s2n_quic_dc_metrics::backend::MetricInfo<'_>, value: u64) {
+        self.inner.record_counter(info, value);
+    }
+    fn record_gauge(&mut self, info: &s2n_quic_dc_metrics::backend::MetricInfo<'_>, value: i64) {
+        self.inner.record_gauge(info, value);
+    }
+    fn record_bool(
+        &mut self,
+        info: &s2n_quic_dc_metrics::backend::MetricInfo<'_>,
+        true_count: u64,
+        false_count: u64,
+    ) {
+        self.inner.record_bool(info, true_count, false_count);
+    }
+    fn record_histogram(
+        &mut self,
+        info: &s2n_quic_dc_metrics::backend::MetricInfo<'_>,
+        hist: s2n_quic_dc_metrics::backend::Histogram<'_>,
+    ) {
+        self.inner.record_histogram(info, hist);
+    }
+    fn record_callback(
+        &mut self,
+        info: &s2n_quic_dc_metrics::backend::MetricInfo<'_>,
+        values: &[&dyn s2n_quic_dc_metrics::backend::CallbackValue],
+    ) {
+        self.inner.record_callback(info, values);
+    }
+    fn report_end(&mut self) {
+        self.inner.report_end();
+    }
+}
+
+/// The async OTLP forwarder: drains the bounded channel and POSTs each protobuf payload to `endpoint`'s
+/// `/v1/metrics` as `application/x-protobuf`. A failed/timed-out POST is DROPPED + logged (best-effort). Runs
+/// until the channel closes (all sinks dropped, i.e. the reporter is gone at daemon shutdown). Spawned by the
+/// daemon alongside the export loop.
+#[cfg(feature = "metrics-export-otlp")]
+pub async fn run_otlp_forwarder(endpoint: String, mut rx: tokio::sync::mpsc::Receiver<Vec<u8>>) {
+    let url = format!("{}/v1/metrics", endpoint.trim_end_matches('/'));
+    let client = reqwest::Client::new();
+    while let Some(payload) = rx.recv().await {
+        let resp = client
+            .post(&url)
+            .header("content-type", "application/x-protobuf")
+            .body(payload)
+            .send()
+            .await;
+        match resp {
+            Ok(r) if r.status().is_success() => {}
+            Ok(r) => {
+                tracing::warn!(status = %r.status(), url = %url, "metrics-export otlp: POST rejected — dropping")
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, url = %url, "metrics-export otlp: POST failed — dropping")
+            }
+        }
+    }
+    tracing::debug!(url = %url, "metrics-export otlp: forwarder shut down (channel closed)");
+}
+
+#[cfg(feature = "metrics-export-otlp")]
+impl MetricsReporter {
+    /// Register an OTLP backend into the reporter and return the channel receiver the daemon hands to
+    /// [`run_otlp_forwarder`]. The backend's sink pushes each report's protobuf payload onto a bounded channel
+    /// (non-blocking); the forwarder POSTs them. One call per OTLP target (each gets its own channel +
+    /// forwarder task, so a slow collector on one target can't backpressure another).
+    pub fn push_otlp(&mut self, target: &OtlpTarget) -> tokio::sync::mpsc::Receiver<Vec<u8>> {
+        use s2n_quic_dc_metrics::backend::OtlpBackend;
+        let (tx, rx) = tokio::sync::mpsc::channel(OTLP_CHANNEL_BOUND);
+        let sink = ChannelOtlpSink { tx };
+        let scope_name = target
+            .scope_name
+            .clone()
+            .unwrap_or_else(|| "cdz-agent-host".to_string());
+        let scope_version = target.scope_version.clone().unwrap_or_default();
+        let inner = OtlpBackend::new(sink, scope_name, scope_version);
+        self.backends.push(Box::new(TimestampedOtlpBackend {
+            inner,
+            last_report_ns: 0,
+        }));
+        rx
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -451,5 +630,80 @@ mod tests {
         // at export setup.
         let err = UdpStatsdSink::connect("not a socket addr").unwrap_err();
         assert!(err.contains("statsd sink"), "{err}");
+    }
+
+    #[cfg(feature = "metrics-export-otlp")]
+    mod otlp {
+        use super::*;
+        use s2n_quic_dc_metrics::backend::OtlpSink;
+
+        #[test]
+        fn otlp_sink_send_is_nonblocking_and_drops_when_channel_full() {
+            // Guard 2: the sink's send runs inside the sync report cycle, so it must NEVER block. Build a
+            // sink over a tiny channel, DON'T drain it, and push more than the bound — every send must return
+            // immediately (dropping on full), never block or panic. (A blocking send here would hang the test
+            // + prove the report cycle could stall on a slow collector.)
+            let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(2);
+            let mut sink = ChannelOtlpSink { tx };
+            // Push well past the bound of 2 — all return immediately, extras dropped.
+            for _ in 0..10 {
+                sink.send(b"otlp-payload");
+            }
+            // Reaching here without hanging is the assertion (send never blocks).
+        }
+
+        #[test]
+        fn otlp_sink_send_after_receiver_dropped_is_a_clean_drop() {
+            // If the forwarder is gone (receiver dropped), send must be a clean no-op drop (Closed), not a
+            // panic — the report cycle keeps going even after the forwarder dies.
+            let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(2);
+            drop(rx);
+            let mut sink = ChannelOtlpSink { tx };
+            sink.send(b"otlp-payload"); // no panic
+        }
+
+        #[tokio::test]
+        async fn otlp_backend_registers_and_a_report_enqueues_without_blocking() {
+            // Push an OTLP target into the reporter + drive a report: the report cycle must complete without
+            // blocking on the (undrained) channel, and a payload must be enqueued for the forwarder.
+            let target = OtlpTarget {
+                endpoint: "http://127.0.0.1:65001".into(),
+                scope_name: Some("cdz-test".into()),
+                scope_version: None,
+            };
+            let (mut reporter, _) = MetricsReporter::from_statsd_targets(&[]);
+            let mut rx = reporter.push_otlp(&target);
+            assert_eq!(reporter.backend_count(), 1);
+
+            let registry = Registry::new();
+            HostMetrics::new(&registry).record_turn(true);
+            reporter.report(&registry); // must not block on the undrained channel
+
+            // A protobuf payload was enqueued for the forwarder.
+            let payload = rx.try_recv();
+            assert!(
+                payload.map(|p| !p.is_empty()).unwrap_or(false),
+                "the OTLP report enqueued a non-empty payload"
+            );
+        }
+
+        #[tokio::test]
+        async fn otlp_forwarder_against_a_dead_endpoint_drops_and_terminates() {
+            // Guard 2 end-to-end: a forwarder pointed at a dead endpoint must DROP the payload (POST fails)
+            // and, when the channel closes, TERMINATE — never hang. Send one payload, close the channel, and
+            // assert the forwarder task joins (doesn't block forever on the failed POST).
+            let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(2);
+            // 127.0.0.1:1 — nothing listens; the POST fails fast (conn refused), the forwarder logs + drops.
+            let handle = tokio::spawn(run_otlp_forwarder("http://127.0.0.1:1".into(), rx));
+            tx.send(b"otlp-payload".to_vec()).await.expect("enqueue");
+            drop(tx); // close the channel → forwarder drains the one payload, then returns
+                      // The forwarder must terminate (a dead endpoint doesn't wedge it). Bound the wait so a hang fails
+                      // the test rather than hanging CI.
+            let joined = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+            assert!(
+                joined.is_ok(),
+                "forwarder terminated after the channel closed"
+            );
+        }
     }
 }

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -87,6 +87,8 @@ pub use config::{
 };
 #[cfg(feature = "metrics-export")]
 pub use export::{run_export_loop, MetricsReporter, StatsdTarget, UdpStatsdSink};
+#[cfg(feature = "metrics-export-otlp")]
+pub use export::{run_otlp_forwarder, ChannelOtlpSink, OtlpTarget};
 #[cfg(feature = "live-net")]
 pub use factory::LiveExecutorSet;
 pub use factory::{


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 60e8e3025, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.