### PR TITLE
fix(effects): route the two-hole refold re-anchor through reparent_under_handle_site (pair-body scoping — #2305 Copilot follow-up)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -7956,11 +7956,18 @@ fn rewrite_resume_to_refolded_context(
         // free var stays orphaned through every refold level. Anchor `filled` under the SAME parent the
         // original `handle_body` sits under (its live lexical chain) so `C`'s free names resolve exactly as
         // they did before the splice. `handle_body` is the still-parented original; a top-level body (parent
-        // None) leaves `filled` as-is (nothing to anchor — the pre-existing behavior). Mirrors the tail
-        // `reparent_under_handle_site`; done HERE (pre-recursion) because the detachment is introduced HERE.
-        if let Some(anchor) = db.parent_of(handle_body) {
-            db.reparent(filled, Some(anchor), db.child_ix_of(handle_body) as u32);
-        }
+        // None) leaves `filled` as-is (nothing to anchor — the pre-existing behavior). Done HERE (pre-recursion)
+        // because the detachment is introduced HERE. Route through `reparent_under_handle_site` (NOT a raw
+        // `db.reparent`) so a `handle_body` sitting in a 2-element PAIR body position — a `match` arm `(pattern
+        // body)` or a `let` binding `(name init)`, when the handle is distributed into such an arm — rebuilds a
+        // fresh `(pattern filled)` pair: resolve's binder helpers (`match_arm_binds`, resolve.rs:1880/1941/2005)
+        // require the scope-walk `from` to be EXACTLY the pair's recorded body child, so parenting `filled`
+        // directly under the pair (leaving `pb[1]` = the old `handle_body`) would leave a pattern/let binder
+        // referenced inside `filled` unresolvable — re-introducing this very false-CDZ0101 class for that
+        // sub-case (github-liaison/Copilot #2305 review). `reparent_under_handle_site` handles the pair rebuild
+        // AND the plain (non-pair, list/handle-node) parent identically to the raw reparent, so it is strictly
+        // safer; a parentless `handle_body` is a no-op (leaves `filled` as-is), matching the prior guard.
+        reparent_under_handle_site(db, filled, handle_body);
         return reduce_handle(db, next_state, arms, filled);
     }
     match db.ast.get(node).clone() {

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -68656,6 +68656,26 @@ mod stage1 {
             "105",
             "pm3: the single-site body-reads-param path stays folding at 105"
         );
+
+        // PAIR-BODY case (github-liaison/Copilot #2305 review): the re-anchor routes through
+        // `reparent_under_handle_site` (NOT a raw `db.reparent`), so a handle DISTRIBUTED into a match arm —
+        // where the handle body sits in the arm's `(pattern body)` PAIR-body position — rebuilds a fresh
+        // `(pattern filled)` pair. The arm body reads the PATTERN BINDER `x` while a two-hole refold rewrites
+        // three `E.op` performs; without the pair rebuild, resolve's `match_arm_binds` (which requires the
+        // scope-walk `from` == the pair's recorded body child) would leave `x` unresolvable → the same false
+        // CDZ0101 for the pair-body sub-case. E seed 0: op1=0 (s→1), op2=1 (s→2), op3=2; `(* 100 0)+(* 10 1)+2`
+        // = 12, `+ x` (x=5) = 17. Pins that a pattern binder resolves through the distributed-handle refold.
+        let pm_pair = "(do (effect E (op op (-> Unit Int64))) \
+             (def (main (: n Int64)) \
+               (match (Some n) \
+                 ((Some x) (handle E 0 ((op (u) s (resume s (+ s 1)))) \
+                   (+ x (+ (* 100 (E.op)) (+ (* 10 (E.op)) (E.op)))))) \
+                 ((None _u) -1))) (export main))";
+        assert_eq!(
+            run(pm_pair, 5, "pm_pair distributed-handle pattern-binder"),
+            "17",
+            "pm_pair: a pattern binder x resolves through the two-hole refold in a pair-body-position handle"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref fd4fe7723, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.