### PR TITLE
rcdzc: fix ag5 false-CDZ0101 — pin reused guarded-match arm bodies before reparent, drop the blanket forget that stranded fold-synth #seed

### DIFF
--- a/implementation/seed/crates/rcdzc/src/lower.rs
+++ b/implementation/seed/crates/rcdzc/src/lower.rs
@@ -5096,7 +5096,26 @@ fn lower_match(db: &mut Db, scrutinee: StructId, arms: &[(StructId, StructId)]) 
                 "a guarded scalar match needs an unguarded wildcard tail",
             ));
         };
+        // ag5 (breaker): PIN the reused arm bodies' + guard-conds' resolution NOW, while they STILL have
+        // their intact lexical ancestry — BEFORE the fold below `push_list`-reparents them (which detaches
+        // them from any enclosing binder). This establishes the invariant the desugar's skip coverage
+        // assumes ("the reused arm bodies resolved + memoized BEFORE the desugar"). A load-time user body
+        // already satisfies it; but the effects fold mints FRESH synth `#seed`/`#cv` references at LOWER
+        // time whose binder is a fold-synth `(let ((#seed n)) …)` ABOVE the match — never memoized, so once
+        // reparented their `#seed` ref can't reach that let → false CDZ0101. Pinning here (ancestry intact)
+        // resolves each to a `Ref` that survives the reparent via the resolve memo (the `apply_lambda`
+        // idiom, resolve.rs:206). Verified at entry: `#seed`'s chain reaches the fold `#seed` let and
+        // resolves to `Ref`. The `(let ((w scrutinee)) …)` wrap below binds `w` to the SAME scrutinee that
+        // its guard-cond resolution already names, so the pinned `w` resolution stays valid across the wrap.
+        for &(pat, body) in arms[..tail_ix].iter() {
+            let cond = db.ast.as_form(pat, "guard").and_then(|g| g.get(1).copied());
+            crate::resolve::resolve_subtree(db, body);
+            if let Some(g) = cond {
+                crate::resolve::resolve_subtree(db, g);
+            }
+        }
         let mut else_node = arms[tail_ix].1;
+        crate::resolve::resolve_subtree(db, else_node);
         // Fold the leading arms (0..tail_ix) from LAST backward into nested `if`s.
         for &(pat, body) in arms[..tail_ix].iter().rev() {
             let (inner_pat, guard) = match db.ast.as_form(pat, "guard") {
@@ -5134,14 +5153,15 @@ fn lower_match(db: &mut Db, scrutinee: StructId, arms: &[(StructId, StructId)]) 
                         let pair = db.push_list(vec![binder, scrutinee]);
                         let bindings = db.push_list(vec![pair]);
                         let wrapped = db.push_list(vec![let_head, bindings, then_branch]);
-                        // The reused guard-cond + body carry a STALE `resolved` column + scope-skip from
-                        // their original `(guard …)` position (where `w` resolved to the scrutinee via
-                        // `guard_cond_binds`, now detached). `forget_subtree` clears that so, under the new
-                        // `(let ((w scrutinee)) …)`, `w` re-resolves to the `let` binder and every OTHER
-                        // name (`n`, an enclosing param the cond reads) re-resolves up the live chain — the
-                        // same re-parent-then-forget discipline the fold paths use. Binding-aware skip
-                        // (`into_subtree`, not `pass_through`) so inner refs land on the `let` in O(1).
-                        crate::resolve::forget_subtree(db, wrapped);
+                        // `w` was PINNED at desugar entry (above) via `guard_cond_binds` to the SAME
+                        // scrutinee occurrence this new `(let ((w scrutinee)) …)` binds — so its memoized
+                        // `Ref` is already correct and survives the reparent; likewise the fold-synth
+                        // `#seed`/`#cv` refs were pinned to their fold-let binders. So we must NOT
+                        // `forget_subtree(wrapped)` here: a blanket forget would clear those correct pins,
+                        // and the detached `wrapped` (parent `None`) can no longer re-resolve a `#seed` whose
+                        // binder is an enclosing fold let → the ag5 false CDZ0101. Keep the pins; just cover
+                        // the fresh synth nodes with binding-aware skip (the `(let …)`/`if` chain) so a name
+                        // NOT already pinned still hops O(1) to the nearest candidate.
                         db.extend_scope_skip_into_subtree(wrapped);
                         wrapped
                     }

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -10055,6 +10055,49 @@ fn a_closure_capturing_a_value_computed_under_a_handler_may_escape() {
     );
 }
 
+/// A compiler-synthesized `#seed` binder carried through a guard-desugared match FALLBACK arm must RESOLVE,
+/// not false-CDZ0101 (breaker ag5). CONJUNCT: [guard-desugared scalar match] × [perform-result SCRUTINEE] ×
+/// [perform in the non-guard FALLBACK arm]. The effects fold lifts the non-constant state seed as nested
+/// synth lets `(let ((#seed n)) (let ((#cv …)) (match …)))`; those lets are genuine ancestors of the arm
+/// bodies at fold exit. But `lower_match`'s guarded-scalar-match desugar rebuilds the arms into an if-chain
+/// via `push_list`, DETACHING each reused body from its `#seed`-let ancestor, and the guarded-wildcard
+/// `w`-path then `forget_subtree`'d the whole `wrapped` — clearing the fold-synth `#seed`/`#cv` resolutions
+/// which the DETACHED tree can no longer recover → false "unbound `#seed`", both backends. FIX: PIN the
+/// reused arm bodies' + guard-conds' resolution at desugar ENTRY (while their `#seed`-let ancestry is
+/// intact → each `#seed` resolves to a `Ref` that survives the reparent via the resolve memo), and DROP the
+/// now-harmful blanket `forget_subtree` in the `w`-path (the pinned `w`/`#seed` resolutions are already
+/// correct). `roll` threads state `s`, resumes `s+3`; seed 5 → outer roll=5 (≤6 → fallback), inner roll=8 →
+/// `(* 10 8) + 5 = 85`.
+#[test]
+fn a_synth_seed_through_a_guard_desugared_match_fallback_resolves_not_false_cdz0101() {
+    use crate::testkit::parse;
+    use wasmtime::component::Val;
+    let src = "(do (effect St (op roll (-> Unit Int64))) \
+               (def (main (: n Int64)) \
+                 (handle St n ((roll (u) s (resume s (+ s 3)))) \
+                   (match (St.roll) ((guard v (> v 6)) (* v 100)) (v (+ (* 10 (St.roll)) v))))) \
+               (export main))";
+    let bytes = compile_component(&crate::codec::encode(&parse(src))).expect(
+        "a synth #seed through a guard-desugared match fallback resolves (no false CDZ0101)",
+    );
+    let got: i64 = run_returns_with(&bytes, "main", &[Val::S64(5)]);
+    assert_eq!(
+        got, 85,
+        "seed 5: outer roll=5 (≤6 → fallback), inner roll=8 → (* 10 8)+5 = 85"
+    );
+    // DISCRIMINATOR CONTROL: the same shape with a USER let-name resolved fine before the fix — pin it so
+    // the entry-pin + dropped-forget never regresses the user-name path.
+    let user = "(module m (def (main (: n Int64)) \
+                   (let ((x n)) (match x ((guard v (> v 6)) (* v 100)) (v (+ (* 10 x) v))))) (export main))";
+    let ub = compile_component(&crate::codec::encode(&parse(user)))
+        .expect("the user-name discriminator resolves");
+    let ug: i64 = run_returns_with(&ub, "main", &[Val::S64(5)]);
+    assert_eq!(
+        ug, 55,
+        "user-name control: x=5 (≤6 → fallback) → (* 10 5)+5 = 55"
+    );
+}
+
 /// The UNSOUND TWIN of discharge-then-capture MUST stay rejected: a closure whose BODY performs the handled
 /// effect and ESCAPES the handle — `(handle St k (arm) (fn (x) (+ x (St.get))))` applied outside — runs the
 /// perform on OUTSIDE-application (out of the handler's dynamic extent), so it has no home → CDZ0401. Pins


### PR DESCRIPTION
Candidate PR for v-inference's merge-request (ref 7bb1dc56e08c38cc58b4ff2b1069e01f428fa42c, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.