### PR TITLE
rcdzc(harness-bootstrap): coverage — pin the effect-request target + correlation fields (B2/B3)

### DIFF
--- a/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b2.cdz
+++ b/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b2.cdz
@@ -42,6 +42,9 @@ def b2_emits_exactly_one_effect() =
   then unit
   else trap("B2 must emit exactly one effect-request")
 
+// Pin ALL of the one effect-request's fields — not just the kind. The host marshals target via str-get,
+// correlation via sum-payload, payload via sum-disc; a silent change to any (a different URL, a dropped
+// token) would break the round-trip with no other test catching it. Each field pinned:
 @test
 def b2_the_effect_is_http() =
   match List.at(apply({ family = "message", version = 1 }, None(), None()), 0) with
@@ -49,6 +52,24 @@ def b2_the_effect_is_http() =
       (match r.kind with
         | EffectKind.Http() => unit
         | _ => trap("B2's effect kind must be Http"))
+    | None() => trap("B2 must have an effect at index 0")
+
+@test
+def b2_effect_target_is_pinned() =
+  match List.at(apply({ family = "message", version = 1 }, None(), None()), 0) with
+    | Some(EffectRequest.Mk(r)) => (if r.target == "https://ok.host/x" then unit else trap("B2's effect target must be https://ok.host/x"))
+    | None() => trap("B2 must have an effect at index 0")
+
+@test
+def b2_effect_correlation_is_pinned() =
+  match List.at(apply({ family = "message", version = 1 }, None(), None()), 0) with
+    | Some(EffectRequest.Mk(r)) => (if r.correlation == Some(String.to-bytes("step-1")) then unit else trap("B2's effect correlation token must be Some(\"step-1\")"))
+    | None() => trap("B2 must have an effect at index 0")
+
+@test
+def b2_effect_payload_is_none() =
+  match List.at(apply({ family = "message", version = 1 }, None(), None()), 0) with
+    | Some(EffectRequest.Mk(r)) => (match r.payload with | None() => unit | Some(_) => trap("B2's effect payload must be None"))
     | None() => trap("B2 must have an effect at index 0")
 
 export { apply }

--- a/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b3.cdz
+++ b/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b3.cdz
@@ -105,4 +105,20 @@ def b3_counter_wraps_at_max() =
   if Bytes.at(bump-count(Some(Bytes.of([UInt8.wrap(255)]))), 0) == Some(0) then unit
   else trap("bump-count of byte 255 must wrap to byte 0")
 
+// Pin the Http effect-request's fields (the message branch performs kv so isn't callable standalone,
+// but http-effect is a pure def — pin the kind/target/correlation the host marshals via sum-disc/str-get/
+// sum-payload, so a silent target/token change is caught).
+@test
+def b3_http_effect_kind_is_http() =
+  match http-effect() with
+    | EffectRequest.Mk(r) => (match r.kind with | EffectKind.Http() => unit | _ => trap("B3's http-effect kind must be Http"))
+
+@test
+def b3_http_effect_target_and_correlation_pinned() =
+  match http-effect() with
+    | EffectRequest.Mk(r) =>
+      (if r.target == "https://ok.host/x" then
+        (if r.correlation == Some(String.to-bytes("step-1")) then unit else trap("B3 http-effect correlation must be Some(\"step-1\")"))
+       else trap("B3 http-effect target must be https://ok.host/x"))
+
 export { apply }


### PR DESCRIPTION
Candidate PR for v-harness-bootstrap's merge-request (ref 5aced98bc24a7522d47a4359aab18b7050a2b839, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.