### PR TITLE
docs+fix(cdz-kernel): fold #2166 doc-precision + harden read-marshalling against guest-length alloc-DoS

### DIFF
--- a/implementation/seed/crates/cdz-kernel/src/heap_unmarshal.rs
+++ b/implementation/seed/crates/cdz-kernel/src/heap_unmarshal.rs
@@ -39,6 +39,15 @@ use crate::wasm_host::{ComponentError, EffectKind, EffectRequest, HeapHandle};
 const OPTION_SOME: i64 = 0;
 const OPTION_NONE: i64 = 1;
 
+/// Cap on the effect-list length we PRE-RESERVE for (reviewer, #2166 read-side DoS). `vec-len` returns a
+/// raw unbounded `u32` reported BY the (untrusted) reducer's returned handle — a bogus large value (up to
+/// `u32::MAX`) fed straight into `Vec::with_capacity` reserves hundreds of GB UP FRONT and aborts the host
+/// via the alloc-error handler, BEFORE the per-element loop can fail-loud on the missing elements. Reserving
+/// at most this many keeps the fast path for realistic effect counts while a bogus length just grows the
+/// Vec amortively and then Traps CHEAPLY on the first missing `vec-get`. A real fold emits a handful of
+/// effects; 4096 is far above any legitimate turn. (Read-side analog of the #2151 write-side length guard.)
+const MAX_PREALLOC_EFFECTS: u32 = 4096;
+
 /// The effect-request record's SORTED-field-name indices: `{correlation, kind, payload, target}` sorted
 /// alphabetically. Naming them keeps the field↔index mapping in one auditable place (a silent off-by-one
 /// here would mis-decode every effect).
@@ -123,7 +132,10 @@ pub fn read_effect_requests<T>(
     list: u32,
 ) -> Result<Vec<EffectRequest>, ComponentError> {
     let len = heap.vec_len(list)?;
-    let mut out = Vec::with_capacity(len as usize);
+    // Reserve for at most MAX_PREALLOC_EFFECTS — `len` is an unbounded guest-reported u32, so a bogus large
+    // value must NOT drive an eager multi-GB reservation (alloc-abort DoS, #2166 read-side). A truthful
+    // large len just grows the Vec amortively; a bogus one Traps on the first missing `vec-get` below.
+    let mut out = Vec::with_capacity(len.min(MAX_PREALLOC_EFFECTS) as usize);
     for i in 0..len {
         let record = heap.vec_get(list, i)?;
         out.push(read_effect_request(heap, record)?);
@@ -198,7 +210,12 @@ mod tests {
                    ;; @220 bytes "id7": [len=3]"id7"
                    (data (i32.const 220) "\03\00\00\00id7")
                    ;; @240 payload = None: [disc=1][payload ignored=0]
-                   (data (i32.const 240) "\01\00\00\00\00\00\00\00"))
+                   (data (i32.const 240) "\01\00\00\00\00\00\00\00")
+                   ;; @300 a BOGUS vec: header reports len = 0xFFFFFFFF but there are NO element slots. The
+                   ;; DoS-guard test hands this handle to read_effect_requests: with the MAX_PREALLOC cap the
+                   ;; host does NOT eager-reserve ~4GB*sizeof — it reserves the cap, then vec-get(i) walks
+                   ;; past the single-page memory and TRAPS (clean Err), never an alloc-abort.
+                   (data (i32.const 300) "\ff\ff\ff\ff"))
                  (core instance $i (instantiate $m))
                  (func $box-int (param "v" s64) (result u32) (canon lift (core func $i "box-int")))
                  (func $arr-alloc (param "len" u32) (result u32) (canon lift (core func $i "arr-alloc")))
@@ -289,6 +306,22 @@ mod tests {
         match disc_to_effect_kind(6) {
             Err(ComponentError::Trap(msg)) => assert!(msg.contains("out of range")),
             other => panic!("disc 6 must be a hard Trap, got {other:?}"),
+        }
+    }
+
+    // DoS guard (reviewer, #2166 read-side): a reducer-returned list handle whose vec-len reports a bogus
+    // huge length (0xFFFFFFFF) with no real element slots must NOT abort the host via an eager multi-GB
+    // Vec::with_capacity — the cap bounds the reservation, then vec-get walks past memory and Traps cleanly.
+    // The test PASSING (returns, doesn't abort/OOM the process) is itself the proof the cap works; the Err
+    // confirms it fails loud rather than hanging.
+    #[test]
+    fn a_bogus_huge_vec_len_traps_cleanly_not_an_alloc_abort() {
+        let mut heap = bind_read_stub();
+        // The @300 handle reports len=0xFFFFFFFF with no elements — pre-cap this would try to reserve
+        // ~4.29e9 * sizeof(EffectRequest) and abort at with_capacity; with the cap it Traps in the loop.
+        match read_effect_requests(&mut heap, 300) {
+            Err(_) => {} // clean fail-loud (a vec-get memory Trap), NOT a process abort
+            Ok(v) => panic!("a bogus u32::MAX vec-len must not read as a real {}-element list", v.len()),
         }
     }
 }

--- a/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
+++ b/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
@@ -246,6 +246,15 @@ pub struct ComponentReducer {
 /// [`ComponentReducer::with_fuel_budget`]; the real per-session budget lands with gas (§22a).
 pub const DEFAULT_FOLD_FUEL: u64 = 1_000_000_000;
 
+/// Cap on the byte-buffer length [`HeapHandle::read_bytes`] will PRE-RESERVE for (reviewer, #2166 read-side
+/// DoS). `bytes-len` returns a raw unbounded `u32` reported by the untrusted guest value-heap; feeding it
+/// straight into `Vec::with_capacity` lets a bogus large length (up to `u32::MAX` ≈ 4 GiB) reserve up front
+/// and abort the host via the alloc-error handler before the read loop can fail-loud. 1 MiB is generous for
+/// a real inline payload/token (larger bodies are content-addressed blobs, not inline value-heap bytes)
+/// while bounding the eager reservation; a truthful larger buffer still reads correctly (the Vec just grows
+/// amortively past the cap), and a bogus length Traps cheaply on the first missing `bytes-get`.
+const MAX_PREALLOC_BYTES: u32 = 1 << 20;
+
 /// Errors constructing or running a component reducer. Kept small; grows as the fold path lands.
 #[derive(Debug)]
 pub enum ComponentError {
@@ -828,9 +837,15 @@ impl<T: 'static> HeapHandle<T> {
 
     /// Read a value-heap `Bytes` handle back to a Rust `Vec<u8>` — `bytes-len` then a `bytes-get` per byte.
     /// The read-dual of [`HeapHandle::bytes_from`]; a byte over 255 is a malformed value-heap byte (Trap).
+    ///
+    /// The pre-reservation is CAPPED at [`MAX_PREALLOC_BYTES`]: `bytes-len` returns a raw unbounded `u32`
+    /// reported by the untrusted guest value-heap, so a bogus large length must NOT drive an eager multi-GB
+    /// `Vec::with_capacity` (which aborts the host via the alloc-error handler BEFORE the loop can fail-loud
+    /// on the missing bytes — reviewer, #2166 read-side DoS). A truthful large buffer just grows the Vec
+    /// amortively; a bogus length Traps CHEAPLY on the first missing `bytes-get`.
     pub fn read_bytes(&mut self, buf: u32) -> Result<Vec<u8>, ComponentError> {
         let len = self.bytes_len(buf)?;
-        let mut out = Vec::with_capacity(len as usize);
+        let mut out = Vec::with_capacity(len.min(MAX_PREALLOC_BYTES) as usize);
         for i in 0..len {
             let b = self.bytes_get(buf, i)?;
             let byte = u8::try_from(b).map_err(|_| {
@@ -2062,6 +2077,10 @@ mod tests {
                    (func (export "get-int") (param i32) (result i64) (i64.const 42))
                    ;; str-get returns "target" (6 bytes) — write to a fixed area, return (ptr,len).
                    (data (i32.const 8) "target")
+                   ;; @100 a BOGUS bytes handle: header reports len=0xFFFFFFFF, no real bytes. read_bytes(100)
+                   ;; must NOT eager-reserve ~4GB (alloc-abort) — the cap bounds it, then bytes-get walks past
+                   ;; the single page and Traps cleanly (#2166 read-side DoS guard).
+                   (data (i32.const 100) "\ff\ff\ff\ff")
                    (func (export "str-get") (param i32) (result i32)
                      (i32.store (i32.const 4096) (i32.const 8))
                      (i32.store (i32.const 4100) (i32.const 6))
@@ -2234,6 +2253,32 @@ mod tests {
         let other = heap.bytes_from(&[1, 2, 3]).expect("bytes_from other");
         assert_eq!(heap.read_bytes(other).expect("read other"), [1, 2, 3]);
         assert_eq!(heap.read_bytes(h).expect("re-read first"), payload); // first still intact
+    }
+
+    // DoS guard (reviewer, #2166 read-side): a bytes handle whose bytes-len reports a bogus huge length
+    // (the forged @100 handle = 0xFFFFFFFF, no real bytes) must NOT abort the host via an eager ~4GB
+    // Vec::with_capacity — the MAX_PREALLOC_BYTES cap bounds the reservation, then bytes-get walks past the
+    // single-page memory and Traps cleanly. The test returning (not OOM-aborting) is the proof.
+    #[test]
+    fn read_bytes_with_bogus_huge_len_traps_cleanly_not_an_alloc_abort() {
+        let bytes = heap_stub_component();
+        let engine = wasmtime::Engine::default();
+        let mut store = wasmtime::Store::new(&engine, ());
+        let linker = wasmtime::component::Linker::<()>::new(&engine);
+        let component =
+            wasmtime::component::Component::new(&engine, &bytes).expect("valid heap stub");
+        let instance = linker
+            .instantiate(&mut store, &component)
+            .expect("heap stub instantiates");
+        let mut heap = match HeapHandle::bind(store, &instance) {
+            Ok(h) => h,
+            Err(e) => panic!("bind HeapHandle: {e:?}"),
+        };
+        // Handle @100 reports bytes-len = 0xFFFFFFFF with no real bytes.
+        match heap.read_bytes(100) {
+            Err(_) => {} // clean fail-loud (a bytes-get memory Trap), NOT a process abort
+            Ok(v) => panic!("a bogus u32::MAX bytes-len must not read as a real {}-byte buffer", v.len()),
+        }
     }
 
     // A runtime that doesn't export cadenza:runtime/heap → a clear Compose error naming it, not a trap.


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 6528a7eff, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.