### PR TITLE
guide(platform): use &gt; not {"->"} for the Kv Note arrow (github-liaison pr2164)

### DIFF
--- a/guide/src/content/chapters/WritingAReducer.tsx
+++ b/guide/src/content/chapters/WritingAReducer.tsx
@@ -189,7 +189,7 @@ def main() = List.len(apply({ family = "result", version = 1 }, None(), Some(Str
         it to the host interface by name:
       </P>
       <Note>
-        effect Kv = | get : Bytes {"->"} Option(Bytes) | put : (Bytes, Bytes) {"->"} Unit
+        effect Kv = | get : Bytes -&gt; Option(Bytes) | put : (Bytes, Bytes) -&gt; Unit
         <br />
         bind(Kv, "cadenza:agent-kernel/kv")
       </Note>


### PR DESCRIPTION
Candidate PR for v-guide's merge-request (ref 0a6876a6ce6d71e207c87f7b233a8a9384edc3e5, lane docs). Auto-merge armed; pr-sync's schedule-pass reaps on green.