### PR TITLE
ci(nix): export REDUCER_CADENZA_B2_COMPONENT in cdz-agent-host-native — fixes the latent half-wired-env red (#2315 b2 full-agent-loop E2E)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -856,6 +856,16 @@
             # <sha256hex>.wasm blobs + runtime.toml), same resolution as the b1/b2 kernel e2es. Distinct var from
             # CDZ_REDUCER_COMPONENT (the Rust reducerGuest above); both set — the genesis test keys on GENESIS_REDUCER_COMPONENT.
             export GENESIS_REDUCER_COMPONENT="${reducerCadenzaGenesis}"
+            # #2315 full-agent-loop E2E: host.rs real_effect_reducer_runs_a_full_http_turn_through_the_host
+            # drives the real effect-emitting reducer_b2 through the host's async apply_handle_lowered (one Http
+            # turn). It env-gates on REDUCER_CADENZA_B2_COMPONENT + CDZ_STORE — and its shared helper
+            # (require_reducer_and_store_or_skip, #2320) PANICS on a HALF-wired env (exactly one set). Since I
+            # set CDZ_STORE (for genesis above), I MUST also set REDUCER_CADENZA_B2_COMPONENT or that guard fires
+            # ("CDZ_STORE is set but REDUCER_CADENZA_B2_COMPONENT is not — nothing to drive"). Setting it makes
+            # the #2315 turn RUN (not skip, not panic) — same reducerCadenzaB2 + CDZ_STORE transitive-nfc
+            # resolution as the b2 kernel e2e. (The hand-wired CI job sets neither → clean-skips this test; the
+            # nix twin runs it, so the twin is a strict superset.)
+            export REDUCER_CADENZA_B2_COMPONENT="${reducerCadenzaB2}"
             export CDZ_STORE="${componentStore}"
             cargo test --locked
             cargo clippy --all-targets --locked -- -D warnings


### PR DESCRIPTION
Candidate PR for v-nix's merge-request (ref e3213ce36f3cc52321719f58099d8bb9c00bfc73, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.