### PR TITLE
ci(nix): mkCadenzaComponent dontFixup — guard the single-wasm output from fixupPhase strip (#2196 review MED)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -534,6 +534,14 @@
               cp component.wasm "$out"
               runHook postInstall
             '';
+            # 🪤 dontFixup: $out is a single wasm FILE. stdenv's fixupPhase runs `strip` on file outputs,
+            # which truncates a wasm to ~54 bytes → a corrupt component in the store (the SAME trap rcdzcWasm
+            # guards; see its note "with fixup out=54B"). It's currently latent here — nativeBuildInputs is
+            # seedCompiler-only, no binutils strip in PATH, so fixup's strip is a no-op (components build
+            # intact: b1=497B). But that's INCIDENTAL: add a toolchain to nativeBuildInputs (or a stdenv
+            # default shift) and strip silently corrupts. Make the guard explicit, same as rcdzcWasm
+            # (github-liaison #2196 review).
+            dontFixup = true;
           };
         reducerCadenzaB1 = mkCadenzaComponent { name = "reducer-cadenza-b1"; cdzFile = "reducer_b1.cdz"; };
         reducerCadenzaB2 = mkCadenzaComponent { name = "reducer-cadenza-b2"; cdzFile = "reducer_b2.cdz"; };


### PR DESCRIPTION
Candidate PR for v-nix's merge-request (ref 67da142ce94d49b1fc651d226f830c8d6e95e855, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.