### PR TITLE
rcdzc(effects): FIX #2179 rx6 OVER-DECLINE — observer-gate the depth-3+ pre-spec-lift decline (rx6 folds 21, rn3 still declines) + fold liaison None=>true nit

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -6989,7 +6989,7 @@ fn specialize_recursive(db: &mut Db, head: StructId, ctx: &HandlerCtx) -> Option
     // own state trivially (next-state == state binder — no inner-op state advance to preserve); a non-trivial
     // inner-state advance is left to the ordinary fold (unchanged). Byte-identical when nothing matches.
     let orig_body = if ctx.slots.len() > 1 {
-        lift_inner_op_arm_outer_perform(db, orig_body, ctx)
+        lift_inner_op_arm_outer_perform(db, orig_body, ctx, caller_observes_outstate)
     } else {
         orig_body
     };
@@ -7229,11 +7229,22 @@ fn resume_val_op_arm_also_performs_outer(
     }
     match tail_resume(db, inner_arm.body) {
         Some((inner_val, _)) => resume_reaches_another_effect_op(db, inner_val, op_id),
-        None => false,
+        // The deeper op's arm is NOT a bare `(resume v next)` — a shape this analysis cannot inspect (a
+        // wrapped `do`/`match` body, or an abortive arm). Per the doc contract, treat an un-analyzable arm
+        // CONSERVATIVELY as "may perform a further outer op" → true, so `lift_inner_op_arm_outer_perform`
+        // DECLINES the chain (under the observer gate) rather than lifting a shape whose depth it can't verify
+        // (github-liaison #2179 review: the old `None => false` said "safe to lift", the OPPOSITE of the
+        // documented conservative-decline, letting a wrapped/abortive depth-3+ intermediate arm slip the lift).
+        None => true,
     }
 }
 
-fn lift_inner_op_arm_outer_perform(db: &mut Db, node: StructId, ctx: &HandlerCtx) -> StructId {
+fn lift_inner_op_arm_outer_perform(
+    db: &mut Db,
+    node: StructId,
+    ctx: &HandlerCtx,
+    caller_observes_outstate: bool,
+) -> StructId {
     // Is this node an inner-op call whose arm resume-value performs an outer op with trivial inner-state?
     if let Resolved::Apply { head, args } = resolved_of(db, node)
         && let Some((decl, idx)) = crate::eval::effect_op_of(db, head)
@@ -7269,7 +7280,19 @@ fn lift_inner_op_arm_outer_perform(db: &mut Db, node: StructId, ctx: &HandlerCtx
         // → `specialize_recursive` declines cleanly) rather than fold a wrong value. Depth-2 (val's op's arm
         // does NOT perform-outer, e.g. B.step's arm `(resume (A.tick) t)` where A.tick's arm is a plain
         // state step) is UNAFFECTED — it lifts and folds → 21.
-        && !resume_val_op_arm_also_performs_outer(db, val, ctx, (decl.0, idx))
+        //
+        // OBSERVER-GATED (rn3/rx4 vs rx6, breaker 2026-08-05). The depth-3+ decline above OVER-DECLINED the
+        // NO-OBSERVER chain: `#2179` applied it unconditionally, so rx6 (bare `(loop 2)`, no post-recursion
+        // observer of the out-state) regressed from fold-21 to a decline. The silent-20 miscompile the decline
+        // exists to prevent ONLY arises under an OBSERVING caller (the accum-redirect path #2136 added, keyed
+        // by `force_multivalue` = `caller_observes_outstate`): there the single-step lift drops the deepest
+        // advance. WITHOUT an observer the deep chain still folds correctly (rx6 → 21 — the between-iteration
+        // advance carries, the redirect never engages), so the lift must fire there as before. Gate the
+        // depth-3+ decline on `caller_observes_outstate`: decline the deeper chain (rn3/rx4) only when observed;
+        // let rx6 lift+fold when unobserved. (A correct recursive lift folding →21 at all depths regardless of
+        // observation is a later increment.)
+        && !(caller_observes_outstate
+            && resume_val_op_arm_also_performs_outer(db, val, ctx, (decl.0, idx)))
     {
         // β-reduce the arm's resume value with params↦args (the op's args) so a param-referencing outer
         // perform arg resolves. (Unit-op arms bind nothing; a mismatch leaves it un-substituted, still sound
@@ -7294,7 +7317,7 @@ fn lift_inner_op_arm_outer_perform(db: &mut Db, node: StructId, ctx: &HandlerCtx
         Struct::List(children) => {
             let lifted: Vec<StructId> = children
                 .iter()
-                .map(|&c| lift_inner_op_arm_outer_perform(db, c, ctx))
+                .map(|&c| lift_inner_op_arm_outer_perform(db, c, ctx, caller_observes_outstate))
                 .collect();
             if lifted == children {
                 node

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -68149,6 +68149,59 @@ mod stage1 {
     }
 
     #[test]
+    fn a_depth3_nested_op_chain_folds_without_an_observer_but_declines_with_one() {
+        use crate::testkit::parse;
+        // OBSERVER-GATED DEPTH-3+ pre-spec-lift guard (breaker rn3/rx6, 2026-08-05). A depth-3 nested-op
+        // chain — `loop` performs `C.hop`; C's arm resumes `(B.step)`; B's arm resumes `(A.tick)` — is lifted
+        // one step at a time; the single lift does NOT chase the deepest `A.tick`, so under an OBSERVING caller
+        // the merged fold drops A's advance → a SILENT 20 (want 21). #2136 briefly shipped that; #2179's guard
+        // fixed it BUT applied unconditionally, over-declining the NO-OBSERVER twin (rx6, which folds 21
+        // correctly). This pins the observer-GATED guard: decline the deeper chain ONLY when the out-state is
+        // observed (rn3), and let the unobserved chain fold (rx6). A correct recursive lift folding →21 at all
+        // depths is a later increment.
+
+        // rx6 — NO post-recursion observer (bare `(loop 2)`, single-op A): the between-iteration advance
+        // carries, the accum-redirect never engages → FOLDS 21. Must NOT be over-declined.
+        let rx6 = "(do (effect A (op tick (-> Unit Int64))) (effect B (op step (-> Unit Int64))) \
+             (effect C (op hop (-> Unit Int64))) \
+             (def (loop (: n Int64)) (if (= n 0) 0 (+ (C.hop) (loop (- n 1))))) \
+             (def (main) (handle A 10 ((tick (u) s (resume s (+ s 1)))) \
+               (handle B 0 ((step (u) t (resume (A.tick) t))) \
+                 (handle C 0 ((hop (u) w (resume (B.step) w))) (loop 2))))) (export main))";
+        let rx6_bytes = compile_component(&crate::codec::encode(&parse(rx6)))
+            .expect("rx6 (depth-3 chain, NO observer) must FOLD — the observer-gated guard must not over-decline it");
+        if let Some(v) = run_linked(&rx6_bytes, "main") {
+            assert_eq!(
+                v, "21",
+                "rx6: loop 2 sums the two A.tick pre-advance values 10 + 11 = 21"
+            );
+        }
+
+        // rn3 — WITH a post-recursion observer (`(+ (loop 1) (A.get))`): the depth-3 chain under an observing
+        // caller would drop A's advance if lifted → the guard DECLINES cleanly (a decline is safe; the silent
+        // 20 is not). Pins the silent-20 stays eliminated: it must NOT compile to a wrong value.
+        let rn3 = "(do (effect A (op tick (-> Unit Int64)) (op get (-> Unit Int64))) \
+             (effect B (op step (-> Unit Int64))) (effect C (op hop (-> Unit Int64))) \
+             (def (loop (: n Int64)) (if (= n 0) 0 (+ (C.hop) (loop (- n 1))))) \
+             (def (main) (handle A 10 ((tick (u) s (resume s (+ s 1))) (get (u) s (resume s s))) \
+               (handle B 0 ((step (u) t (resume (A.tick) t))) \
+                 (handle C 0 ((hop (u) w (resume (B.step) w))) (+ (loop 1) (A.get)))))) (export main))";
+        match compile_component(&crate::codec::encode(&parse(rn3))) {
+            // Clean decline — the current, expected behavior (the correct →21 fold is a later increment).
+            Err(_) => {}
+            // If a future recursive lift folds it, the value MUST be 21, never the silent 20 this guards.
+            Ok(bytes) => {
+                if let Some(v) = run_linked(&bytes, "main") {
+                    assert_eq!(
+                        v, "21",
+                        "if rn3 (observer, depth-3) ever folds, it must be 21, never the silent 20"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn a_recursive_advance_observed_by_a_same_effect_abort_arm_declines_not_miscompiles() {
         use crate::testkit::parse;
         // BREAKER sr5 (HIGH silent-miscompile, restore-safe-decline). A recursive loop of same-effect

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -8733,3 +8733,27 @@
                     (+ (loop 1) (A.get))))))
             (export main)))
   (output (: 21 Int64)))
+
+(case "a DEPTH-3 nested-op chain WITHOUT a post-observer folds (the no-observer control for the observer-gated guard)"
+  (doc    "The no-observer control (breaker rx6) for the depth-3 decline case above. The SAME recursion ×
+           depth-3 chain — `loop` performs `C.hop`; C's arm resumes `(B.step)`; B's arm resumes `(A.tick)` —
+           but the body is bare `(loop 2)` with NO post-loop observer and a single-op `A`. Without an observer
+           of the recursion's out-state, the accum-redirect never engages, so the between-iteration advance
+           carries through the merge and the chain FOLDS: `loop 2` sums the two `A.tick` pre-advance values 10
+           then 11 = 21. This pins that the observer-GATED depth-3+ guard does NOT over-decline the working
+           no-observer chain — the guard (`caller_observes_outstate && resume_val_op_arm_also_performs_outer`)
+           fires ONLY when the out-state is observed (the decline case above), so this twin is unaffected.
+           #2179's guard briefly over-declined this (fold→decline); the observer gate is what separates the
+           must-decline observer chain from this must-fold no-observer twin.")
+  (input  (do
+            (effect A (op tick (-> Unit Int64)))
+            (effect B (op step (-> Unit Int64)))
+            (effect C (op hop (-> Unit Int64)))
+            (def (loop (: n Int64)) (if (= n 0) 0 (+ (C.hop) (loop (- n 1)))))
+            (def (main)
+              (handle A 10 ((tick (u) s (resume s (+ s 1))))
+                (handle B 0 ((step (u) t (resume (A.tick) t)))
+                  (handle C 0 ((hop (u) w (resume (B.step) w)))
+                    (loop 2)))))
+            (export main)))
+  (output (: 21 Int64)))


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 2895db1905280a3a16e01cb07e3840b0291288d0, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.