### PR TITLE
test(cdz-kernel): fail loud when the RUNTIME_HEAP_COMPONENT override meets a >1-dep reducer (b1/b2/b3 resolver parity)

### DIFF
--- a/implementation/seed/crates/cdz-kernel/tests/reducer_cadenza_b1_e2e.rs
+++ b/implementation/seed/crates/cdz-kernel/tests/reducer_cadenza_b1_e2e.rs
@@ -119,9 +119,20 @@ async fn reducer_cadenza_b1_folds_empty_effects_through_apply_handle_lowered() {
 /// content-addressed `ComponentStore`, read via `get_by_hash` — the SHA-256-verified content-address
 /// path the fold itself uses). A declared dep with neither source available FAILS LOUD.
 async fn resolve_runtime_deps(deps: &[ComponentDep]) -> Vec<(ComponentDep, Vec<u8>)> {
-    // Direct-path override: compose the runtime component from a path env, no hash lookup. b1 declares a
-    // single runtime dep, so a single direct path satisfies it.
+    // Direct-path override: compose the runtime component from a path env, no hash lookup. The override
+    // supplies ONE component's bytes, so it only makes sense for a single-dep reducer — b1 declares exactly
+    // one (its cadenza:runtime/heap). FAIL LOUD if a future reducer declares >1 dep (github-liaison #2312):
+    // mapping the same heap bytes to every dep would silently hand an unrelated dep the wrong component →
+    // a deep compose/link failure instead of this targeted error. (Mirrors apply_handle_lowered's
+    // "MORE THAN ONE cadenza:runtime/heap dep" fail-loud.) Use CDZ_STORE for a genuine multi-dep reducer.
     if let Ok(path) = std::env::var("RUNTIME_HEAP_COMPONENT") {
+        assert_eq!(
+            deps.len(),
+            1,
+            "RUNTIME_HEAP_COMPONENT override supplies ONE component but the reducer declares {} deps — \
+             use CDZ_STORE (content-addressed, per-dep) for a multi-dep reducer",
+            deps.len()
+        );
         let bytes = std::fs::read(&path)
             .unwrap_or_else(|e| panic!("RUNTIME_HEAP_COMPONENT={path:?} set but unreadable: {e}"));
         return deps.iter().cloned().map(|d| (d, bytes.clone())).collect();

--- a/implementation/seed/crates/cdz-kernel/tests/reducer_cadenza_b2_e2e.rs
+++ b/implementation/seed/crates/cdz-kernel/tests/reducer_cadenza_b2_e2e.rs
@@ -111,7 +111,18 @@ async fn reducer_cadenza_b2_folds_one_http_effect_through_apply_handle_lowered()
 /// `ComponentStore::get_by_hash` — the SHA-256-verified content-address path the fold uses) or the
 /// `RUNTIME_HEAP_COMPONENT` direct-path override — identical to the b1 e2e's resolver.
 async fn resolve_runtime_deps(deps: &[ComponentDep]) -> Vec<(ComponentDep, Vec<u8>)> {
+    // Direct-path override supplies ONE component's bytes → only valid for a single-dep reducer (b2
+    // declares exactly one, its cadenza:runtime/heap). FAIL LOUD on >1 dep (github-liaison #2312) — mapping
+    // the same heap bytes to every dep would silently mis-supply an unrelated dep; use CDZ_STORE for a
+    // multi-dep reducer. (Mirrors apply_handle_lowered's "MORE THAN ONE cadenza:runtime/heap dep" fail-loud.)
     if let Ok(path) = std::env::var("RUNTIME_HEAP_COMPONENT") {
+        assert_eq!(
+            deps.len(),
+            1,
+            "RUNTIME_HEAP_COMPONENT override supplies ONE component but the reducer declares {} deps — \
+             use CDZ_STORE (content-addressed, per-dep) for a multi-dep reducer",
+            deps.len()
+        );
         let bytes = std::fs::read(&path)
             .unwrap_or_else(|e| panic!("RUNTIME_HEAP_COMPONENT={path:?} set but unreadable: {e}"));
         return deps.iter().cloned().map(|d| (d, bytes.clone())).collect();

--- a/implementation/seed/crates/cdz-kernel/tests/reducer_cadenza_b3_e2e.rs
+++ b/implementation/seed/crates/cdz-kernel/tests/reducer_cadenza_b3_e2e.rs
@@ -133,7 +133,18 @@ async fn reducer_cadenza_b3_bumps_kv_count_and_emits_one_http_effect() {
 /// `ComponentStore::get_by_hash` — the SHA-256-verified content-address path the fold uses) — identical to
 /// the b1/b2 e2e's resolver.
 async fn resolve_runtime_deps(deps: &[ComponentDep]) -> Vec<(ComponentDep, Vec<u8>)> {
+    // Direct-path override supplies ONE component's bytes → only valid for a single-dep reducer (b3
+    // declares exactly one, its cadenza:runtime/heap). FAIL LOUD on >1 dep (github-liaison #2312) — mapping
+    // the same heap bytes to every dep would silently mis-supply an unrelated dep; use CDZ_STORE for a
+    // multi-dep reducer. (Mirrors apply_handle_lowered's "MORE THAN ONE cadenza:runtime/heap dep" fail-loud.)
     if let Ok(path) = std::env::var("RUNTIME_HEAP_COMPONENT") {
+        assert_eq!(
+            deps.len(),
+            1,
+            "RUNTIME_HEAP_COMPONENT override supplies ONE component but the reducer declares {} deps — \
+             use CDZ_STORE (content-addressed, per-dep) for a multi-dep reducer",
+            deps.len()
+        );
         let bytes = std::fs::read(&path)
             .unwrap_or_else(|e| panic!("RUNTIME_HEAP_COMPONENT={path:?} set but unreadable: {e}"));
         return deps.iter().cloned().map(|d| (d, bytes.clone())).collect();


### PR DESCRIPTION
Candidate PR for v-agent-harness's merge-request (ref 33faa084294d56c0a5eaa6c285a4991f419859d2, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.