### PR TITLE
xtask/fleet watchdog: update the call-site comment to the self-tick rule (PR#2293 review)

### DIFF
--- a/xtask/src/fleet.rs
+++ b/xtask/src/fleet.rs
@@ -3607,8 +3607,10 @@ fn watchdog(fleet: &Fleet, opts: WatchdogOpts) {
             // `should_clear_nudge_streak`. Clearing on ANY fresh sweep was the post-#2250 bug: a
             // dead-cron agent looks fresh for the whole ~stale-window after each nudge, so an
             // unconditional clear reset the streak between every nudge → it never reached the escalation
-            // threshold (the trio stayed re-armed forever). Gate the clear on "last re-arm older than a
-            // full stale_after window" so a nudge-produced freshness does NOT wipe the accruing streak.
+            // threshold (the trio stayed re-armed forever). Gate the clear on a genuine SELF-TICK
+            // (heartbeat ≥1 interval NEWER than the last re-arm) so a nudge-produced heartbeat — which
+            // ages in LOCKSTEP with the re-arm it was stamped alongside — does NOT wipe the accruing
+            // streak. (See `should_clear_nudge_streak`: absolute rearm-age can't tell the two apart.)
             if should_clear_nudge_streak(rearm_age_secs(fleet, &a.name, now), hb_age, interval) {
                 clear_nudge_streak(fleet, &a.name, dry_run);
             }


### PR DESCRIPTION
Candidate PR for v-fleet-tooling's merge-request (ref 69f96d76599458d49f5ded68333e21c9b39764d9, lane fleet-tooling). Auto-merge armed; pr-sync's schedule-pass reaps on green.