### PR TITLE
docs(effects): align the sy1 decline-witness doc to the landed arm-shape-uniformity framing (breaker #2349)

### DIFF
--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -2221,19 +2221,18 @@
   (call   main (: 5 Int64)) (output (: 2050 Int64)))
 
 (case "a two-site arm with a second op that REPLACES the state mid-chain declines cleanly"
-  (doc    "The decline BOUNDARY of the served two-site family (breaker sy1). ts1 above FOLDS because its
-           second op (`tally`) READS the threaded state; here the second op (`flip`) REPLACES the handler
-           state with a DIFFERENT value — `(flip (u) s (resume 0 (Symbol.of \"quiet\")))` — a mode-switch
-           dispatched BETWEEN the two `emit` performs. breaker's position-sharpened rule is a PREFIX rule
-           (not merely interleaved-between): the two-site arm's performs must form a CONTIGUOUS PREFIX of
-           the handler's dispatch sequence; any different-op dispatch BEFORE or between them breaks the
-           two-hole refold — only TRAILING second ops are served (every served case sg2/ts1/rp5/ic1 has the
-           two-site performs first; the leading control ic2 `(+ (St.peek) (St.sift 20))` also declines).
-           The two-hole refold cannot yet thread a DIFFERENT op through the middle of a multi-site
-           continuation chain. This is an HONEST decline (a fold-capability gap, never a wrong value), NOT
-           the ts1/ag5 false-CDZ0101 orphan (those were bugs, fixed). The eventual fold: emit(5) sees `loud`
-           → 5·100 = 500, flip sets state `quiet` and resumes 0, emit(3) sees `quiet` → 3 → 500 + 0 + 3 =
-           503. Pins the boundary as a clean todo, not a leak.")
+  (doc    "The decline BOUNDARY of the served family (breaker sy1). The rule is arm-shape UNIFORMITY at the
+           handler's frame: multi-site arms mix freely (any dispatch order), and a single-site arm among
+           multi-site performs declines except trailing. Here `emit` is a two-site (multi-site) arm but the
+           second op `flip` — `(flip (u) s (resume 0 (Symbol.of \"quiet\")))` — is SINGLE-site (it resumes
+           once, replacing the state with a different value), dispatched BETWEEN the two `emit` performs, so
+           the refold must mix a one-hole and a two-hole rebuild mid-chain and declines. (Making `flip`
+           itself multi-site would serve the same order — confirmed by re-derivation.) The two-hole refold
+           cannot yet thread a non-uniform (single-site) op through the middle of a multi-site continuation
+           chain. This is an HONEST decline (a fold-capability gap, never a wrong value), NOT the ts1/ag5
+           false-CDZ0101 orphan (those were bugs, fixed). The eventual fold: emit(5) sees `loud` → 5·100 =
+           500, flip sets state `quiet` and resumes 0, emit(3) sees `quiet` → 3 → 500 + 0 + 3 = 503. Pins
+           the boundary as a clean todo, not a leak.")
   (input  (do
             (effect St (op emit (-> Int64 Int64)) (op flip (-> Unit Int64)))
             (def (main (: n Int64))


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 293639be2, lane corpus). Auto-merge armed; pr-sync's schedule-pass reaps on green.