### PR TITLE
fix(effects): safe-decline the outer-perform-in-next-state-slot silent miscompile (as2/as1)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -4791,6 +4791,33 @@ fn thread_bounded(
             //     handler / emitted as host calls), then the resume value. This is what lets an inner
             //     handler INTERPOSE on a delegated effect — count it via an outer effect, then forward.
             let (value, next_state) = peel_resume_from_arm_body(db, arm_body)?;
+            // SAFE-DECLINE: a FOREIGN perform embedded ONLY in the threaded NEXT-STATE (as2/as1, breaker
+            // 2026-08-05). An arm `(resume t (+ t (A.get)))` performing an OUTER effect `A.get` in its
+            // next-state expr is unsound as a fold: the next-state threads forward as a state EXPRESSION, so
+            // the embedded `A.get` is either DROPPED (a single perform discards the final slot state — as2:
+            // `(+ 10 0) + seed = 5`, should be 6) or DUPLICATED across dispatches (multi-perform re-splices
+            // the state expr — as1: 63, fits no model). Both are SILENT wrong values, both backends, O0-O3.
+            // The proven-correct forms already fold and MUST stay folding: the foreign perform in the VALUE
+            // slot (`(resume (+ t (A.get)) t)` — as3=56, served on the live spine), the manual let-lift
+            // (`(let ((x (A.get))) (resume t (+ t x)))` — as7=6, its foreign runs in the value-wrapper too),
+            // and the interposing `(do (A.tick) (resume v s))` (the foreign is a do-STATEMENT the value's
+            // `(do … v)` runs). So decline ONLY when the foreign perform is EXCLUSIVE to `next_state` — a
+            // DIRECT `(Outer.op …)` in the threaded-state position that is NOT in the value. The check runs
+            // over the ORIGINAL PARENTED arm (`peel_resume_from_arm_body(arm.body)`) — NOT the post-peel
+            // `value`/`next_state`, whose `deep_fresh_copy` orphans (dead parent chain) would POISON spec-name
+            // resolution (`effect_op_of` resolves the decl-literal; resolving an orphan leaked a
+            // `loop#eff3$s1` CDZ0101 into the recursive-fold surface). The structural (non-call-following)
+            // `next_state_directly_performs_foreign` distinguishes as2's literal `(A.get)` in the arm's own
+            // next-state from a recursive fold that threads an outer effect through a self-call/specialized
+            // CALLEE body (never a direct perform in the arm's next-state), so the recursive-fold suite stays
+            // folding. The correct FOLD (run the next-state foreign once at dispatch, thread its pure result —
+            // the inline analogue of as7's let-lift) is a deeper eval-order arc; decline is the safe floor.
+            if let Some((orig_value, orig_next_state)) = peel_resume_from_arm_body(db, arm.body)
+                && next_state_directly_performs_foreign(db, orig_next_state, ctx)
+                && !next_state_directly_performs_foreign(db, orig_value, ctx)
+            {
+                return None;
+            }
             // `value`/`next_state` are the resume node's own CHILDREN, so their `parent_of` still points at
             // that (now-discarded) `resume` node — an orphan whose parent chain does NOT reach the threaded
             // body's enclosing `(def …)`. If either carries a NAME reference (e.g. a state-threading arm's
@@ -8274,6 +8301,29 @@ fn body_reaches_foreign_perform(db: &mut Db, node: StructId, ctx: &HandlerCtx) -
         }
     }
     walk(db, node, ctx, 0)
+}
+
+/// Whether `node` performs a FOREIGN op (an effect op NOT in this handler's arms — an outer handler's
+/// effect) DIRECTLY, as a literal `(Outer.op …)` Apply somewhere in the expression tree — WITHOUT
+/// following user calls into their bodies. This is the NARROW twin of `body_reaches_foreign_perform`
+/// (which over-reports through recursive/unresolvable heads, sweeping the whole recursive-fold surface).
+/// Used to gate the as2/as1 safe-decline: an inner arm's NEXT-STATE `(+ t (A.get))` literally performs the
+/// OUTER effect in the threaded-state position (dropped/duplicated → silent wrong). A recursive fold that
+/// threads an outer effect does so through a self-call/specialized CALLEE body, never a direct `(A.get)` in
+/// the arm's own next-state — so NOT following calls is exactly the discriminator that spares those folds.
+fn next_state_directly_performs_foreign(db: &mut Db, node: StructId, ctx: &HandlerCtx) -> bool {
+    if let Resolved::Apply { head, .. } = resolved_of(db, node)
+        && let Some((decl, idx)) = crate::eval::effect_op_of(db, head)
+        && !ctx.arms.contains_key(&(decl.0, idx))
+    {
+        return true;
+    }
+    match db.ast.get(node).clone() {
+        Struct::List(children) => children
+            .iter()
+            .any(|&c| next_state_directly_performs_foreign(db, c, ctx)),
+        Struct::Atom(_) => false,
+    }
 }
 
 /// Whether `param` is the unit placeholder `()` (a nullary operation's single "parameter", which binds

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -68193,6 +68193,57 @@ mod stage1 {
     }
 
     #[test]
+    fn an_outer_perform_directly_in_a_resume_next_state_slot_declines_not_miscompiles() {
+        use crate::testkit::parse;
+        // as2/as1 SAFE-DECLINE (breaker as-family, 2026-08-05). An inner handler arm whose NEXT-STATE slot
+        // performs an OUTER effect DIRECTLY — `(step (u) t (resume t (+ t (A.get))))` — was a CONFIRMED
+        // SILENT MISCOMPILE: the next-state threads forward as a state EXPRESSION, so the embedded `(A.get)`
+        // is either DROPPED (a single B.step discards the final slot state — as2 returned 5, must be 6) or
+        // DUPLICATED across dispatches (a multi-step body re-splices the state expr — as1 returned 63, a
+        // value that fits NO evaluation model). Both wrong, both backends, all opt levels. The fold now
+        // DECLINES cleanly (`next_state_directly_performs_foreign` gate in effects.rs's tail-resume arm) —
+        // never a wrong value. The correct FOLD (run the next-state foreign once at dispatch, thread its pure
+        // result — the inline analogue of as7's let-lift) is a deeper eval-order arc; this pin flips
+        // decline→value when it lands (as2→6, as1→61). The proven-correct as3 (value slot) / as7 (let-lift)
+        // faces STAY folding — pinned in the sibling control above; the gate fires ONLY on a DIRECT outer
+        // perform exclusive to the next-state slot, so it does not sweep the recursive-fold surface (which
+        // threads outer effects through self-call/specialized callees, never a literal perform in the arm's
+        // own next-state). The user WORKAROUND meanwhile is the let-lift (as7).
+        let as2 = "(do (effect A (op get (-> Unit Int64))) (effect B (op step (-> Unit Int64))) \
+             (def (main) (handle A 5 ((get (u) s (resume s (+ s 1)))) \
+               (handle B 0 ((step (u) t (resume t (+ t (A.get))))) \
+                 (+ (* 10 (B.step)) (A.get))))) (export main))";
+        // as1 — three chained B.step performs (multi-step): the drop/duplicate manifests as 63 (no model).
+        let as1 = "(do (effect A (op get (-> Unit Int64))) (effect B (op step (-> Unit Int64))) \
+             (def (main) (handle A 5 ((get (u) s (resume s (+ s 1)))) \
+               (handle B 0 ((step (u) t (resume t (+ t (A.get))))) \
+                 (+ (* 100 (B.step)) (+ (* 10 (B.step)) (B.step)))))) (export main))";
+        for (src, name) in [(as2, "as2"), (as1, "as1")] {
+            match compile_component(&crate::codec::encode(&parse(src))) {
+                // TODO(as-fold): flip to a value assertion (as2→6, as1→61) when the next-state-slot
+                // outer-perform fold lands. Until then the DECLINE must be CLEAN — never a leaked internal
+                // state-param name, never a wrong value.
+                Err(e) => assert!(
+                    !e.message.contains("#eff") && !e.message.contains("$s"),
+                    "{name}: the next-state-slot outer-perform decline must not leak an internal \
+                     state-param name, got: {}",
+                    e.message
+                ),
+                // If a future increment folds it, the value MUST be correct (as2=6, as1=61) — never the
+                // pre-fix silent miscompile (as2=5, as1=63).
+                Ok(bytes) => {
+                    let v: i64 = run_returns(&bytes, "main");
+                    let want = if name == "as2" { 6 } else { 61 };
+                    assert_eq!(
+                        v, want,
+                        "{name}: if the next-state-slot outer perform folds it must be {want}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn a_performing_condition_advance_survives_an_inner_abort_and_is_read_by_a_post_handle_observer()
      {
         use crate::testkit::parse;


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 6857f78cf, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.