### PR TITLE
corpus(14-effects): tighten nv1f todo-witness doc — drop the stale-prone .gate-baseline* file naming (#2327 Copilot c1 follow-on)

### DIFF
--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -4763,7 +4763,7 @@
            DECLINE, never a wrong value (an honest not-yet-reducible todo). When the op-arg-lift × match-peel
            composition lands, this FOLDS to 14: `A.src` = bytes[20,30,40]; `Bytes.slice … 1 2` = [30,40] (Some);
            `B.cut` resumes that view; `Bytes.len` = 2; `(+ 2 12)` = 14. The output is already pinned (14); when
-           the composition lands, flip this case's BASELINE entry todo→pass across all three .gate-baseline* files.")
+           the composition lands, flip this case's baseline entry todo→pass.")
   (input  (do
             (effect A (op src (-> Unit Bytes)))
             (effect B (op cut (-> Bytes Bytes)))


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref b2c016938, lane corpus). Auto-merge armed; pr-sync's schedule-pass reaps on green.