### PR TITLE
test(effects): flip the ob-family conditional-resume pin decline→fold(65) — #2305 refold now serves 2-perform two-site arms

### DIFF
--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -68535,18 +68535,19 @@ mod stage1 {
     }
 
     #[test]
-    fn a_conditional_resume_arm_folds_with_one_perform_but_declines_cleanly_with_two() {
+    fn a_conditional_resume_arm_folds_across_one_and_two_performs() {
         use crate::testkit::parse;
-        // CONDITIONAL-RESUME ARM × PERFORM-COUNT (breaker ob-family datapoint, 2026-08-05). A handler arm
-        // with a BRANCHING (two-site) resume — `(if (> s 5) (resume v s) (resume -1 s))` — is served by the
-        // tail-resumptive fold when the handle body performs the op ONCE, but currently DECLINES cleanly
-        // when the body performs it TWICE: the refold cannot re-serve a MULTI-SITE resume arm to a SECOND
-        // perform. This pins that the two-perform face is a CLEAN DECLINE, never a wrong value or crash.
-        // Arm: seed s=7, `(> s 5)` true → resumes the op arg `v`; state passed through unchanged (`s`), so
-        // every read sees s=7 and returns its argument. A future increment may fold the two-perform form;
-        // if it ever does, it must equal the value the semantics dictate, never miscompile.
+        // CONDITIONAL-RESUME ARM × PERFORM-COUNT (breaker ob-family, 2026-08-05; FLIPPED decline→fold by the
+        // pm-family two-hole refold re-anchor #2305). A handler arm with a BRANCHING (two-site) resume —
+        // `(if (> s 5) (resume v s) (resume -1 s))` — folds when the body performs the op ONCE and, since
+        // #2305, ALSO when it performs it TWICE: the two-hole refold now re-serves a multi-site (both-branch)
+        // resume arm across the second perform (the re-anchored continuation resolves its free vars). breaker
+        // verified the widening is clean (post-#2305 sr/rx/rn sweep: no silent-wrong, recursion/abort/spec-lift
+        // boundaries unchanged). This pin was `..._declines_cleanly_with_two`; the "future increment" arrived,
+        // so it now asserts the FOLD VALUE (65) — the previous decline is dead history. Arm: seed s=7,
+        // `(> s 5)` true → resumes the op arg `v`; state passes through unchanged (`s`), so every read sees 7.
 
-        // ONE perform: `(Src.read 5)` under seed 7 → arm resumes `v` = 5. Folds.
+        // ONE perform: `(Src.read 5)` under seed 7 → arm resumes `v` = 5.
         let one = "(do (effect Src (op read (-> Int64 Int64))) \
                    (def (main (: n Int64)) \
                      (handle Src 7 ((read (v) s (if (> s 5) (resume v s) (resume -1 s)))) \
@@ -68559,29 +68560,21 @@ mod stage1 {
             "seed 7 > 5 → the arm resumes the op arg v = read's argument 5"
         );
 
-        // TWO performs in the body, SAME branching arm. Today this declines cleanly (uncoded, or the
-        // imprecise CDZ0101 unbound-name — the not-yet-foldable multi-site-resume path currently surfaces as
-        // unbound-name; a cleaner diagnostic is a separate LOW follow-up); a future fold must not miscompile.
-        // Guard: it must either decline OR, if it folds, run without crashing.
+        // TWO performs in the body, SAME branching arm — now FOLDS (was a clean decline pre-#2305). Both reads
+        // see seed 7 (state passed through unchanged), each resumes its own arg: read(5)=5, read(6)=6 →
+        // 5 + 10*6 = 65. (Regression guard: if a future change ever RE-declines this, that is a regression of
+        // the #2305 widening; if it folds, it must be exactly 65, never a miscompile.)
         let two = "(do (effect Src (op read (-> Int64 Int64))) \
                    (def (main (: n Int64)) \
                      (handle Src 7 ((read (v) s (if (> s 5) (resume v s) (resume -1 s)))) \
                        (+ (Src.read n) (* 10 (Src.read (+ n 1)))))) (export main))";
-        match compile_component(&crate::codec::encode(&parse(two))) {
-            // Clean decline — the current, expected behavior.
-            Err(e) => assert!(
-                e.code.as_deref() == Some("CDZ0101") || e.code.is_none(),
-                "the two-perform conditional-resume face must decline CLEANLY, got {:?}",
-                e.code
-            ),
-            // If a future increment folds it, both reads see seed 7 (state passed through unchanged), each
-            // resumes its own arg: read(5)=5, read(6)=6 → 5 + 10*6 = 65. Never a different value.
-            Ok(bytes) => assert_eq!(
-                run_returns_with::<i64>(&bytes, "main", &[wasmtime::component::Val::S64(5)]),
-                65,
-                "if the two-perform conditional-resume ever folds it must equal 65, never miscompile"
-            ),
-        }
+        let two_bytes = compile_component(&crate::codec::encode(&parse(two)))
+            .expect("the two-perform conditional-resume arm folds since #2305 (multi-site refold re-anchor)");
+        assert_eq!(
+            run_returns_with::<i64>(&two_bytes, "main", &[wasmtime::component::Val::S64(5)]),
+            65,
+            "two-perform two-site arm folds: read(5)=5, read(6)=6, state passthrough → 5 + 10*6 = 65"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 81f887f37, lane rcdzc-tests). Auto-merge armed; pr-sync's schedule-pass reaps on green.