### PR TITLE
guide(platform): reducer-chapter review fixes — Kv arrow footnote, correlation-token wording, gate strip/rewrap symmetry

### DIFF
--- a/guide/scripts/check-examples.mjs
+++ b/guide/scripts/check-examples.mjs
@@ -625,13 +625,17 @@ async function checkExample(ex) {
     const mlFail = await checkProgram(mlProgram, "ml", ex, "ML");
     if (mlFail) return mlFail;
     try {
-      // Render the WRAPPED ML program to s-expr and compile that — the toggle pass (mirrors line ~89's
-      // renderToMl direction). render_syntax takes a whole module, so feed it the wrapped ML.
-      const sexprProgram = render_syntax(mlProgram, "ml", "sexpr");
+      // Toggle pass — the EXACT mirror of renderToMl (line ~89) in the ml→s-expr direction, so both toggle
+      // directions exercise identical wrap → render → STRIP → rewrap. The reader's real toggle re-renders
+      // the wrapped ML to s-expr, STRIPS back to the bare displayed snippet, then REWRAPS to compile/run;
+      // compiling the un-stripped render output would gate a shape the reader never runs and let a
+      // strip/wrap bug for the s-expr surface slip past (the scaffolding-bug class this arc keeps hitting).
+      const sexprSnippet = stripModule(render_syntax(mlProgram, "ml", "sexpr"), "sexpr");
+      const sexprProgram = wrapModule(sexprSnippet, "sexpr");
       const sexprFail = await checkProgram(sexprProgram, "sexpr", ex, "s-expr toggle");
       if (sexprFail) return sexprFail;
     } catch (e) {
-      return `${ex.file} [${ex.kind}] (s-expr toggle): render threw — ${String(e.message || e).slice(0, 80)}`;
+      return `${ex.file} [${ex.kind}] (s-expr toggle): render/strip/wrap threw — ${String(e.message || e).slice(0, 80)}`;
     }
     return null;
   }

--- a/guide/src/content/chapters/WritingAReducer.tsx
+++ b/guide/src/content/chapters/WritingAReducer.tsx
@@ -131,8 +131,12 @@ def main() = List.len(apply({ family = "message", version = 1 }, None(), None())
       <P>
         A returned effect-request is <em>declarative</em>: the reducer doesn't perform the HTTP call, it
         hands the kernel a description of the work and returns. The kernel schedules it, and when it
-        completes, feeds the result back as a new event, a <em>resume</em>, carrying the <C>correlation</C>{" "}
-        tag. That's how a pure fold reaches the outside world without ever blocking inside the reducer.
+        completes, calls <C>apply</C> again with the <em>resumes</em> field set to that same{" "}
+        <C>correlation</C> tag, echoed back verbatim. The tag is the reducer's <em>own</em> token, not a
+        kernel-assigned id, so a later <C>apply</C> whose <C>resumes</C> matches the token you chose is the
+        completion of the request you made. That guest-chosen token is the only resume mechanism; a{" "}
+        <C>resumes</C> of <C>None</C> means "not a resume", an inbound message, not the answer to an earlier
+        request. That's how a pure fold reaches the outside world without ever blocking inside the reducer.
       </P>
 
       <H2>Deciding by event</H2>
@@ -189,6 +193,13 @@ def main() = List.len(apply({ family = "result", version = 1 }, None(), Some(Str
         <br />
         bind(Kv, "cadenza:agent-kernel/kv")
       </Note>
+      <P>
+        One syntax note if you write this out: a multi-argument operation like <C>put</C> uses the
+        arrow-form <C>{`\`->\`(Bytes, Bytes, Unit)`}</C> in real source, not <C>{`(Bytes, Bytes) -> Unit`}</C>.
+        The tuple-looking form above reads clearly but means <em>one</em> tuple argument; the arrow-form is
+        what makes <C>put</C> a genuine two-argument op (the fixture <C>reducer_b3.cdz</C> writes it that
+        way).
+      </P>
       <P>
         With that in place, the reducer <em>performs</em> the operations inside a <C>host</C> block, the
         scope where the effect may be used. On a message it reads the old counter, writes the new one, and


### PR DESCRIPTION
Candidate PR for v-guide's merge-request (ref 60c54855c779661a4971f246865c79a6318fcc4b, lane docs). Auto-merge armed; pr-sync's schedule-pass reaps on green.