### PR TITLE
ci: cache-warm — add least-privilege permissions block (#2280 review fix-forward)

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -26,6 +26,11 @@ concurrency:
   group: cache-warm
   cancel-in-progress: false
 
+# Least-privilege, matching ci.yml/pages: this job only READS the repo + reads/writes the GHA cache (the
+# cache API works under contents:read — the actions: scope gates workflow-RUN management, not cache r/w).
+permissions:
+  contents: read
+
 env:
   CARGO_INCREMENTAL: "0"
   CARGO_NET_RETRY: "10"


### PR DESCRIPTION
Candidate PR for v-nix's merge-request (ref 2933fdd6108512a06e05fd932fa1a28df0108dfc, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.