### PR TITLE
fix(cdz-agent-host): sync Cargo.lock (add the tracing dep edge) — unblocks fleet-wide advisory-nix

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/Cargo.lock
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.lock
@@ -592,6 +592,7 @@ dependencies = [
  "bytes",
  "cadenza-ast",
  "num-bigint",
+ "tracing",
  "url",
  "wasmtime",
 ]


### PR DESCRIPTION
Candidate PR for v-nix's merge-request (ref 886ba0828, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.