### PR TITLE
rcdzc(wasm): fix closure-from-collection CallIndirect miscompile — arg scratch aliased the closure operand's retain slot (i32/i64)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
@@ -11302,10 +11302,19 @@ fn emit(
                 _ => None,
             };
             // The lifted function is `(env, args…) -> result`, so push env (param 0) THEN each arg, in
-            // order, before the call. Each arg emits above the cell slot (never reusing it).
+            // order, before the call. Each arg emits above the cell slot AND above every scratch slot the
+            // CLOSURE OPERAND's own emit consumed — use `(*high).max(cell_slot + 1)`, not a bare
+            // `cell_slot + 1`. A closure operand that is a dup-site `Core::SumPayload` (the looked-up-closure
+            // shape: `(match (Map.lookup …) ((Some f) (f …)))`) floats its retain child into a slot at `*high`
+            // typed I32 (the closure cell); a plain `cell_slot + 1` base lets a following perform-threaded arg
+            // (an i64) materialize into that SAME index, and a wasm local has ONE type function-wide → i32/i64
+            // collision → an invalid module (`func failed to validate: expected i64, found i32`). Threading the
+            // base past `*high` keeps the arg's scratch DISJOINT from the closure operand's retain slot. (The
+            // host-call arg emit below already threads `arg_base` for the identical two-widths hazard.)
+            let arg_base = (*high).max(cell_slot + 1);
             out.push(Lir::LocalGet(cell_slot)); // env (the cell)
             for &arg in &args {
-                emit(db, arg, slots, cell_slot + 1, high, scratch_ty, layout, out)?;
+                emit(db, arg, slots, arg_base, high, scratch_ty, layout, out)?;
             }
             match known_code {
                 // Devirtualized: the table slot is known, so call the lifted function directly.

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -5854,3 +5854,4 @@ todo	expect on an overflowing checked add traps
 todo	expect traps on the absent case of a runtime optional
 todo	read of malformed text is a coded reject, not a wrong value
 todo	two runtime String entry args compare by content including multibyte
+pass	a closure looked up from a map by a perform result, applied to a perform result, threads through call_indirect

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5854,3 +5854,4 @@ todo	expect on an overflowing checked add traps
 todo	expect traps on the absent case of a runtime optional
 todo	read of malformed text is a coded reject, not a wrong value
 todo	two adapter records with different state types drive a take-while fold in one program
+pass	a closure looked up from a map by a perform result, applied to a perform result, threads through call_indirect

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5854,3 +5854,4 @@ todo	two host responses combine in call order through a non-commutative operator
 todo	two nested recursive const-closure drivers (filter under fold) emit valid wasm and compute correctly
 todo	two same-unit Qty host results combine guest-side as a same-dimension add
 todo	two specializations of one driver on different closures do not collide in the spec memo
+pass	a closure looked up from a map by a perform result, applied to a perform result, threads through call_indirect

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -9354,3 +9354,31 @@
               (handle B 0 ((flip () t k (+ (* (k 2) 10) (A.geta)))) (B.flip)))) (export main)))
   (output (: 120 Int64)))
 
+
+(case "a closure looked up from a map by a perform result, applied to a perform result, threads through call_indirect"
+  (doc    "A Map of CLOSURES indexed by a perform-computed key, the selected closure applied to a
+           perform-fed argument, under a resumptive handler: `(match (Map.lookup ops (St.pick)) ((Some f)
+           (f (St.feed))) ((None _u) -1))`. This is the closure-from-collection × effects-threaded-operands
+           shape — the looked-up closure is the funcref-table callee (`call_indirect`) and BOTH its selector
+           key and its applied argument are perform results the handler fold splices in. Pins a wasm-codegen
+           miscompile (breaker-found, v-effects-routed, 2026-08-05): the closure operand is a dup-site
+           `Core::SumPayload` (the `Some` payload) whose Perceus retain floats its cell into a scratch slot
+           typed i32; the perform-threaded i64 argument was materialized into that SAME slot (the closure and
+           the arg both emitted at `cell_slot + 1`), and a wasm local has one type function-wide → an i32/i64
+           collision → `call_indirect`'s function failed to validate (invalid module, wasmtime rejected at
+           compile). The rust backend always ran it correctly (the fold is sound; the defect was purely the
+           wasm scratch-slot allocation). ops = {0: x↦x*2, 1: x↦x+1000}; the pick/feed handler threads s=5,6,…
+           so pick→5%2=1 selects the +1000 closure, feed→6, giving 6+1000 = 1006.")
+  (input  (do
+            (effect St (op pick (-> Unit Int64)) (op feed (-> Unit Int64)))
+            (def (main (: n Int64))
+              (do
+                (def ops (Map.insert (Map.insert Map.empty 0 (fn ((: x Int64)) (* x 2))) 1 (fn ((: x Int64)) (+ x 1000))))
+                (handle St n
+                  ((pick (u) s (resume (% s 2) (+ s 1)))
+                   (feed (u) s (resume s (+ s 1))))
+                  (match (Map.lookup ops (St.pick))
+                    ((Some f) (f (St.feed)))
+                    ((None _u) -1)))))
+            (export main)))
+  (call   main (: 5 Int64)) (output (: 1006 Int64)))


### PR DESCRIPTION
Candidate PR for v-runtime's merge-request (ref 5763b9431, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.