### PR TITLE
corpus(12-metaprog): pin eval of a quasiquote with an active BYTES unquote

### DIFF
--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -4630,6 +4630,7 @@ pass	eval of a partially-exported type's WITHHELD constructor is rejected
 pass	eval of a quasiquote splicing a compile-time-known value
 pass	eval of a quasiquote splicing a string works through String ops
 pass	eval of a quasiquote with TWO unquotes splices a bound and a computed value in one form
+pass	eval of a quasiquote-built form with a byte-string unquote folds
 pass	eval of a quasiquote-built form with a float unquote folds
 pass	eval of a quote carrying a symbol literal is rejected CDZ0101 — the reify bail as a perf-bound tripwire
 pass	eval of a quoted List.at folds the indexing operation to its Option result

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -4644,6 +4644,7 @@ pass	eval of a partially-exported type's WITHHELD constructor is rejected
 pass	eval of a quasiquote splicing a compile-time-known value
 pass	eval of a quasiquote splicing a string works through String ops
 pass	eval of a quasiquote with TWO unquotes splices a bound and a computed value in one form
+pass	eval of a quasiquote-built form with a byte-string unquote folds
 pass	eval of a quasiquote-built form with a float unquote folds
 pass	eval of a quote carrying a symbol literal is rejected CDZ0101 — the reify bail as a perf-bound tripwire
 pass	eval of a quoted List.at folds the indexing operation to its Option result

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -4561,6 +4561,7 @@ pass	eval of a partially-exported type's WITHHELD constructor is rejected
 pass	eval of a quasiquote splicing a compile-time-known value
 pass	eval of a quasiquote splicing a string works through String ops
 pass	eval of a quasiquote with TWO unquotes splices a bound and a computed value in one form
+pass	eval of a quasiquote-built form with a byte-string unquote folds
 pass	eval of a quasiquote-built form with a float unquote folds
 pass	eval of a quote carrying a symbol literal is rejected CDZ0101 — the reify bail as a perf-bound tripwire
 pass	eval of a quoted List.at folds the indexing operation to its Option result

--- a/spec/semantics/12-metaprogramming.sexp
+++ b/spec/semantics/12-metaprogramming.sexp
@@ -231,6 +231,20 @@
             (export main)))
   (output (: 4.0 Float64)))
 
+(case "eval of a quasiquote-built form with a byte-string unquote folds"
+  (doc    "The BYTES companion of the eval-splice idiom, closing the leaf-lift family for the `Ast.Bytes`
+           variant this vertical realized (operator seq 113 — added AFTER the Int/Float/String/Name lift
+           cases were pinned). `(let ((b b\"hi\")) (eval `(Bytes.concat ,b b\"x\")))` lifts the live byte-string
+           `b` into the reconstructed `(Bytes.concat b b\"x\")` — the active unquote reifies its operand into an
+           `(Ast.Bytes …)` node, which `eval`'s source reconstruction unwraps back to `b` in the enclosing
+           scope, exactly as the integer/float/string lifts do. The result `b\"hix\"` has `Bytes.len` 3. A
+           lift path that had no `Ast.Bytes` arm would leave the eval un-desugared (a misleading 'unbound
+           name eval') or fail to reconstruct the byte operand.")
+  (input  (do
+            (def (main) (let ((b b"hi")) (Bytes.len (eval (quasiquote (Bytes.concat (unquote b) b"x"))))))
+            (export main)))
+  (output (: 3 Int64)))
+
 (case "eval of a quasiquote with TWO unquotes splices a bound and a computed value in one form"
   (doc    "The eval-splice pins above are SINGLE-unquote; this reconstructs a form with TWO active
            unquotes at different nesting depths — one LET-BOUND (a=5) and one COMPUTED ((+ 3 4)) —


### PR DESCRIPTION
Candidate PR for v-metaprogramming's merge-request (ref 4a540f85c, lane baseline). Auto-merge armed; pr-sync's schedule-pass reaps on green.