### PR TITLE
refactor(cdz-kernel): bare_iface_name uses split_once('@') (drop dead unwrap_or, #2237 follow-up)

### DIFF
--- a/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
+++ b/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
@@ -358,7 +358,12 @@ fn bare_iface_name(import_name: &str) -> &str {
     let no_hash = import_name
         .rsplit_once('+')
         .map_or(import_name, |(iface, _hash)| iface);
-    no_hash.split('@').next().unwrap_or(no_hash)
+    // `split_once('@')` (only the first `@` matters), mirroring the `rsplit_once('+')` above — an
+    // unsuffixed name maps to itself. (NOT `split('@').next().unwrap_or(...)`: `next()` is infallible so
+    // the `unwrap_or` was dead code — #2237 review.)
+    no_hash
+        .split_once('@')
+        .map_or(no_hash, |(iface, _ver)| iface)
 }
 
 /// The declared component dependencies of a component (§23): EVERY import whose name carries a


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 94f493f14bfb2b80e97dbd15533ca49a4c7f9d05, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.