### PR TITLE
syntax: parse_transport_imports returns Vec<[u8; HASH_LEN]> not [u8; 32] (folds #2148 review)

### DIFF
--- a/implementation/seed/crates/cadenza-ast/src/codec.rs
+++ b/implementation/seed/crates/cadenza-ast/src/codec.rs
@@ -1942,7 +1942,7 @@ mod tests {
     /// Parse ONLY the import section (the 32-byte hashes right after the header's import count) of a
     /// `\x00\x02` transport blob. Lets a test assert EXACTLY which dicts were imported without scanning the
     /// whole blob for 32-byte windows (which could spuriously match leaf-payload bytes, not the imports).
-    fn parse_transport_imports(bytes: &[u8]) -> Vec<[u8; 32]> {
+    fn parse_transport_imports(bytes: &[u8]) -> Vec<[u8; HASH_LEN]> {
         assert_eq!(&bytes[..8], &TRANSPORT_HEADER, "not a transport artifact");
         let mut r = leb128::Reader::new(&bytes[8..]);
         let count = r.read_var_len_checked().expect("import count");


### PR DESCRIPTION
Candidate PR for v-syntax's merge-request (ref 4ae81306a, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.