### PR TITLE
cdz-agent-host: prometheus scrape hardening — read-timeout (idle-client leak) + loopback check is ALL-addrs not first (#2155/#2160 review)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/config.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/config.rs
@@ -394,16 +394,29 @@ impl std::fmt::Display for ConfigError {
 }
 impl std::error::Error for ConfigError {}
 
-/// `true` if `addr` (`host:port`) resolves to a loopback address. FAIL-CLOSED: an unresolvable / unparseable
-/// address returns `false` (treated as non-loopback), so a bind we can't classify still requires the explicit
-/// `allow_non_loopback` opt-in rather than slipping through. Kept in `config` (always-on) so validation can
-/// enforce the prometheus posture without the `metrics-export-prometheus` feature (which has its own runtime
-/// copy for the boot warning).
+/// `true` only if `addr` (`host:port`) resolves to at least one address and EVERY resolved address is
+/// loopback. FAIL-CLOSED: an unresolvable/unparseable/empty address returns `false` (treated as non-loopback),
+/// and — critically — a name resolving to a MIX of loopback + non-loopback addresses is NOT loopback. Checking
+/// only the FIRST resolved address would let a mixed name (loopback first) pass the gate while
+/// `TcpListener::bind` could still bind the non-loopback address (a bypass of the `allow_non_loopback` opt-in;
+/// same multi-address class as the #2112 IPv6-first bind — #2160 review). Kept in `config` (always-on) so
+/// validation enforces the prometheus posture without the `metrics-export-prometheus` feature (which has its
+/// own runtime copy for the boot warning).
 fn bind_is_loopback(addr: &str) -> bool {
     use std::net::ToSocketAddrs;
-    addr.to_socket_addrs()
-        .map(|mut it| it.next().map(|a| a.ip().is_loopback()).unwrap_or(false))
-        .unwrap_or(false)
+    match addr.to_socket_addrs() {
+        Ok(mut addrs) => {
+            let mut any = false;
+            for a in &mut addrs {
+                any = true;
+                if !a.ip().is_loopback() {
+                    return false; // a mixed name with any non-loopback addr is NOT loopback
+                }
+            }
+            any // all resolved were loopback AND at least one existed
+        }
+        Err(_) => false, // unresolvable → fail-closed (needs the explicit opt-in)
+    }
 }
 
 impl DaemonConfig {
@@ -843,6 +856,32 @@ mod tests {
         )
         .expect("non-loopback bind with the opt-in validates");
         assert_eq!(cfg.observability.targets[0].kind(), "prometheus");
+    }
+
+    #[test]
+    fn bind_is_loopback_requires_all_resolved_addrs_loopback() {
+        // Literal loopback addresses classify loopback.
+        assert!(bind_is_loopback("127.0.0.1:9090"));
+        assert!(bind_is_loopback("[::1]:9090"));
+        // A non-loopback literal is not loopback.
+        assert!(!bind_is_loopback("0.0.0.0:9090"));
+        assert!(!bind_is_loopback("10.0.0.5:9090"));
+        // Fail-closed: unparseable/unresolvable → not loopback (needs the explicit opt-in).
+        assert!(!bind_is_loopback("not-a-bind-addr"));
+        assert!(!bind_is_loopback(""));
+        // The #2160-review invariant: the check is ALL-addrs, not first-addr. `localhost` typically resolves
+        // to both ::1 and 127.0.0.1 (all loopback) → loopback; but if it resolves to a non-loopback addr too,
+        // it must be classified non-loopback. We can only assert the all-loopback direction deterministically
+        // here (localhost → all loopback on a normal host); skip if localhost doesn't resolve.
+        use std::net::ToSocketAddrs;
+        if let Ok(addrs) = "localhost:9090".to_socket_addrs() {
+            let all_lo = {
+                let v: Vec<_> = addrs.collect();
+                !v.is_empty() && v.iter().all(|a| a.ip().is_loopback())
+            };
+            // Our classifier must agree with "all resolved are loopback".
+            assert_eq!(bind_is_loopback("localhost:9090"), all_lo);
+        }
     }
 
     #[test]

--- a/implementation/seed/crates/cdz-agent-host/src/export.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/export.rs
@@ -426,14 +426,27 @@ impl MetricsReporter {
     }
 }
 
-/// `true` if `addr` is a loopback socket address (127.0.0.0/8 or ::1). Used to enforce the concierge posture:
-/// a no-auth scrape endpoint is only acceptable loopback-bound; a non-loopback bind is warned.
+/// `true` only if `addr` resolves to at least one address and EVERY resolved address is loopback (127.0.0.0/8
+/// or ::1). Used for the concierge posture WARN: a no-auth scrape endpoint is only appropriate loopback-bound.
+/// Checks ALL resolved addresses (not just the first) so a mixed loopback+non-loopback name is correctly
+/// treated as non-loopback — matching the config-side validation gate (#2160 review); an
+/// unresolvable/empty addr is non-loopback (fail-closed → the warning fires).
 #[cfg(feature = "metrics-export-prometheus")]
 pub fn is_loopback_bind(addr: &str) -> bool {
     use std::net::ToSocketAddrs;
-    addr.to_socket_addrs()
-        .map(|mut it| it.next().map(|a| a.ip().is_loopback()).unwrap_or(false))
-        .unwrap_or(false)
+    match addr.to_socket_addrs() {
+        Ok(mut addrs) => {
+            let mut any = false;
+            for a in &mut addrs {
+                any = true;
+                if !a.ip().is_loopback() {
+                    return false;
+                }
+            }
+            any
+        }
+        Err(_) => false,
+    }
 }
 
 /// Serve the prometheus scrape endpoint: bind `bind_addr` and answer each connection's `GET /metrics` with the
@@ -481,10 +494,22 @@ pub async fn run_prometheus_scrape_server(
                 // throughout — any read/write error just drops this connection.
                 tokio::spawn(async move {
                     let mut buf = [0u8; 1024];
-                    let n = match stream.read(&mut buf).await {
-                        Ok(0) => return, // client closed
-                        Ok(n) => n,
-                        Err(_) => return,
+                    // Bound the request read with a timeout: a scrape client sends its request line immediately,
+                    // so a connection that opens and then sends NOTHING must not leave this read().await pending
+                    // forever — that would leak the task + FD per idle/half-open connection (a slow-loris-style
+                    // resource exhaustion, reachable by any client on a non-loopback bind or a buggy local
+                    // scraper on loopback). On timeout (or read error / clean close) we just drop the connection
+                    // (#2155 review; mirrors the OTLP forwarder's outbound connect/request timeouts).
+                    let read = tokio::time::timeout(
+                        std::time::Duration::from_secs(5),
+                        stream.read(&mut buf),
+                    )
+                    .await;
+                    let n = match read {
+                        Ok(Ok(0)) => return,     // client closed
+                        Ok(Ok(n)) => n,          // got the request bytes
+                        Ok(Err(_)) => return,    // read error
+                        Err(_elapsed) => return, // idle client — drop rather than leak the task/FD
                     };
                     let req = String::from_utf8_lossy(&buf[..n]);
                     let request_line = req.lines().next().unwrap_or("");
@@ -994,6 +1019,51 @@ mod tests {
             });
             let err = run_prometheus_scrape_server("not-a-bind-addr".into(), handle, rx).await;
             assert!(err.is_err(), "a bad bind address is a clean Err");
+        }
+
+        #[tokio::test]
+        async fn scrape_server_idle_client_does_not_block_the_accept_loop() {
+            // #2155 review (slow-loris): a client that opens a connection and SENDS NOTHING must not wedge the
+            // server. The per-connection handler has a read timeout, and the accept loop is decoupled by the
+            // per-connection spawn — so a concurrent normal scrape still succeeds IMMEDIATELY while the idle
+            // connection sits there. We assert responsiveness (the property that matters) without waiting out
+            // the full read timeout: the normal scrape returns 200 well before the idle handler's timeout.
+            let (mut reporter, _) = MetricsReporter::from_statsd_targets(&[]);
+            let handle = reporter.push_prometheus(&PrometheusTarget {
+                bind: "127.0.0.1:0".into(),
+                prefix: None,
+            });
+            let registry = Registry::new();
+            HostMetrics::new(&registry).record_turn(true);
+            reporter.report(&registry);
+
+            let probe = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+            let addr = probe.local_addr().unwrap().to_string();
+            drop(probe);
+
+            let (sd_tx, sd_rx) = tokio::sync::oneshot::channel();
+            let server = tokio::spawn(run_prometheus_scrape_server(addr.clone(), handle, sd_rx));
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            // Open an IDLE connection that never sends a request line, and hold it open.
+            let _idle = tokio::net::TcpStream::connect(&addr)
+                .await
+                .expect("idle connect");
+
+            // A normal scrape must still succeed promptly (the idle connection didn't block the accept loop).
+            let got = tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                scrape(&addr, "GET /metrics HTTP/1.1\r\nhost: x\r\n\r\n"),
+            )
+            .await
+            .expect("a normal scrape completes while an idle client is connected");
+            assert!(
+                got.starts_with("HTTP/1.1 200"),
+                "scrape still served: {got:.40}"
+            );
+
+            let _ = sd_tx.send(());
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server).await;
         }
     }
 }


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref aa5884e7f, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.