### PR TITLE
rcdzc(effects): tighten the ms-family pin test-precision (github-liaison #2243 review, fold-forward)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -68166,27 +68166,36 @@ mod stage1 {
                (* (Amb.flip) (Amb.flip)))) (export main))";
         let flat_bytes = compile_component(&crate::codec::encode(&parse(flat)))
             .expect("a flat multi-shot arm with two performs folds (the 4-path cross-product)");
-        if let Some(v) = run_linked(&flat_bytes, "main") {
-            assert_eq!(
-                v, "25",
-                "flat multi-shot cross-product: (2*2)+(2*3)+(3*2)+(3*3) = 25"
-            );
-        }
+        // run_returns (not if-let-Some(run_linked)) so the value assert ALWAYS runs + is typed
+        // (github-liaison #2243 review: the if-let form silently skips the check if the runtime is absent).
+        assert_eq!(
+            run_returns::<i64>(&flat_bytes, "main"),
+            25,
+            "flat multi-shot cross-product: (2*2)+(2*3)+(3*2)+(3*3) = 25"
+        );
 
         // RECURSIVE: the SAME multi-shot arm but the performs are inside a self-recursive loop. Today this
-        // declines cleanly; a future fold (a recursive multi-shot refold) must not miscompile — the guard
-        // accepts a clean decline OR, if it ever folds, requires it to run without crashing.
+        // declines cleanly; a future fold (a recursive multi-shot refold) must equal the SAME 25 — `(loop 1)`
+        // returns 1, so `(* flip1 (* flip2 1))` = `(* flip1 flip2)` = the identical 4-path cross-product.
         let rec = "(do (effect Amb (op flip (-> Unit Int64))) \
              (def (loop (: n Int64)) (if (= n 0) 1 (* (Amb.flip) (loop (- n 1))))) \
              (def (main) (handle Amb 0 ((flip (u) s (+ (resume 2 s) (resume 3 s)))) (loop 2))) (export main))";
         match compile_component(&crate::codec::encode(&parse(rec))) {
-            // Clean decline — the current, expected behavior (a recursive multi-shot refold is a later increment).
-            Err(_) => {}
-            // If a future increment folds it, it must run without crashing (the multi-shot × recursion
-            // cross-product is well-defined; a wrong value or trap here is the miscompile this guards).
-            Ok(bytes) => {
-                let _ = run_linked(&bytes, "main");
-            }
+            // Clean decline is the current, EXPECTED behavior — assert it is UNCODED (a recursive multi-shot
+            // refold is a later increment), NOT masked by a bare `_` (github-liaison #2243: a coded-rejection
+            // regression must fail loudly, not pass via Err(_)).
+            Err(e) => assert!(
+                e.code.is_none(),
+                "the recursive multi-shot face must decline CLEANLY (uncoded) — a coded rejection is a different regression: {:?}",
+                e.code
+            ),
+            // If a future recursive-multi-shot-refold increment folds it, the value MUST be 25 (same
+            // cross-product as flat, since `(loop 1)` = 1), never a wrong value.
+            Ok(bytes) => assert_eq!(
+                run_returns::<i64>(&bytes, "main"),
+                25,
+                "if the recursive multi-shot ever folds it must equal the flat cross-product 25, never miscompile"
+            ),
         }
     }
 


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref e7156bf9396e83fef2383c338b44bf88edacebdc, lane rcdzc-tests). Auto-merge armed; pr-sync's schedule-pass reaps on green.