### PR TITLE
feat(cdz-kernel): component_store — resolve component bytes from a content-addressed store (§23 transitive-dep resolution half)

### DIFF
--- a/implementation/seed/crates/cdz-kernel/src/component_store.rs
+++ b/implementation/seed/crates/cdz-kernel/src/component_store.rs
@@ -1,0 +1,221 @@
+//! component_store — resolve a Cadenza component's bytes from an on-disk content-addressed store, the
+//! layout v-nix's `packages.store` (nix `componentStore`) uses and the reference resolver (`cdz-run`)
+//! reads. This is the RESOLUTION half of the §19e/§23 transitive-dep compose: given a store dir, fetch a
+//! component's bytes either by its content HASH (a reducer's `+<hash>` dep import) or by a MANIFEST NAME
+//! (the runtime's own bare inter-runtime imports like `cadenza:nfc/normalize`, mapped in `runtime.toml`).
+//!
+//! ## Store layout (v-nix-confirmed, mirrors cdz-run's `resolve_nfc_from_store`)
+//! - `<store>/<hash>.wasm` — one component per file, named by its blake3 content address.
+//! - `<store>/runtime.toml` — a `name = "<hash>"` manifest mapping the well-known runtime-internal
+//!   components (`runtime`, `debug_runtime`, `nfc`, …) to their content hashes. This is how a BARE
+//!   interface import (no `+<hash>` build-metadata) is resolved: the importer names the interface, the
+//!   manifest names the providing component's hash.
+//!
+//! Every fetch CONTENT-VERIFIES (`Hash::of(bytes) == hash`) before returning — a corrupt or substituted
+//! blob can never compose silently (the same integrity gate `blob::DiskBlobStore` and cdz-run apply). The
+//! two resolution paths differ only in how the hash is obtained: a `+<hash>` dep carries it in the import
+//! name; a bare dep looks it up by name in `runtime.toml`.
+//!
+//! This module is pure resolution (filesystem reads + hashing) — no wasmtime, no compose. The
+//! transitive-dep compose in [`crate::wasm_host`] consumes it to supply a dep's own dep bytes.
+
+use crate::hash::Hash;
+use std::path::{Path, PathBuf};
+
+/// A content-addressed component store rooted at a directory (`<hash>.wasm` files + a `runtime.toml`
+/// name→hash manifest). Cheap to construct (just holds the root path); every resolve hits the filesystem.
+#[derive(Debug, Clone)]
+pub struct ComponentStore {
+    root: PathBuf,
+}
+
+/// Why a component-store resolution failed. A sum (no-sentinels) so each failure mode is distinguishable:
+/// a missing manifest, a name absent from it, a missing blob file, an unreadable file, or a
+/// content-address MISMATCH (the integrity gate — bytes on disk don't hash to their key).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StoreError {
+    /// `runtime.toml` is absent or unreadable at the store root — needed to resolve a bare/named dep.
+    ManifestMissing { path: String },
+    /// The manifest has no `<name> = "<hash>"` line for the requested name (e.g. `nfc`).
+    NameNotInManifest { name: String },
+    /// A manifest hash string isn't a valid content address (malformed `runtime.toml` entry).
+    MalformedHash { name: String, value: String },
+    /// No `<hash>.wasm` blob in the store for the resolved hash.
+    BlobMissing { hash: String },
+    /// The blob file exists but couldn't be read (I/O error).
+    BlobUnreadable { hash: String, source: String },
+    /// The blob's bytes do NOT hash to their key — a corrupt or substituted entry (integrity failure).
+    ContentAddressMismatch { hash: String },
+}
+
+impl ComponentStore {
+    /// Open a store at `root` (no I/O — resolves are lazy). The root is the dir holding `<hash>.wasm` +
+    /// `runtime.toml` (v-nix's `componentStore` / the `CDZ_STORE` env path).
+    pub fn open(root: impl AsRef<Path>) -> Self {
+        ComponentStore {
+            root: root.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Fetch a component's bytes BY CONTENT HASH — a reducer's `+<hash>` dep import (the hash is in the
+    /// import name). Reads `<root>/<hash>.wasm` and verifies its content address matches `hash`.
+    pub fn get_by_hash(&self, hash: &Hash) -> Result<Vec<u8>, StoreError> {
+        let hex = hash.to_hex();
+        let path = self.root.join(format!("{hex}.wasm"));
+        let bytes = std::fs::read(&path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                StoreError::BlobMissing { hash: hex.clone() }
+            } else {
+                StoreError::BlobUnreadable {
+                    hash: hex.clone(),
+                    source: e.to_string(),
+                }
+            }
+        })?;
+        // Integrity gate: the bytes MUST hash to their key, or a corrupt/substituted blob would compose.
+        if Hash::of(&bytes) != *hash {
+            return Err(StoreError::ContentAddressMismatch { hash: hex });
+        }
+        Ok(bytes)
+    }
+
+    /// Fetch a runtime-internal component's bytes BY MANIFEST NAME — a bare inter-runtime import (e.g.
+    /// `nfc`), resolved via `runtime.toml`'s `<name> = "<hash>"` line, then fetched + content-verified by
+    /// that hash. This is the resolution path for the runtime's own bare `cadenza:nfc/normalize` import
+    /// (the transitive dep the §19e handle-lowered fold must compose before instantiating the runtime).
+    pub fn get_by_manifest_name(&self, name: &str) -> Result<Vec<u8>, StoreError> {
+        let manifest_path = self.root.join("runtime.toml");
+        let manifest =
+            std::fs::read_to_string(&manifest_path).map_err(|_| StoreError::ManifestMissing {
+                path: manifest_path.display().to_string(),
+            })?;
+        let hex = manifest_hash_for(&manifest, name).ok_or_else(|| StoreError::NameNotInManifest {
+            name: name.to_string(),
+        })?;
+        let hash = Hash::from_hex(&hex).ok_or_else(|| StoreError::MalformedHash {
+            name: name.to_string(),
+            value: hex.clone(),
+        })?;
+        self.get_by_hash(&hash)
+    }
+}
+
+/// Parse a `runtime.toml` for a `<name> = "<hash>"` line, returning the hash string. A minimal line-based
+/// scan (the manifest is a flat `key = "value"` map — `runtime`/`debug_runtime`/`nfc`); we avoid a full
+/// TOML-parser dep for a two-field manifest. Matches the KEY exactly (so `nfc` doesn't match `nfc_extra`).
+fn manifest_hash_for(manifest: &str, name: &str) -> Option<String> {
+    manifest.lines().find_map(|line| {
+        let line = line.trim();
+        let rest = line.strip_prefix(name)?;
+        // The char right after the key must be `=` or whitespace-then-`=`, so `nfc` doesn't match `nfcx`.
+        let rest = rest.trim_start();
+        let rest = rest.strip_prefix('=')?;
+        Some(rest.trim().trim_matches('"').to_string())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, name: &str, bytes: &[u8]) {
+        std::fs::write(dir.join(name), bytes).unwrap();
+    }
+
+    // A hash-addressed fetch round-trips + content-verifies. Uses a real temp dir with a `<hash>.wasm` file.
+    #[test]
+    fn get_by_hash_reads_and_verifies() {
+        let dir = std::env::temp_dir().join(format!("cdzstore-hash-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bytes = b"component-bytes-abc".to_vec();
+        let hash = Hash::of(&bytes);
+        write(&dir, &format!("{}.wasm", hash.to_hex()), &bytes);
+        let store = ComponentStore::open(&dir);
+        assert_eq!(store.get_by_hash(&hash).unwrap(), bytes);
+        // A hash with no blob → BlobMissing.
+        let absent = Hash::of(b"nope");
+        assert!(matches!(
+            store.get_by_hash(&absent),
+            Err(StoreError::BlobMissing { .. })
+        ));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // A CORRUPT blob (bytes don't hash to their filename) is rejected, not composed.
+    #[test]
+    fn get_by_hash_rejects_a_content_address_mismatch() {
+        let dir = std::env::temp_dir().join(format!("cdzstore-corrupt-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let good = b"the-real-bytes".to_vec();
+        let hash = Hash::of(&good);
+        // Write DIFFERENT bytes under the good hash's name → integrity failure.
+        write(&dir, &format!("{}.wasm", hash.to_hex()), b"tampered");
+        let store = ComponentStore::open(&dir);
+        assert!(matches!(
+            store.get_by_hash(&hash),
+            Err(StoreError::ContentAddressMismatch { .. })
+        ));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // A manifest-name fetch resolves nfc → hash → verified bytes (the runtime's bare-dep path).
+    #[test]
+    fn get_by_manifest_name_resolves_nfc_via_runtime_toml() {
+        let dir = std::env::temp_dir().join(format!("cdzstore-nfc-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let nfc_bytes = b"nfc-component".to_vec();
+        let nfc_hash = Hash::of(&nfc_bytes);
+        let rt_bytes = b"runtime-component".to_vec();
+        let rt_hash = Hash::of(&rt_bytes);
+        write(&dir, &format!("{}.wasm", nfc_hash.to_hex()), &nfc_bytes);
+        write(&dir, &format!("{}.wasm", rt_hash.to_hex()), &rt_bytes);
+        write(
+            &dir,
+            "runtime.toml",
+            format!(
+                "# a store manifest\nruntime = \"{}\"\nnfc = \"{}\"\n",
+                rt_hash.to_hex(),
+                nfc_hash.to_hex()
+            )
+            .as_bytes(),
+        );
+        let store = ComponentStore::open(&dir);
+        assert_eq!(store.get_by_manifest_name("nfc").unwrap(), nfc_bytes);
+        assert_eq!(store.get_by_manifest_name("runtime").unwrap(), rt_bytes);
+        // A name not in the manifest → NameNotInManifest.
+        assert!(matches!(
+            store.get_by_manifest_name("debug_runtime"),
+            Err(StoreError::NameNotInManifest { .. })
+        ));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // A missing runtime.toml → ManifestMissing (distinct from a name absent from a present manifest).
+    #[test]
+    fn get_by_manifest_name_without_a_manifest_is_manifest_missing() {
+        let dir = std::env::temp_dir().join(format!("cdzstore-nomanifest-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = ComponentStore::open(&dir);
+        assert!(matches!(
+            store.get_by_manifest_name("nfc"),
+            Err(StoreError::ManifestMissing { .. })
+        ));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // The manifest scan matches the KEY exactly — `nfc` must not match a `nfc_extra` line.
+    #[test]
+    fn manifest_scan_matches_the_key_exactly() {
+        assert_eq!(
+            manifest_hash_for("nfc = \"abc\"\n", "nfc"),
+            Some("abc".to_string())
+        );
+        // A longer key sharing the prefix must NOT match the shorter name.
+        assert_eq!(manifest_hash_for("nfc_extra = \"xyz\"\n", "nfc"), None);
+        // Whitespace tolerance.
+        assert_eq!(
+            manifest_hash_for("  nfc   =   \"def\"  \n", "nfc"),
+            Some("def".to_string())
+        );
+    }
+}

--- a/implementation/seed/crates/cdz-kernel/src/lib.rs
+++ b/implementation/seed/crates/cdz-kernel/src/lib.rs
@@ -23,6 +23,10 @@
 //!   [`executor::CompositeExecutor`] routes by kind so a session serves multiple effect kinds.
 //! - [`blob`] — the content-addressable blob store (CAS): `hash → bytes`, self-verifying on disk. The
 //!   §4 large-payload store + the substrate for resolving a reducer's declared component deps by hash.
+//! - [`component_store`] — resolve a component's bytes from an on-disk content-addressed store (v-nix's
+//!   `componentStore`: `<hash>.wasm` + a `runtime.toml` name→hash manifest): by HASH (a reducer's `+<hash>`
+//!   dep) or by manifest NAME (the runtime's bare `cadenza:nfc/normalize` inter-runtime import). The
+//!   resolution half of the §19e/§23 transitive-dep compose; content-verifies every fetch.
 //! - [`log_store`] — the durable append-only disk log: length-framed events, torn-tail-tolerant
 //!   recovery (`Clean`/`TornTail`/`Corrupt`), heal-a-torn-tail via `truncate_to`.
 //! - [`wasm_host`] — the wasmtime component host (§19b): binds `wit/reducer.wit`, runs a reducer as a
@@ -59,6 +63,7 @@
 pub mod ast_marshal;
 pub mod authz;
 pub mod blob;
+pub mod component_store;
 pub mod effect;
 pub mod event;
 pub mod event_ast;


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 2f665ff6a, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.