### PR TITLE
test(cdz-kernel): fix ast_to_val_round_trips_nested_compounds doc comment (#2207 review nit)

### DIFF
--- a/implementation/seed/crates/cdz-kernel/src/ast_marshal.rs
+++ b/implementation/seed/crates/cdz-kernel/src/ast_marshal.rs
@@ -1154,7 +1154,8 @@ mod tests {
 
     // NESTED compound round-trips (v-syntax review F3, LOW): all other round-trips are single-level, so the
     // build_val/build_from_ast recursion is only transitively covered. Lock it in both directions: a record
-    // with list + option fields, and a list-of-records.
+    // with list + option fields, and a list-of-lists (list<list<string>>) — see the note below on why
+    // list-of-lists rather than list-of-record.
     #[test]
     fn ast_to_val_round_trips_nested_compounds() {
         // `ast_to_val` reconstructs record fields in the target WIT type's FIELD ORDER, so build the


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 6c339f760719bb50e4563821298b28ddaad0e025, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.