### PR TITLE
rcdzc(wasm): fix Bytes.slice scratch-alias miscompile (sibling of #2311) — operand base aliased the looked-up-Bytes retain slot (i32/i64)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
@@ -9430,11 +9430,22 @@ fn emit(
             scratch_ty.insert(start_slot, ValType::I64);
             scratch_ty.insert(len_slot, ValType::I64);
             scratch_ty.insert(bytelen_slot, ValType::I64);
-            emit(db, bytes, slots, base + 4, high, scratch_ty, layout, out)?; // [bytes]
+            // Each operand emits at a base ABOVE both `base + 4` (the four reserved slots) AND every scratch
+            // slot a PRIOR operand's own emit consumed — `(*high).max(base + 4)`, NOT a bare `base + 4`. A
+            // `bytes` operand that is a dup-site `Core::SumPayload` (the collection-lookup shape: `(match
+            // (Map.lookup …) ((Some bs) (Bytes.slice bs …)))`) floats its Perceus retain child into a slot at
+            // `*high` typed I32; a bare `base + 4` base then lets a following perform-threaded i64 `start`/`len`
+            // materialize into that SAME index, and a wasm local has ONE type function-wide → i32/i64 collision
+            // → an invalid module (the #2311 CallClosure scratch-alias, here at `bytes-slice`). Threading the
+            // base past `*high` keeps each operand's scratch DISJOINT.
+            let opnd_base = (*high).max(base + 4);
+            emit(db, bytes, slots, opnd_base, high, scratch_ty, layout, out)?; // [bytes]
             out.push(Lir::LocalSet(bytes_slot));
-            emit(db, start, slots, base + 4, high, scratch_ty, layout, out)?; // [start:i64]
+            let opnd_base = (*high).max(base + 4);
+            emit(db, start, slots, opnd_base, high, scratch_ty, layout, out)?; // [start:i64]
             out.push(Lir::LocalSet(start_slot));
-            emit(db, len, slots, base + 4, high, scratch_ty, layout, out)?; // [len:i64]
+            let opnd_base = (*high).max(base + 4);
+            emit(db, len, slots, opnd_base, high, scratch_ty, layout, out)?; // [len:i64]
             out.push(Lir::LocalSet(len_slot));
             // Materialize the byte-count ONCE (i64, u32-extended — read three times below).
             out.push(Lir::LocalGet(bytes_slot));

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -5862,3 +5862,4 @@ todo	expect traps on the absent case of a runtime optional
 todo	read of malformed text is a coded reject, not a wrong value
 todo	two runtime String entry args compare by content including multibyte
 pass	a closure looked up from a map by a perform result, applied to a perform result, threads through call_indirect
+pass	Bytes.slice of a map-looked-up Bytes with perform-threaded start and len threads without a scratch collision

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5862,3 +5862,4 @@ todo	expect traps on the absent case of a runtime optional
 todo	read of malformed text is a coded reject, not a wrong value
 todo	two adapter records with different state types drive a take-while fold in one program
 pass	a closure looked up from a map by a perform result, applied to a perform result, threads through call_indirect
+pass	Bytes.slice of a map-looked-up Bytes with perform-threaded start and len threads without a scratch collision

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5862,3 +5862,4 @@ todo	two nested recursive const-closure drivers (filter under fold) emit valid w
 todo	two same-unit Qty host results combine guest-side as a same-dimension add
 todo	two specializations of one driver on different closures do not collide in the spec memo
 pass	a closure looked up from a map by a perform result, applied to a perform result, threads through call_indirect
+pass	Bytes.slice of a map-looked-up Bytes with perform-threaded start and len threads without a scratch collision

--- a/spec/semantics/10-bytes.sexp
+++ b/spec/semantics/10-bytes.sexp
@@ -2012,3 +2012,34 @@
                              (* 10000 (if (< ab abc) 1 0)))))))))
             (export main)))
   (call   main (: 65 Int64)) (output (: 10321 Int64)))
+
+(case "Bytes.slice of a map-looked-up Bytes with perform-threaded start and len threads without a scratch collision"
+  (doc    "A `Bytes.slice` whose BYTES operand is looked up from a Map (an Option-returning lookup yielding a
+           Bytes) and whose START/LEN are perform results, under a resumptive handler. Pins a wasm-codegen
+           miscompile (v-wasm-opt-scouted, breaker-witnessed, 2026-08-05 — the sibling of the #2311
+           closure-CallIndirect scratch-alias): the looked-up-Bytes operand is a dup-site `Core::SumPayload`
+           whose Perceus retain floats its cell into a scratch slot typed i32; the `bytes-slice` emit ran all
+           three operands (bytes i32, start/len i64) at the SAME base (`base + 4`), so a perform-threaded i64
+           start/len materialized into that i32 slot → an i32/i64 collision (a wasm local has one type
+           function-wide) → `bytes-slice`'s function failed to validate (invalid module). Fix: each operand
+           emits at `(*high).max(base + 4)`, disjoint from the retain slot. table[1] = [10,20,30,40,50,60,70,80];
+           the `next` handler threads s=1,2 so start=1,len=2 → slice = [20,30], len 2, first byte 20 → 10·2+20 =
+           40. Correct on rust throughout (fold sound; the defect was purely wasm scratch allocation).")
+  (input  (do
+            (effect St (op next (-> Unit Int64)))
+            (def (main (: n Int64))
+              (do
+                (def table (Map.insert Map.empty 1 (Bytes.of (list 10 20 30 40 50 60 70 80))))
+                (handle St n
+                  ((next (u) s (resume s (+ s 1))))
+                  (match (Map.lookup table 1)
+                    ((Some bs)
+                      (match (Bytes.slice bs (St.next) (St.next))
+                        ((Some sl) (+ (* 10 (Bytes.len sl))
+                                      (match (Bytes.at sl 0)
+                                        ((Some b) (Int64.of b))
+                                        ((None _u) -1))))
+                        ((None _u) -100)))
+                    ((None _u) -200)))))
+            (export main)))
+  (call   main (: 1 Int64)) (output (: 40 Int64)))


### PR DESCRIPTION
Candidate PR for v-runtime's merge-request (ref a43ed5031, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.