### PR TITLE
corpus(14-effects): pin the cross-handler-arg × match-shaped-resume decline as a todo-witness (breaker nv1f completeness gap)

### DIFF
--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -5846,6 +5846,7 @@ todo	a block-wrapped OUTER-effect perform in a non-tail do-statement INSIDE a ne
 todo	a block-wrapped branch perform of the OUTER effect in a let-init INSIDE a nested handler body declines cleanly (adv-69 a4 sub-face)
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject
 todo	a constant-try helper that fails feeds the None arm's fallback into resume
+todo	a cross-handler foreign-perform op-arg into a MATCH-shaped-resume arm declines cleanly (completeness gap)
 todo	a mutually-recursive group with a BRANCH-PERFORM sharing a strict expr with the mutual call declines cleanly (adv-69 rw4 sub-face)
 todo	a recursive nested-op performer whose resume-VALUE reads the inner state around the outer perform declines cleanly
 todo	a recursive scalar-walk classifies characters across a multibyte String entry arg

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5848,6 +5848,7 @@ todo	a block-wrapped OUTER-effect perform in a non-tail do-statement INSIDE a ne
 todo	a block-wrapped branch perform of the OUTER effect in a let-init INSIDE a nested handler body declines cleanly (adv-69 a4 sub-face)
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject
 todo	a constant-try helper that fails feeds the None arm's fallback into resume
+todo	a cross-handler foreign-perform op-arg into a MATCH-shaped-resume arm declines cleanly (completeness gap)
 todo	a mutually-recursive group with a BRANCH-PERFORM sharing a strict expr with the mutual call declines cleanly (adv-69 rw4 sub-face)
 todo	a recursive NEWTYPE traversal recurses on its projected recursive field
 todo	a recursive NEWTYPE-wrapped linked list folds to a scalar

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5765,6 +5765,7 @@ todo	a closure capturing a build-time host effect preserves the order of two hos
 todo	a conditional performs only the taken branch's effect — else
 todo	a conditional performs only the taken branch's effect — then
 todo	a constant-try helper that fails feeds the None arm's fallback into resume
+todo	a cross-handler foreign-perform op-arg into a MATCH-shaped-resume arm declines cleanly (completeness gap)
 todo	a deep trie built BETWEEN two host calls reads correctly after the second
 todo	a delegated effect performed in a closure passed to a HOF is reached and fires
 todo	a delegated effect performed inside an intra-program handler

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -4665,6 +4665,33 @@
             (export main)))
   (call   main (: 100 Int64)) (output (: 4950 Int64)))
 
+(case "a cross-handler foreign-perform op-arg into a MATCH-shaped-resume arm declines cleanly (completeness gap)"
+  (doc    "The completeness boundary where the op-arg lift meets the match-shaped-resume peel (breaker nv1f).
+           The inner `B.cut`'s ARG is a CROSS-HANDLER foreign perform `(A.src)` AND B's arm RESUMES through a
+           MATCH on a slice of its param — `(cut (b) t (match (Bytes.slice b 1 2) ((Some w) (resume w t)) ((None
+           _x) (resume (Bytes.of (list)) t))))`. Each half folds ALONE: a cross-handler foreign-perform arg with
+           a BARE-resume arm folds (nv1c/nv1d: `(cut (b) t (resume (Bytes.len b) t))`), and a match-shaped-resume
+           arm with a LITERAL arg folds (nv1e). But their CONJUNCTION declines: `b` is single-use so `(A.src)`
+           substitutes directly into the match SCRUTINEE `(Bytes.slice (A.src) 1 2)`, and threading a foreign
+           perform embedded in a peeled match-value's scrutinee across the outer `A` fold is not yet composed.
+           DECLINE, never a wrong value (an honest not-yet-reducible todo). When the op-arg-lift × match-peel
+           composition lands, this FOLDS to 14: `A.src` = bytes[20,30,40]; `Bytes.slice … 1 2` = [30,40] (Some);
+           `B.cut` resumes that view; `Bytes.len` = 2; `(+ 2 12)` = 14. Flip this todo→14 then.")
+  (input  (do
+            (effect A (op src (-> Unit Bytes)))
+            (effect B (op cut (-> Bytes Bytes)))
+            (def (main (: a Int64))
+              (handle A 0
+                ((src (u) s (resume (Bytes.of (list 20 30 40)) s)))
+                (handle B 0
+                  ((cut (b) t
+                    (match (Bytes.slice b 1 2)
+                      ((Some w) (resume w t))
+                      ((None _x) (resume (Bytes.of (list)) t)))))
+                  (+ (Bytes.len (B.cut (A.src))) a))))
+            (export main)))
+  (call   main (: 12 Int64)) (output (: 14 Int64)))
+
 (case "a BRANCHING tree walk performs once per leaf at 200-leaf scale"
   (doc    "Branching self-recursion × per-node performs (the recursive-perform pins are all LINEAR loops):
            `walk` recurses into BOTH children of a user-sum tree (`(+ (walk a) (walk b))`), each LEAF


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref b0141b94b, lane baseline). Auto-merge armed; pr-sync's schedule-pass reaps on green.