### PR TITLE
test(cdz-kernel): fix stale resolve_runtime_deps fn-doc — DiskBlobStore → ComponentStore/get_by_hash (b1/b2 twins)

### DIFF
--- a/implementation/seed/crates/cdz-kernel/tests/reducer_cadenza_b1_e2e.rs
+++ b/implementation/seed/crates/cdz-kernel/tests/reducer_cadenza_b1_e2e.rs
@@ -116,8 +116,8 @@ async fn reducer_cadenza_b1_folds_empty_effects_through_apply_handle_lowered() {
 
 /// Resolve every declared dep's bytes for the b1 e2e, from whichever runtime source v-nix wired:
 /// `RUNTIME_HEAP_COMPONENT` (a direct path, composed as-is) takes precedence; else `CDZ_STORE` (a
-/// content-addressed [`DiskBlobStore`] the dep is looked up in by its `+<hash>`). A declared dep with
-/// neither source available FAILS LOUD.
+/// content-addressed `ComponentStore`, read via `get_by_hash` — the SHA-256-verified content-address
+/// path the fold itself uses). A declared dep with neither source available FAILS LOUD.
 async fn resolve_runtime_deps(deps: &[ComponentDep]) -> Vec<(ComponentDep, Vec<u8>)> {
     // Direct-path override: compose the runtime component from a path env, no hash lookup. b1 declares a
     // single runtime dep, so a single direct path satisfies it.

--- a/implementation/seed/crates/cdz-kernel/tests/reducer_cadenza_b2_e2e.rs
+++ b/implementation/seed/crates/cdz-kernel/tests/reducer_cadenza_b2_e2e.rs
@@ -107,8 +107,9 @@ async fn reducer_cadenza_b2_folds_one_http_effect_through_apply_handle_lowered()
     }
 }
 
-/// Resolve every declared dep's bytes from `CDZ_STORE` (v-nix's componentStore, `<hash>.wasm` naming) or
-/// the `RUNTIME_HEAP_COMPONENT` direct-path override — identical to the b1 e2e's resolver.
+/// Resolve every declared dep's bytes from `CDZ_STORE` (v-nix's componentStore, read via
+/// `ComponentStore::get_by_hash` — the SHA-256-verified content-address path the fold uses) or the
+/// `RUNTIME_HEAP_COMPONENT` direct-path override — identical to the b1 e2e's resolver.
 async fn resolve_runtime_deps(deps: &[ComponentDep]) -> Vec<(ComponentDep, Vec<u8>)> {
     if let Ok(path) = std::env::var("RUNTIME_HEAP_COMPONENT") {
         let bytes = std::fs::read(&path)


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 59c08d0b8ae29d3db251466d56f1cdb1eddd39d3, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.