### PR TITLE
cdz-agent-host: prometheus (PULL) metrics-export backend — hand-rolled scrape server, loopback-default (metrics-export-prometheus feature)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/Cargo.toml
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.toml
@@ -66,6 +66,17 @@ metrics-export = []
 # backpressure or a failed POST (guard 2: telemetry is best-effort, must never block/panic the report loop).
 metrics-export-otlp = ["metrics-export", "dep:reqwest", "s2n-quic-dc-metrics/otel"]
 
+# `metrics-export-prometheus` adds the PULL prometheus export backend: the daemon SERVES an HTTP scrape
+# endpoint (`GET /metrics`) rather than pushing. STRICTLY opt-in + separate so the hermetic default (and a
+# statsd/otlp build) NEVER pulls tokio's `net` tree (guard: verify `cargo tree` on the default build shows no
+# tokio net feature via prometheus). It enables tokio's `net` + `io-util` (for the `TcpListener` +
+# `AsyncReadExt`/`AsyncWriteExt` the hand-rolled HTTP/1.1 responder uses) — NO hyper/axum, the responder is
+# hand-rolled (same dep-light pattern as the admin Unix-socket listener). The `PrometheusBackend`/handle live
+# in the always-on s2n-quic-dc-metrics dep (NOT behind a crate feature, unlike otel), so no extra crate
+# feature is needed here. Security posture (concierge): the scrape endpoint binds LOOPBACK by default; a
+# non-loopback bind is warned (a no-auth inbound port is only acceptable loopback-bound).
+metrics-export-prometheus = ["metrics-export", "tokio/net", "tokio/io-util"]
+
 [dependencies]
 # The kernel whose Executor/Authorize traits + effect/event types we implement. Path dep across the
 # workspace boundary (both are their own workspaces). We CONSUME these traits; we never edit its src.

--- a/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
@@ -227,7 +227,13 @@ async fn main() -> std::process::ExitCode {
         // after the loop returns) and does one final report on the way out. OTLP/prometheus backends push in
         // here too once built (statsd first; a following slice).
         #[cfg(feature = "metrics-export")]
-        let (export_registry, export_reporter, export_interval, otlp_forwarders) = {
+        let (
+            export_registry,
+            export_reporter,
+            export_interval,
+            otlp_forwarders,
+            prometheus_servers,
+        ) = {
             use cdz_agent_host::{MetricsReporter, MetricsTarget, StatsdTarget};
             // Collect the statsd targets. OTLP targets are exportable only when the `metrics-export-otlp`
             // feature is compiled; otherwise they're counted as unexportable so an enabled config with only
@@ -242,7 +248,8 @@ async fn main() -> std::process::ExitCode {
                             endpoint: endpoint.clone(),
                             prefix: prefix.clone(),
                         }),
-                        MetricsTarget::Otlp { .. } => None,
+                        // Non-statsd targets (otlp/prometheus) are collected separately below.
+                        _ => None,
                     })
                     .collect()
             } else {
@@ -266,29 +273,61 @@ async fn main() -> std::process::ExitCode {
                             scope_name: scope_name.clone(),
                             scope_version: scope_version.clone(),
                         }),
-                        MetricsTarget::Statsd { .. } => None,
+                        // Non-otlp targets (statsd/prometheus) are collected in their own passes.
+                        _ => None,
                     })
                     .collect()
             } else {
                 Vec::new()
             };
-            #[cfg(not(feature = "metrics-export-otlp"))]
+            // Prometheus (PULL) targets are exportable with the metrics-export-prometheus feature. Collected
+            // like otlp: with the feature they become backends + scrape servers; without it they count toward
+            // the unexportable diagnostic below.
+            #[cfg(feature = "metrics-export-prometheus")]
+            let prometheus_targets: Vec<cdz_agent_host::PrometheusTarget> =
+                if config.observability.enabled {
+                    config
+                        .observability
+                        .targets
+                        .iter()
+                        .filter_map(|t| match t {
+                            MetricsTarget::Prometheus { bind, prefix } => {
+                                Some(cdz_agent_host::PrometheusTarget {
+                                    bind: bind.clone(),
+                                    prefix: prefix.clone(),
+                                })
+                            }
+                            _ => None,
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+            // Count targets this build can't export (for the enabled-but-nothing-exportable diagnostic): an
+            // OTLP target without metrics-export-otlp, or a prometheus target without metrics-export-prometheus.
             let unexportable = config
                 .observability
                 .targets
                 .iter()
-                .filter(|t| matches!(t, MetricsTarget::Otlp { .. }))
+                .filter(|t| {
+                    (matches!(t, MetricsTarget::Otlp { .. })
+                        && !cfg!(feature = "metrics-export-otlp"))
+                        || (matches!(t, MetricsTarget::Prometheus { .. })
+                            && !cfg!(feature = "metrics-export-prometheus"))
+                })
                 .count();
-            // `mut` only needed when OTLP pushes into the reporter below (statsd-only builds never mutate it).
-            #[cfg(feature = "metrics-export-otlp")]
+            // `mut` only when a push backend (otlp/prometheus) registers into the reporter; a statsd-only build
+            // never mutates it after construction.
+            #[cfg_attr(
+                not(any(feature = "metrics-export-otlp", feature = "metrics-export-prometheus")),
+                allow(unused_mut)
+            )]
             let (mut reporter, failed) = MetricsReporter::from_statsd_targets(&statsd_targets);
-            #[cfg(not(feature = "metrics-export-otlp"))]
-            let (reporter, failed) = MetricsReporter::from_statsd_targets(&statsd_targets);
             for f in &failed {
                 eprintln!("cdz-agent-daemon: metrics export target unavailable at boot: {f}");
             }
-            // Push each OTLP target into the SAME reporter (one drain fans out to statsd + otlp together) and
-            // keep its (endpoint, receiver) so we can spawn a forwarder task per target below.
+            // Push each OTLP target into the SAME reporter (one drain fans out to statsd + otlp + prometheus
+            // together) and keep its (endpoint, receiver) so we can spawn a forwarder task per target below.
             #[cfg(feature = "metrics-export-otlp")]
             let otlp_forwarders: Vec<(String, tokio::sync::mpsc::Receiver<Vec<u8>>)> = otlp_targets
                 .iter()
@@ -296,6 +335,18 @@ async fn main() -> std::process::ExitCode {
                 .collect();
             #[cfg(not(feature = "metrics-export-otlp"))]
             let otlp_forwarders: Vec<((), ())> = Vec::new();
+            // Push each prometheus target's backend into the reporter + keep (bind, handle) so we can spawn a
+            // scrape server per target below (the handle reads the exposition text the backend re-renders).
+            #[cfg(feature = "metrics-export-prometheus")]
+            let prometheus_servers: Vec<(
+                String,
+                s2n_quic_dc_metrics::backend::PrometheusHandle,
+            )> = prometheus_targets
+                .iter()
+                .map(|t| (t.bind.clone(), reporter.push_prometheus(t)))
+                .collect();
+            #[cfg(not(feature = "metrics-export-prometheus"))]
+            let prometheus_servers: Vec<((), ())> = Vec::new();
             // Enabled but NO export backend got set up → warn (never a silent skip). Distinguish the causes so
             // the message is accurate (#2137 review): (a) zero targets configured, (b) targets present but
             // unexportable in THIS build (non-statsd targets without the feature compiled), (c) targets present
@@ -306,21 +357,13 @@ async fn main() -> std::process::ExitCode {
                         "cdz-agent-daemon: [observability] enabled but no targets configured \
                          — nothing will be exported."
                     );
+                } else if unexportable > 0 {
+                    eprintln!(
+                        "cdz-agent-daemon: [observability] enabled but no export backend in this build \
+                         — nothing will be exported ({unexportable} target(s) need an export feature not \
+                         compiled here, e.g. metrics-export-otlp / metrics-export-prometheus)."
+                    );
                 } else {
-                    #[cfg(not(feature = "metrics-export-otlp"))]
-                    if unexportable > 0 {
-                        eprintln!(
-                            "cdz-agent-daemon: [observability] enabled but no export backend in this build \
-                             — nothing will be exported ({unexportable} non-statsd (OTLP) target(s) need the \
-                             metrics-export-otlp feature, not compiled here)."
-                        );
-                    } else {
-                        eprintln!(
-                            "cdz-agent-daemon: [observability] enabled but no export backend could be set up \
-                             — nothing will be exported (all configured targets failed to initialize)."
-                        );
-                    }
-                    #[cfg(feature = "metrics-export-otlp")]
                     eprintln!(
                         "cdz-agent-daemon: [observability] enabled but no export backend could be set up \
                          — nothing will be exported (all configured targets failed to initialize)."
@@ -332,6 +375,7 @@ async fn main() -> std::process::ExitCode {
                 reporter,
                 std::time::Duration::from_secs(config.observability.report_interval_secs),
                 otlp_forwarders,
+                prometheus_servers,
             )
         };
 
@@ -372,6 +416,27 @@ async fn main() -> std::process::ExitCode {
         // Bind the non-otlp placeholder so the value is consumed in a build without the OTLP feature.
         #[cfg(all(feature = "metrics-export", not(feature = "metrics-export-otlp")))]
         let _ = otlp_forwarders;
+        // Spawn one prometheus scrape server per prometheus target. Each binds its (loopback-by-default)
+        // address and serves GET /metrics from its handle until shut down. Collect their shutdown senders so
+        // they're torn down after the host loop returns (before the socket), like the export task.
+        #[cfg(feature = "metrics-export-prometheus")]
+        let mut prometheus_shutdowns: Vec<tokio::sync::oneshot::Sender<()>> = Vec::new();
+        #[cfg(feature = "metrics-export-prometheus")]
+        for (bind, handle) in prometheus_servers {
+            eprintln!("cdz-agent-daemon: metrics export → prometheus scrape server on {bind}");
+            let (sd_tx, sd_rx) = tokio::sync::oneshot::channel::<()>();
+            prometheus_shutdowns.push(sd_tx);
+            tokio::spawn(async move {
+                if let Err(e) =
+                    cdz_agent_host::run_prometheus_scrape_server(bind, handle, sd_rx).await
+                {
+                    eprintln!("cdz-agent-daemon: prometheus scrape server failed to start: {e}");
+                }
+            });
+        }
+        // Consume the placeholder in a build without the prometheus feature.
+        #[cfg(all(feature = "metrics-export", not(feature = "metrics-export-prometheus")))]
+        let _ = prometheus_servers;
         // Spawn the periodic metrics-export task (if built + at least one backend was registered). It reads
         // the cloned registry the host loop increments; its own shutdown oneshot fires after the loop returns
         // so it does a final report on the way out. Skipped (no task) when no backends registered.
@@ -401,6 +466,11 @@ async fn main() -> std::process::ExitCode {
             if let Err(e) = task.await {
                 eprintln!("cdz-agent-daemon: metrics export task failed: {e:?}");
             }
+        }
+        // Shut down the prometheus scrape servers (best-effort; they're detached, we just fire their signals).
+        #[cfg(feature = "metrics-export-prometheus")]
+        for tx in prometheus_shutdowns {
+            let _ = tx.send(());
         }
         // The loop is done — tear down the socket server and await its task so the socket file's Drop
         // cleanup runs before we exit. A JoinError here means the socket server task PANICKED; the exit code

--- a/implementation/seed/crates/cdz-agent-host/src/config.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/config.rs
@@ -161,6 +161,20 @@ pub enum MetricsTarget {
         #[serde(default)]
         scope_version: Option<String>,
     },
+    /// The `prometheus` backend — `s2n-quic-dc-metrics`' `PrometheusBackend`. UNLIKE statsd/otlp (outbound
+    /// PUSH), prometheus is PULL: the daemon SERVES an HTTP scrape endpoint (`GET /metrics`) that a scraper
+    /// reads, so its config is a `bind` LISTEN address (not a push endpoint). Bound to LOOPBACK by default
+    /// (concierge posture ruling: an inbound port is a new exposure — a no-auth scrape endpoint is only
+    /// acceptable loopback-bound; a non-loopback `bind` is gated + warned at boot). `prefix` optionally
+    /// namespaces every metric name.
+    Prometheus {
+        /// The address the scrape listener binds (`host:port`), e.g. `"127.0.0.1:9090"`. Loopback host keeps
+        /// the no-auth endpoint on the local trust boundary; a non-loopback host is warned at boot.
+        bind: String,
+        /// Optional metric-name prefix applied to every emitted metric (maps to `PrometheusBackend`'s prefix).
+        #[serde(default)]
+        prefix: Option<String>,
+    },
 }
 
 impl MetricsTarget {
@@ -169,6 +183,7 @@ impl MetricsTarget {
         match self {
             MetricsTarget::Statsd { .. } => "statsd",
             MetricsTarget::Otlp { .. } => "otlp",
+            MetricsTarget::Prometheus { .. } => "prometheus",
         }
     }
 }
@@ -436,6 +451,12 @@ impl DaemonConfig {
                         return Err(ConfigError(format!(
                             "[observability] target {i} ({}) needs a non-empty endpoint",
                             t.kind()
+                        )));
+                    }
+                    // The PULL backend requires a non-empty bind (LISTEN) address.
+                    MetricsTarget::Prometheus { bind, .. } if bind.trim().is_empty() => {
+                        return Err(ConfigError(format!(
+                            "[observability] target {i} (prometheus) needs a non-empty bind address"
                         )));
                     }
                     _ => {}

--- a/implementation/seed/crates/cdz-agent-host/src/export.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/export.rs
@@ -383,6 +383,137 @@ impl MetricsReporter {
     }
 }
 
+// ─── Prometheus backend (feature `metrics-export-prometheus`) ──────────────────────────────────────────
+//
+// Prometheus is PULL, not push: the crate's `PrometheusBackend` IS a `Backend` (so it still pushes into the
+// same `MetricsReporter` and rides the one-drain fan-out — no special report path), but each report re-renders
+// the exposition text into a shared cell, and a `PrometheusHandle` is read by an inbound HTTP scrape endpoint
+// the daemon SERVES at `GET /metrics`. It keeps CUMULATIVE series (correct for the pull model; vs statsd/otlp
+// per-interval delta). The scrape server is a MINIMAL hand-rolled HTTP/1.1 responder over
+// `tokio::net::TcpListener` (no hyper/axum — same dep-light pattern as the admin Unix-socket listener),
+// gated behind `metrics-export-prometheus` so the default/hermetic build pulls no `tokio/net`.
+//
+// SECURITY POSTURE (concierge ruling): an inbound port is a new exposure. The server binds LOOPBACK by
+// default and a no-auth endpoint is only acceptable loopback-bound; a non-loopback bind is WARNED at boot
+// (auth/allowlist would be a separate decision).
+
+/// One resolved prometheus export target — the address the scrape listener binds + an optional metric-name
+/// prefix. OWNED so the daemon holds it for the listener's lifetime.
+#[cfg(feature = "metrics-export-prometheus")]
+#[derive(Debug, Clone)]
+pub struct PrometheusTarget {
+    /// The address the scrape HTTP listener binds (`host:port`), e.g. `127.0.0.1:9090`.
+    pub bind: String,
+    /// Optional metric-name prefix (maps to `PrometheusBackend`'s prefix).
+    pub prefix: Option<String>,
+}
+
+#[cfg(feature = "metrics-export-prometheus")]
+impl MetricsReporter {
+    /// Register a `PrometheusBackend` into the reporter and return its
+    /// [`PrometheusHandle`](s2n_quic_dc_metrics::backend::PrometheusHandle) — the daemon hands the handle to
+    /// [`run_prometheus_scrape_server`]. The backend re-renders the exposition text on each report (cumulative
+    /// series); the handle reads the latest published text cheaply on the scrape path.
+    pub fn push_prometheus(
+        &mut self,
+        target: &PrometheusTarget,
+    ) -> s2n_quic_dc_metrics::backend::PrometheusHandle {
+        use s2n_quic_dc_metrics::backend::PrometheusBackend;
+        let (backend, handle) = PrometheusBackend::new(target.prefix.clone());
+        self.backends.push(Box::new(backend));
+        handle
+    }
+}
+
+/// `true` if `addr` is a loopback socket address (127.0.0.0/8 or ::1). Used to enforce the concierge posture:
+/// a no-auth scrape endpoint is only acceptable loopback-bound; a non-loopback bind is warned.
+#[cfg(feature = "metrics-export-prometheus")]
+pub fn is_loopback_bind(addr: &str) -> bool {
+    use std::net::ToSocketAddrs;
+    addr.to_socket_addrs()
+        .map(|mut it| it.next().map(|a| a.ip().is_loopback()).unwrap_or(false))
+        .unwrap_or(false)
+}
+
+/// Serve the prometheus scrape endpoint: bind `bind_addr` and answer each connection's `GET /metrics` with the
+/// latest exposition text from `handle`, until `shutdown` fires. A MINIMAL hand-rolled HTTP/1.1 responder (no
+/// hyper/axum): read the request line, return `200` + the exposition body for `GET /metrics`, `404` for any
+/// other path, `405` for a non-GET method. Every per-connection error is DROP + log — a scrape-serving failure
+/// (malformed request, a slow client) must never take the daemon down. `Err` only if the initial bind fails
+/// (a bad `bind` address is a boot-time config error worth surfacing).
+///
+/// Posture: a NON-loopback `bind_addr` is WARNED (a no-auth inbound port off loopback is a new exposure — the
+/// concierge ruling); the server still binds it (explicit operator config), but the warning is loud.
+#[cfg(feature = "metrics-export-prometheus")]
+pub async fn run_prometheus_scrape_server(
+    bind_addr: String,
+    handle: s2n_quic_dc_metrics::backend::PrometheusHandle,
+    mut shutdown: tokio::sync::oneshot::Receiver<()>,
+) -> Result<(), String> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    if !is_loopback_bind(&bind_addr) {
+        tracing::warn!(
+            bind = %bind_addr,
+            "metrics-export prometheus: scrape endpoint bound to a NON-loopback address with no auth — \
+             this exposes metrics on an inbound port; prefer a loopback bind or add auth/allowlist"
+        );
+    }
+    let listener = tokio::net::TcpListener::bind(&bind_addr)
+        .await
+        .map_err(|e| format!("prometheus scrape server could not bind {bind_addr}: {e}"))?;
+    tracing::info!(bind = %bind_addr, "metrics-export prometheus: scrape endpoint serving GET /metrics");
+
+    loop {
+        tokio::select! {
+            accepted = listener.accept() => {
+                let (mut stream, _peer) = match accepted {
+                    Ok(pair) => pair,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "metrics-export prometheus: accept failed — continuing");
+                        continue;
+                    }
+                };
+                // The exposition snapshot is cheap to read (clones a shared Arc<str>); take it per-connection.
+                let body = handle.encode();
+                // Handle one request then close (scrape clients open a fresh connection per scrape). Best-effort
+                // throughout — any read/write error just drops this connection.
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 1024];
+                    let n = match stream.read(&mut buf).await {
+                        Ok(0) => return, // client closed
+                        Ok(n) => n,
+                        Err(_) => return,
+                    };
+                    let req = String::from_utf8_lossy(&buf[..n]);
+                    let request_line = req.lines().next().unwrap_or("");
+                    let mut parts = request_line.split_whitespace();
+                    let method = parts.next().unwrap_or("");
+                    let path = parts.next().unwrap_or("");
+                    let response = if method != "GET" {
+                        "HTTP/1.1 405 Method Not Allowed\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                            .to_string()
+                    } else if path == "/metrics" {
+                        format!(
+                            "HTTP/1.1 200 OK\r\ncontent-type: text/plain; version=0.0.4\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                            body.len(),
+                            body
+                        )
+                    } else {
+                        "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_string()
+                    };
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    let _ = stream.flush().await;
+                });
+            }
+            _ = &mut shutdown => {
+                tracing::debug!(bind = %bind_addr, "metrics-export prometheus: scrape server shut down");
+                return Ok(());
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -756,6 +887,112 @@ mod tests {
                 joined.is_ok(),
                 "forwarder terminated after the channel closed"
             );
+        }
+    }
+
+    #[cfg(feature = "metrics-export-prometheus")]
+    mod prometheus {
+        use super::*;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        #[test]
+        fn is_loopback_bind_classifies_addresses() {
+            assert!(is_loopback_bind("127.0.0.1:9090"));
+            assert!(is_loopback_bind("[::1]:9090"));
+            assert!(!is_loopback_bind("0.0.0.0:9090"));
+            // A bad address is not loopback (the caller warns/handles separately).
+            assert!(!is_loopback_bind("not-an-addr"));
+        }
+
+        #[test]
+        fn push_prometheus_registers_a_backend_and_a_report_renders_exposition() {
+            // Registering a prometheus target adds a backend; after a report the handle's exposition text is
+            // published + non-empty (the backend re-rendered the cumulative series).
+            let target = PrometheusTarget {
+                bind: "127.0.0.1:0".into(),
+                prefix: Some("cdz".into()),
+            };
+            let (mut reporter, _) = MetricsReporter::from_statsd_targets(&[]);
+            let handle = reporter.push_prometheus(&target);
+            assert_eq!(reporter.backend_count(), 1);
+
+            let registry = Registry::new();
+            HostMetrics::new(&registry).record_turn(true);
+            reporter.report(&registry);
+
+            let text = handle.render();
+            assert!(
+                !text.is_empty(),
+                "the report published non-empty exposition text"
+            );
+        }
+
+        #[tokio::test]
+        async fn scrape_server_serves_get_metrics_and_404s_other_paths() {
+            // End-to-end: bind a loopback scrape server, report once so there's exposition text, then connect
+            // as a scrape client — GET /metrics returns 200 + a body, and another path returns 404. Proves the
+            // hand-rolled responder + the handle read path.
+            let target = PrometheusTarget {
+                bind: "127.0.0.1:0".into(), // ephemeral; we read the actual bound port below
+                prefix: None,
+            };
+            let (mut reporter, _) = MetricsReporter::from_statsd_targets(&[]);
+            let handle = reporter.push_prometheus(&target);
+            let registry = Registry::new();
+            HostMetrics::new(&registry).record_turn(true);
+            reporter.report(&registry);
+
+            // Bind our own listener to learn a free loopback port, then hand its addr to the server after
+            // dropping it (small race window, acceptable in a test).
+            let probe = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+            let addr = probe.local_addr().unwrap().to_string();
+            drop(probe);
+
+            let (sd_tx, sd_rx) = tokio::sync::oneshot::channel();
+            let server = tokio::spawn(run_prometheus_scrape_server(addr.clone(), handle, sd_rx));
+            // Give the server a moment to bind.
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            // GET /metrics → 200 + body.
+            let got = scrape(&addr, "GET /metrics HTTP/1.1\r\nhost: x\r\n\r\n").await;
+            assert!(got.starts_with("HTTP/1.1 200"), "metrics 200: {got:.40}");
+            assert!(
+                got.contains("text/plain"),
+                "content-type present: {got:.80}"
+            );
+
+            // GET /nope → 404.
+            let got404 = scrape(&addr, "GET /nope HTTP/1.1\r\nhost: x\r\n\r\n").await;
+            assert!(
+                got404.starts_with("HTTP/1.1 404"),
+                "other path 404: {got404:.40}"
+            );
+
+            let _ = sd_tx.send(());
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server).await;
+        }
+
+        // Minimal scrape client: connect, send `request`, read the whole response to a string.
+        async fn scrape(addr: &str, request: &str) -> String {
+            let mut s = tokio::net::TcpStream::connect(addr).await.expect("connect");
+            s.write_all(request.as_bytes()).await.expect("write");
+            s.flush().await.unwrap();
+            let mut buf = Vec::new();
+            let _ = s.read_to_end(&mut buf).await;
+            String::from_utf8_lossy(&buf).into_owned()
+        }
+
+        #[tokio::test]
+        async fn scrape_server_bad_bind_is_a_clean_err() {
+            // An unbindable address is a clean Err (not a panic) — surfaces as a boot diagnostic.
+            let (_tx, rx) = tokio::sync::oneshot::channel();
+            let (mut reporter, _) = MetricsReporter::from_statsd_targets(&[]);
+            let handle = reporter.push_prometheus(&PrometheusTarget {
+                bind: "127.0.0.1:0".into(),
+                prefix: None,
+            });
+            let err = run_prometheus_scrape_server("not-a-bind-addr".into(), handle, rx).await;
+            assert!(err.is_err(), "a bad bind address is a clean Err");
         }
     }
 }

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -85,6 +85,8 @@ pub use config::{
     AdminConfig, BlobConfig, DaemonConfig, LogConfig, MetricsTarget, ObservabilityConfig,
     RetryConfig, TracingConfig, TracingFormat, TracingOutput,
 };
+#[cfg(feature = "metrics-export-prometheus")]
+pub use export::{is_loopback_bind, run_prometheus_scrape_server, PrometheusTarget};
 #[cfg(feature = "metrics-export")]
 pub use export::{run_export_loop, MetricsReporter, StatsdTarget, UdpStatsdSink};
 #[cfg(feature = "metrics-export-otlp")]


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref e9120c4c8, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.