### PR TITLE
rcdzc(effects): FIX breaker sr5 HIGH silent-miscompile — recursive same-effect advance observed by a same-effect ABORT arm now DECLINES (was 0), not the seed value

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -2497,6 +2497,22 @@ pub fn reduce_handle(
     // OWN body, so this caller-side observation must be recorded up front. Purely additive: it only UPGRADES a
     // multi-value-threadable callee — a non-threadable one stays single-return.
     mark_caller_observed_outstate(db, body, &ctx);
+    // CALLER-OBSERVED OUT-STATE via a same-effect ABORT arm (breaker sr5). The task-#15 machinery above
+    // upgrades a recursive-effectful callee to MULTI-VALUE mode when a LATER spine perform observes its
+    // out-state — which threads correctly to a RESUMING observer (sr4 → 2). But when the observing perform's
+    // arm is ABORTIVE (a `(fin (u) s s)` with no `resume`), the abort COLLAPSE materializes the arm value
+    // (reading the state binder `s`) against the pre-recursion SEED slot rather than the callee's threaded
+    // out-state — so `(do (def _g (grow k)) (Acc.fin))` reads 0 instead of the advanced 2: a SILENT
+    // MISCOMPILE on both backends (breaker sr5, HIGH). Folding it correctly needs the abort collapse to read
+    // the multi-value out-state the recursion advanced (a later increment, same family as the resuming
+    // thread). Until then DECLINE cleanly (→ Todo) rather than emit the wrong value. NARROW: fires only when
+    // a recursive-effectful callee advancing THIS handler's state is followed on the body spine by an
+    // ABORTIVE same-handler perform that reads state — the resuming observer (sr4), the observer as the
+    // recursion BASE CASE (sr2), and a plain same-op observer (sr1) all thread/fold correctly and are NOT
+    // flagged.
+    if !ctx.abortive.is_empty() && body_recursive_advance_observed_by_abort(db, body, &ctx) {
+        return None;
+    }
     // SEED LET-LIFT for a NON-CONSTANT init carrying a live CAPTURE. The `thread` perform arm splices the
     // threaded state (which starts as `init`) at every `s` reference and `deep_fresh_copy`s each splice to
     // break value/next-state sharing (the resume(a,a) bug). That fresh copy re-pushes each leaf UNPINNED, so
@@ -6460,6 +6476,90 @@ fn collect_rec_eff_call_defs(db: &mut Db, node: StructId, ctx: &HandlerCtx, out:
         }
         Struct::Atom(_) => {}
     }
+}
+
+/// Whether `node` contains an ABORTIVE same-handler perform — a call to one of this handler's ops whose arm
+/// is in `ctx.abortive` (a `(fin (u) s s)` with no `resume`). Used to detect the breaker-sr5 shape where a
+/// same-effect ABORT arm observes a recursive callee's out-state (which the abort collapse currently reads
+/// from the pre-recursion SEED slot, not the threaded out-state → silent miscompile).
+fn contains_abortive_perform(db: &mut Db, node: StructId, ctx: &HandlerCtx) -> bool {
+    if let Resolved::Apply { head, .. } = resolved_of(db, node)
+        && let Some(id) = is_perform(db, head, ctx)
+        && ctx.abortive.contains(&id)
+    {
+        return true;
+    }
+    match db.ast.get(node).clone() {
+        Struct::List(children) => children
+            .iter()
+            .any(|&c| contains_abortive_perform(db, c, ctx)),
+        Struct::Atom(_) => false,
+    }
+}
+
+/// Whether the handle body has a strict spine on which a recursive-effectful callee (which advances THIS
+/// handler's state, the same shape `mark_caller_observed_outstate` upgrades to multi-value) is followed by an
+/// element containing an ABORTIVE same-handler perform that observes that out-state — breaker sr5. The
+/// multi-value out-state threads correctly to a RESUMING observer (sr4), but the ABORT collapse materializes
+/// its arm value against the pre-recursion seed slot, dropping the recursion-era advances → reads the seed
+/// (0) not the advanced state (2). Declined by `reduce_handle` until the abort collapse can read the threaded
+/// out-state. NARROW — the observing element must contain an abortive perform, so a resuming observer (sr4),
+/// a plain non-abort same-op observer (sr1), and the observer-as-recursion-base-case (sr2) do NOT match.
+fn body_recursive_advance_observed_by_abort(db: &mut Db, node: StructId, ctx: &HandlerCtx) -> bool {
+    fn scan_seq(db: &mut Db, seq: &[StructId], ctx: &HandlerCtx) -> bool {
+        let mut pending: Vec<usize> = Vec::new();
+        for &el in seq {
+            // A recursive-effectful callee is pending, and a LATER spine element aborts observing its
+            // out-state — the sr5 miscompile shape.
+            if !pending.is_empty() && contains_abortive_perform(db, el, ctx) {
+                return true;
+            }
+            collect_rec_eff_call_defs(db, el, ctx, &mut pending);
+        }
+        false
+    }
+    if let Resolved::Apply { args, .. } = resolved_of(db, node)
+        && scan_seq(db, &args, ctx)
+    {
+        return true;
+    }
+    if let Some(items) = db.ast.as_form(node, "do").map(|t| t.to_vec())
+        && scan_seq(db, &items, ctx)
+    {
+        return true;
+    }
+    if let Some(form) = db.ast.as_form(node, "let").map(|t| t.to_vec())
+        && form.len() == 2
+        && let Struct::List(pairs) = db.ast.get(form[0]).clone()
+    {
+        let mut seq: Vec<StructId> = pairs
+            .iter()
+            .filter_map(|&pair| match db.ast.get(pair).clone() {
+                Struct::List(kv) if kv.len() == 2 => Some(kv[1]),
+                _ => None,
+            })
+            .collect();
+        seq.push(form[1]);
+        if scan_seq(db, &seq, ctx) {
+            return true;
+        }
+    }
+    if let Resolved::Match { scrutinee, arms } = resolved_of(db, node) {
+        for &(_, arm_body) in &arms {
+            if scan_seq(db, &[scrutinee, arm_body], ctx) {
+                return true;
+            }
+        }
+    }
+    // Recurse structurally so a spine nested inside a branch/let/operand is scanned too.
+    if let Struct::List(children) = db.ast.get(node).clone() {
+        for c in children {
+            if body_recursive_advance_observed_by_abort(db, c, ctx) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Scan the HANDLE BODY for a recursive-effectful call whose FINAL out-state is OBSERVED by a LATER item on

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -68149,6 +68149,99 @@ mod stage1 {
     }
 
     #[test]
+    fn a_recursive_advance_observed_by_a_same_effect_abort_arm_declines_not_miscompiles() {
+        use crate::testkit::parse;
+        // BREAKER sr5 (HIGH silent-miscompile, restore-safe-decline). A recursive loop of same-effect
+        // `(Acc.put)` performs advances the handler state; a LATER same-effect `(Acc.fin)` whose arm is
+        // ABORTIVE (`(fin (u) s s)` — no `resume`) reads that state. The caller-observed-out-state machinery
+        // (`mark_caller_observed_outstate`) threads the recursion's advance correctly to a RESUMING observer
+        // (sr4 → 2), but the ABORT collapse materialized fin's arm value against the pre-recursion SEED slot,
+        // so `(do (def _g (grow k)) (Acc.fin))` silently returned 0 instead of the advanced 2 on BOTH
+        // backends. `reduce_handle` now DECLINES this shape (a clean Todo) rather than emit the wrong value;
+        // the correct fold (abort collapse reads the threaded out-state) is a later increment. The guard is
+        // NARROW — a resuming observer (sr4), a plain non-abort observer, and a non-recursive abort all still
+        // fold, verified below — so this restores correctness without over-declining valid programs.
+        let runtime = find_runtime_wasm();
+        let run_k = |bytes: &[u8], k: i64| -> Option<String> {
+            let runtime = runtime.clone()?;
+            let opts = cdz_run::RunOpts {
+                export: Some("main".to_string()),
+                args: vec![k.to_string()],
+                runtime: Some(runtime),
+                runtime_cache_dir: None,
+                host_responses: Vec::new(),
+            };
+            match cdz_run::run(bytes, &opts).expect("run") {
+                cdz_run::Outcome::Value(s) => Some(s),
+                cdz_run::Outcome::Trap(t) => panic!("sr5-family run trapped: {t}"),
+            }
+        };
+
+        // sr5: the miscompile shape — MUST now decline cleanly (uncoded Todo), NOT compile to a wrong value.
+        let sr5 = "(do (effect Acc (op put (-> Unit Int64)) (op fin (-> Unit Int64))) \
+             (def (grow (: n Int64)) (if (= n 0) 0 (+ (Acc.put) (grow (- n 1))))) \
+             (def (main (: k Int64)) (handle Acc 0 ((put (u) s (resume 0 (+ s 1))) (fin (u) s s)) \
+                 (do (def _g (grow k)) (Acc.fin)))) (export main))";
+        let err = compile_component(&crate::codec::encode(&parse(sr5)))
+            .expect_err("sr5 (recursive advance observed by a same-effect ABORT arm) must DECLINE, not miscompile to 0");
+        assert!(
+            err.code.is_none(),
+            "sr5 must be a CLEAN (uncoded) decline — a coded rejection here is a different regression: {:?}",
+            err.code
+        );
+
+        // sr4 CONTROL: the SAME shape but fin RESUMES `(resume s s)` — the advance threads, folds to 2.
+        let sr4 = "(do (effect Acc (op put (-> Unit Int64)) (op fin (-> Unit Int64))) \
+             (def (grow (: n Int64)) (if (= n 0) 0 (+ (Acc.put) (grow (- n 1))))) \
+             (def (main (: k Int64)) (handle Acc 0 ((put (u) s (resume 0 (+ s 1))) (fin (u) s (resume s s))) \
+                 (do (def _g (grow k)) (Acc.fin)))) (export main))";
+        let sr4_bytes = compile_component(&crate::codec::encode(&parse(sr4))).expect(
+            "sr4 (resuming observer of the recursive advance) folds — must NOT be over-declined",
+        );
+        if let Some(v) = run_k(&sr4_bytes, 2) {
+            assert_eq!(
+                v, "2",
+                "sr4 resuming fin reads the advanced state = 2 (put ran k=2 times)"
+            );
+        }
+
+        // CONTROL: a same-effect ABORT arm with NO recursive advance before it (two INLINE puts) — the guard
+        // must NOT fire; it folds. Two puts advance 0→2, the abort reads 2.
+        let inline_abort = "(do (effect Acc (op put (-> Unit Int64)) (op fin (-> Unit Int64))) \
+             (def (main) (handle Acc 0 ((put (u) s (resume 0 (+ s 1))) (fin (u) s s)) \
+                 (do (def _a (Acc.put)) (def _b (Acc.put)) (Acc.fin)))) (export main))";
+        let inline_bytes = compile_component(&crate::codec::encode(&parse(inline_abort)))
+            .expect("a same-effect abort arm with NO recursion before it folds — the guard must not over-fire");
+        if let Some(v) = run_linked(&inline_bytes, "main") {
+            assert_eq!(
+                v, "2",
+                "two inline puts advance 0→2, the abort reads 2 (no recursion → not flagged)"
+            );
+        }
+
+        // CONTROL cx1 (breaker radius addendum): recursive INNER `(B.put)` performs, then an OUTER-effect
+        // `(A.fin)` ABORT reads A's state — A's state is NOT recursion-advanced (a DIFFERENT effect), so the
+        // abort correctly reads its seed 700. The guard keys on THIS handler's abortive arms (`ctx.abortive`),
+        // so an abort of a DIFFERENT effect after the recursion must NOT be swept — it folds. This pins that
+        // the guard's effect-scoping is right: the live silent-wrong band is same-effect only.
+        let cx1 = "(do (effect A (op fin (-> Unit Int64))) \
+             (effect B (op put (-> Unit Int64))) \
+             (def (grow (: n Int64)) (if (= n 0) 0 (+ (B.put) (grow (- n 1))))) \
+             (def (main (: k Int64)) \
+               (handle A 700 ((fin (u) s s)) \
+                 (handle B 0 ((put (u) s (resume 0 (+ s 1)))) \
+                   (do (def _g (grow k)) (A.fin))))) (export main))";
+        let cx1_bytes = compile_component(&crate::codec::encode(&parse(cx1)))
+            .expect("cx1 (outer-effect abort after inner recursion) folds — a DIFFERENT-effect abort must not be swept");
+        if let Some(v) = run_k(&cx1_bytes, 2) {
+            assert_eq!(
+                v, "700",
+                "cx1: A.fin aborts reading A's seed 700 (A's state was never recursion-advanced — different effect)"
+            );
+        }
+    }
+
+    #[test]
     fn a_conditional_resume_arm_folds_with_one_perform_but_declines_cleanly_with_two() {
         use crate::testkit::parse;
         // CONDITIONAL-RESUME ARM × PERFORM-COUNT (breaker ob-family datapoint, 2026-08-05). A handler arm


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 50e70b69995321b7e446eaf5cc948b85e5c9ffc0, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.