### PR TITLE
cdz test: make ALL 6 store_present() guards HASH-aware — fixes the REQUIRED test(macos-latest) trunk-red

### DIFF
--- a/fleet/roster.json
+++ b/fleet/roster.json
@@ -40,7 +40,6 @@
     { "name": "tracker", "role": "tracker", "model": "opus", "effort": "high", "interval": "15m" },
     { "name": "v-value-facts", "role": "vertical", "vertical": "value-facts", "area": "rcdzc", "model": "opus", "effort": "high", "interval": "30m" },
     { "name": "v-agent-harness-host", "role": "vertical", "vertical": "agent-harness-host", "area": "agent-harness", "model": "opus", "effort": "high", "interval": "10m" },
-    { "name": "v-nix", "role": "vertical", "vertical": "nix-flake-pipeline", "area": "xtask", "model": "opus", "effort": "high", "interval": "30m" },
-    { "name": "v-harness-bootstrap", "role": "vertical", "vertical": "harness-bootstrap", "area": "rcdzc", "model": "opus", "effort": "high", "interval": "30m" }
+    { "name": "v-nix", "role": "vertical", "vertical": "nix-flake-pipeline", "area": "xtask", "model": "opus", "effort": "high", "interval": "30m" }
   ]
 }

--- a/implementation/seed/crates/cdz/tests/normalize_cli.rs
+++ b/implementation/seed/crates/cdz/tests/normalize_cli.rs
@@ -48,26 +48,23 @@ fn compile_and_run(path: &str, wasm: &str) -> String {
 /// `cargo xtask build` — so the compile+run value check must SKIP there). Same resolution as the
 /// runtime resolver; mirrors `run_ml_cli`/`run_emitted_cli`'s guard.
 fn store_present() -> bool {
-    if let Ok(dir) = std::env::var("CADENZA_STORE") {
-        return std::path::Path::new(&dir).is_dir()
-            && std::fs::read_dir(&dir)
-                .map(|mut e| e.next().is_some())
-                .unwrap_or(false);
-    }
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_cdz"))
-        .parent()
-        .and_then(|d| d.parent())
-        .map(|t| {
-            // NON-EMPTY, not just present: CI's rust-cache can restore an empty `<target>/cadenza-store`
-            // (no `cargo xtask build` ran), and a bare `.exists()` then falsely reports the store present,
-            // so a runtime-driving test runs storeless and fails "no runtime … refusing to run". Match the
-            // `CADENZA_STORE` branch above (non-empty) so an empty dir reads as absent and the test SKIPS.
-            let store = t.join("cadenza-store");
-            store.is_dir()
-                && std::fs::read_dir(&store)
-                    .map(|mut e| e.next().is_some())
-                    .unwrap_or(false)
-        })
+    // HASH-AWARE: the store must hold the CURRENT runtime — `<store>/<REQUIRED_RUNTIME_HASH>.wasm` is a
+    // file — NOT just be a non-empty dir. A NON-EMPTY-only check passed on a STALE rust-cached store (an
+    // OLDER runtime hash after a hash bump) → the runtime-driving test ran → the resolver missed the
+    // current hash → "no runtime of content address … refusing to run" red. Checking the exact `<hash>.wasm`
+    // makes a stale/empty store read as absent so the test SKIPS (as in the storeless CI job, where xtask
+    // sets `CADENZA_STORE=<empty temp dir>`).
+    let required = rcdzc::backend::wasm::runtime_abi::REQUIRED_RUNTIME_HASH;
+    let store_dir = std::env::var_os("CADENZA_STORE")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::path::PathBuf::from(env!("CARGO_BIN_EXE_cdz"))
+                .parent()
+                .and_then(|d| d.parent())
+                .map(|t| t.join("cadenza-store"))
+        });
+    store_dir
+        .map(|d| d.join(format!("{required}.wasm")).is_file())
         .unwrap_or(false)
 }
 

--- a/implementation/seed/crates/cdz/tests/peer_list_handle_cli.rs
+++ b/implementation/seed/crates/cdz/tests/peer_list_handle_cli.rs
@@ -29,28 +29,27 @@ fn cdz() -> &'static str {
 /// runtime resolver does (`CADENZA_STORE` env first, else `<target>/cadenza-store`), so this guard
 /// AGREES with the storeless-rerun mechanism (which sets `CADENZA_STORE` to an empty temp dir).
 /// Mirrors the `store_present()` guard in `run_emitted_cli.rs` / `normalize_cli.rs`.
+///
+/// HASH-AWARE (not merely presence): the store must hold the CURRENT runtime, `<store>/<hash>.wasm` for
+/// `REQUIRED_RUNTIME_HASH` — NOT just be a non-empty dir. A runner's rust-cache can restore a STALE
+/// `cadenza-store` holding an OLDER runtime hash (after a runtime-hash bump with no fresh `cargo xtask
+/// build`); a presence/non-empty check passes on that stale store, the peer run then resolves the CURRENT
+/// hash, misses it, and fails "no runtime of content address <hash> … refusing to run" (this red the
+/// REQUIRED `test (macos-latest)` job trunk-wide). Checking the exact `<hash>.wasm` makes a stale store
+/// read as absent → the test SKIPS (its documented storeless behavior) instead of running against the
+/// wrong/missing runtime.
 fn store_present() -> bool {
-    if let Ok(dir) = std::env::var("CADENZA_STORE") {
-        return std::path::Path::new(&dir).is_dir()
-            && std::fs::read_dir(&dir)
-                .map(|mut e| e.next().is_some())
-                .unwrap_or(false);
-    }
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_cdz"))
-        .parent()
-        .and_then(|d| d.parent())
-        .map(|t| {
-            // Must be NON-EMPTY, not merely present: CI's rust-cache can restore an empty
-            // `target/cadenza-store` dir (no `cargo xtask build` ran), and a bare `.exists()`
-            // then falsely reports the store present → the peer run executes storeless and fails
-            // "no runtime of content address … refusing to run". Match the `CADENZA_STORE` branch
-            // above (non-empty check) so an empty dir reads as absent and the run SKIPS.
-            let store = t.join("cadenza-store");
-            store.is_dir()
-                && std::fs::read_dir(&store)
-                    .map(|mut e| e.next().is_some())
-                    .unwrap_or(false)
-        })
+    let required = rcdzc::backend::wasm::runtime_abi::REQUIRED_RUNTIME_HASH;
+    let store_dir = std::env::var_os("CADENZA_STORE")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::path::PathBuf::from(env!("CARGO_BIN_EXE_cdz"))
+                .parent()
+                .and_then(|d| d.parent())
+                .map(|t| t.join("cadenza-store"))
+        });
+    store_dir
+        .map(|d| d.join(format!("{required}.wasm")).is_file())
         .unwrap_or(false)
 }
 

--- a/implementation/seed/crates/cdz/tests/run_emitted_cli.rs
+++ b/implementation/seed/crates/cdz/tests/run_emitted_cli.rs
@@ -92,32 +92,25 @@ fn run_emitted_agrees_with_run_ml_the_interpret_oracle() {
 /// out-of-subset program traps "no runtime in store" + exits non-zero storeless. Skip when absent; the
 /// store-having `gate` + `@test suites` jobs exercise it fully. Mirrors `test_manifest_cli`'s guard.
 fn store_present() -> bool {
-    // Resolve the store dir the SAME way the runtime resolver does (`CADENZA_STORE` first, else the
-    // physical `<target>/cadenza-store`), so this guard AGREES with a storeless rerun's mechanism: xtask's
-    // storeless-CI rerun sets `CADENZA_STORE=<empty temp dir>`, and this guard must then report ABSENT so
-    // the runtime-driving test SKIPS — exactly as it does in the real storeless CI job. Checking only the
-    // physical dir would ignore that env and wrongly report PRESENT (the physical store still exists),
-    // running the test → the resolver finds no runtime → a false-positive red.
-    if let Ok(dir) = std::env::var("CADENZA_STORE") {
-        return std::path::Path::new(&dir).is_dir()
-            && std::fs::read_dir(&dir)
-                .map(|mut e| e.next().is_some())
-                .unwrap_or(false);
-    }
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_cdz"))
-        .parent()
-        .and_then(|d| d.parent())
-        .map(|t| {
-            // NON-EMPTY, not just present: CI's rust-cache can restore an empty `<target>/cadenza-store`
-            // (no `cargo xtask build` ran), and a bare `.exists()` then falsely reports the store present,
-            // so a runtime-driving test runs storeless and fails "no runtime … refusing to run". Match the
-            // `CADENZA_STORE` branch above (non-empty) so an empty dir reads as absent and the test SKIPS.
-            let store = t.join("cadenza-store");
-            store.is_dir()
-                && std::fs::read_dir(&store)
-                    .map(|mut e| e.next().is_some())
-                    .unwrap_or(false)
-        })
+    // HASH-AWARE: the store must hold the CURRENT runtime — `<store>/<REQUIRED_RUNTIME_HASH>.wasm` is a
+    // file — NOT just be a non-empty dir. Resolve the store dir the SAME way the runtime resolver does
+    // (`CADENZA_STORE` first, else `<target>/cadenza-store`). A NON-EMPTY-only check passed on a STALE
+    // rust-cached store (an OLDER runtime hash after a hash bump with no fresh `cargo xtask build`) → the
+    // runtime-driving test ran → the resolver missed the current hash → "no runtime of content address …
+    // refusing to run" red (this red the REQUIRED `test (macos-latest)` job trunk-wide). Checking the exact
+    // `<hash>.wasm` makes a stale/empty store read as absent so the test SKIPS — as it does in the storeless
+    // CI job (where xtask sets `CADENZA_STORE=<empty temp dir>`).
+    let required = rcdzc::backend::wasm::runtime_abi::REQUIRED_RUNTIME_HASH;
+    let store_dir = std::env::var_os("CADENZA_STORE")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::path::PathBuf::from(env!("CARGO_BIN_EXE_cdz"))
+                .parent()
+                .and_then(|d| d.parent())
+                .map(|t| t.join("cadenza-store"))
+        });
+    store_dir
+        .map(|d| d.join(format!("{required}.wasm")).is_file())
         .unwrap_or(false)
 }
 

--- a/implementation/seed/crates/cdz/tests/run_ml_cli.rs
+++ b/implementation/seed/crates/cdz/tests/run_ml_cli.rs
@@ -30,30 +30,23 @@ fn run(args: &[&str]) -> (bool, String, String) {
 /// storeless it `declined`s (or errors) instead. Skip the VALUE assertion when absent; the store-having
 /// `gate` + `@test suites` jobs exercise it fully. Mirrors `run_emitted_cli`/`test_manifest_cli`'s guard.
 fn store_present() -> bool {
-    // Resolve the store dir the SAME way the runtime resolver does (`CADENZA_STORE` first, else the
-    // physical `<target>/cadenza-store`), so this guard AGREES with the storeless-rerun mechanism: xtask's
-    // storeless-CI rerun sets `CADENZA_STORE=<empty temp dir>`, and this guard must then report ABSENT so
-    // the runtime-driving value-check SKIPS — exactly as in the real storeless CI job.
-    if let Ok(dir) = std::env::var("CADENZA_STORE") {
-        return std::path::Path::new(&dir).is_dir()
-            && std::fs::read_dir(&dir)
-                .map(|mut e| e.next().is_some())
-                .unwrap_or(false);
-    }
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_cdz"))
-        .parent()
-        .and_then(|d| d.parent())
-        .map(|t| {
-            // NON-EMPTY, not just present: CI's rust-cache can restore an empty `<target>/cadenza-store`
-            // (no `cargo xtask build` ran), and a bare `.exists()` then falsely reports the store present,
-            // so a runtime-driving test runs storeless and fails "no runtime … refusing to run". Match the
-            // `CADENZA_STORE` branch above (non-empty) so an empty dir reads as absent and the test SKIPS.
-            let store = t.join("cadenza-store");
-            store.is_dir()
-                && std::fs::read_dir(&store)
-                    .map(|mut e| e.next().is_some())
-                    .unwrap_or(false)
-        })
+    // HASH-AWARE: the store must hold the CURRENT runtime — `<store>/<REQUIRED_RUNTIME_HASH>.wasm` is a
+    // file — NOT just be a non-empty dir. A NON-EMPTY-only check passed on a STALE rust-cached store (an
+    // OLDER runtime hash after a hash bump) → the runtime-driving value-check ran → the resolver missed the
+    // current hash → "no runtime of content address … refusing to run" red. Checking the exact `<hash>.wasm`
+    // makes a stale/empty store read as absent so the check SKIPS (as in the storeless CI job, where xtask
+    // sets `CADENZA_STORE=<empty temp dir>`).
+    let required = rcdzc::backend::wasm::runtime_abi::REQUIRED_RUNTIME_HASH;
+    let store_dir = std::env::var_os("CADENZA_STORE")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::path::PathBuf::from(env!("CARGO_BIN_EXE_cdz"))
+                .parent()
+                .and_then(|d| d.parent())
+                .map(|t| t.join("cadenza-store"))
+        });
+    store_dir
+        .map(|d| d.join(format!("{required}.wasm")).is_file())
         .unwrap_or(false)
 }
 

--- a/implementation/seed/crates/cdz/tests/test_manifest_cli.rs
+++ b/implementation/seed/crates/cdz/tests/test_manifest_cli.rs
@@ -33,33 +33,23 @@ fn run(args: &[&str]) -> (bool, String, String) {
 /// still exercise it fully. This mirrors the `let Some(store) else return` guard the heap-value CLI
 /// tests already use.
 fn store_present() -> bool {
-    // Resolve the store dir the SAME way the runtime resolver does (`CADENZA_STORE` first, else the
-    // physical `<target>/cadenza-store`), so this guard AGREES with a storeless rerun's mechanism: xtask's
-    // storeless-CI rerun sets `CADENZA_STORE=<empty temp dir>`, and this guard must then report ABSENT so
-    // the runtime-driving test SKIPS — exactly as it does in the real storeless CI job. Checking only the
-    // physical dir would ignore that env and wrongly report PRESENT (the physical store still exists),
-    // running the test → the resolver finds no runtime → a false-positive red. `CARGO_BIN_EXE_cdz` =
-    // `<target>/<profile>/cdz`; the physical store sits at `<target>/cadenza-store` (two parents up).
-    if let Ok(dir) = std::env::var("CADENZA_STORE") {
-        return std::path::Path::new(&dir).is_dir()
-            && std::fs::read_dir(&dir)
-                .map(|mut e| e.next().is_some())
-                .unwrap_or(false);
-    }
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_cdz"))
-        .parent()
-        .and_then(|d| d.parent())
-        .map(|t| {
-            // NON-EMPTY, not just present: CI's rust-cache can restore an empty `<target>/cadenza-store`
-            // (no `cargo xtask build` ran), and a bare `.exists()` then falsely reports the store present,
-            // so a runtime-driving test runs storeless and fails "no runtime … refusing to run". Match the
-            // `CADENZA_STORE` branch above (non-empty) so an empty dir reads as absent and the test SKIPS.
-            let store = t.join("cadenza-store");
-            store.is_dir()
-                && std::fs::read_dir(&store)
-                    .map(|mut e| e.next().is_some())
-                    .unwrap_or(false)
-        })
+    // HASH-AWARE: the store must hold the CURRENT runtime — `<store>/<REQUIRED_RUNTIME_HASH>.wasm` is a
+    // file — NOT just be a non-empty dir. A NON-EMPTY-only check passed on a STALE rust-cached store (an
+    // OLDER runtime hash after a hash bump) → the runtime-driving test ran → the resolver missed the
+    // current hash → "no runtime of content address … refusing to run" red. Checking the exact `<hash>.wasm`
+    // makes a stale/empty store read as absent so the test SKIPS (as in the storeless CI job, where xtask
+    // sets `CADENZA_STORE=<empty temp dir>`).
+    let required = rcdzc::backend::wasm::runtime_abi::REQUIRED_RUNTIME_HASH;
+    let store_dir = std::env::var_os("CADENZA_STORE")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::path::PathBuf::from(env!("CARGO_BIN_EXE_cdz"))
+                .parent()
+                .and_then(|d| d.parent())
+                .map(|t| t.join("cadenza-store"))
+        });
+    store_dir
+        .map(|d| d.join(format!("{required}.wasm")).is_file())
         .unwrap_or(false)
 }
 

--- a/implementation/seed/crates/cdz/tests/test_per_file_cli.rs
+++ b/implementation/seed/crates/cdz/tests/test_per_file_cli.rs
@@ -23,26 +23,22 @@ fn cdz() -> &'static str {
 /// AGREES with the storeless-rerun mechanism (which sets `CADENZA_STORE` to an empty temp dir).
 /// Mirrors the `store_present()` guard in `run_emitted_cli.rs` / `peer_list_handle_cli.rs`.
 fn store_present() -> bool {
-    if let Ok(dir) = std::env::var("CADENZA_STORE") {
-        return std::path::Path::new(&dir).is_dir()
-            && std::fs::read_dir(&dir)
-                .map(|mut e| e.next().is_some())
-                .unwrap_or(false);
-    }
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_cdz"))
-        .parent()
-        .and_then(|d| d.parent())
-        .map(|t| {
-            // NON-EMPTY, not just present: CI's rust-cache can restore an empty `<target>/cadenza-store`
-            // (no `cargo xtask build` ran), and a bare `.exists()` then falsely reports the store present,
-            // so a runtime-driving test runs storeless and fails "no runtime … refusing to run". Match the
-            // `CADENZA_STORE` branch above (non-empty) so an empty dir reads as absent and the test SKIPS.
-            let store = t.join("cadenza-store");
-            store.is_dir()
-                && std::fs::read_dir(&store)
-                    .map(|mut e| e.next().is_some())
-                    .unwrap_or(false)
-        })
+    // HASH-AWARE: the store must hold the CURRENT runtime — `<store>/<REQUIRED_RUNTIME_HASH>.wasm` is a
+    // file — NOT just be a non-empty dir. A NON-EMPTY-only check passed on a STALE rust-cached store (an
+    // OLDER runtime hash after a hash bump) → the runtime-driving test ran → the resolver missed the
+    // current hash → "no runtime of content address … refusing to run" red. Checking the exact `<hash>.wasm`
+    // makes a stale/empty store read as absent so the test SKIPS (as in the storeless CI job).
+    let required = rcdzc::backend::wasm::runtime_abi::REQUIRED_RUNTIME_HASH;
+    let store_dir = std::env::var_os("CADENZA_STORE")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::path::PathBuf::from(env!("CARGO_BIN_EXE_cdz"))
+                .parent()
+                .and_then(|d| d.parent())
+                .map(|t| t.join("cadenza-store"))
+        });
+    store_dir
+        .map(|d| d.join(format!("{required}.wasm")).is_file())
         .unwrap_or(false)
 }
 

--- a/issues/design-session-lifecycle.md
+++ b/issues/design-session-lifecycle.md
@@ -1,0 +1,48 @@
+# Vertical-ready brief: SESSION LIFECYCLES for the agent harness
+
+**Design doc (landed on trunk):** `implementation/design/DESIGN-session-lifecycle.md`
+(landed via PR #2372, trunk @ ff4476907; peer-converged with v-agent-harness + v-agent-harness-host +
+design-session-directory).
+
+**Subsystem:** `cdz-kernel` (durable events + fold guard) + `cdz-agent-host` (host executors).
+Kernel slices are `v-agent-harness`'s zone; host slices are `v-agent-harness-host`'s zone — this is a
+coordinate-not-fork feature spanning both, so the natural owner is **v-agent-harness leading, with
+v-agent-harness-host owning I3–I6 host/Cedar seams** (mirrors how the cross-session-messaging E2E was
+split). Alternatively a dedicated `v-session-lifecycle` vertical that coordinates both.
+
+**What it is:** lifecycle-CONTROL of ANOTHER session as first-class Cedar-gated effect families
+(`lifecycle/spawn|suspend|resume|terminate`), layered on the §6/§6a supervision roadmap (CloseOutcome
+BUILT; spawn/child-completed planned) and the just-landed Emit/Inbound cross-session messaging. NOT a
+duplicate of a session closing itself — this is controlling a *different* session's lifecycle, which
+does not exist today.
+
+**First increment (I1):** kernel — add `EventBody::Terminated{by, reason}` + a first-class
+`FoldRefused` guard (a session whose log tail is `Terminated` refuses further folds — a kernel guard,
+not a host convention, so a buggy host can't re-drive it). Gate: a fold-unit test (terminate → next
+fold refused) + a replay test (recovered session stays terminated). This is the smallest durable
+foundation the rest builds on; it is `v-agent-harness`'s zone.
+
+**Full increment plan (see doc §"Increment plan"):**
+- I1 kernel: `Terminated` marker + `FoldRefused` guard  ← START HERE
+- I2 kernel: `Spawned{child_hash}` edge + genesis parent-provenance (= §6 slice-2)
+- I3 host: `lifecycle/spawn` executor — INLINE registry mutation via `&mut AgentHost` (NOT
+  route-and-await; on-loop effects self-deadlock — settled with v-agent-harness-host)
+- I4 host: `lifecycle/suspend` + `lifecycle/resume` — per-session drive-eligible bool; QUEUE (not drop)
+  inbound during suspension
+- I5 host: `lifecycle/terminate` executor + a NEW PERMANENT Emit-bounce route (terminated target ≠
+  RETRYABLE closed-inbox); also drives design-session-directory's group auto-evict via the Terminated
+  signal
+- I6 Cedar: new `ResourcePredicate::DescendantOf` — tree-derived descendant authority from the durable
+  spawn-edge log (the spawn tree IS the supervision tree IS the grant; no bearer token)
+- I7 prelude: userspace supervisor library (= §6a slice-4) — one-for-one restart + retry-with-backoff
+  + restart-intensity ceiling, consuming ChildExited/FoldFailed
+
+**Cross-design contract (LOCKED with design-session-directory):** terminate → my `Terminated` event
+drives their group auto-evict (their I5); direct-name = tombstone; suspend = transparent to directory.
+
+**Remaining external dependency:** SessionId = genesis-hash-hex (v-agent-harness pinning with operator).
+Confirm the pin landed before I3 freezes the spawn effect-result type. All other host-mechanics
+questions are resolved and recorded in the doc's "Coordination points" section.
+
+**Operator context:** operator explicitly wants this designed AND implemented ("assign it to an owner
+after everything is ready"). Priority: AFTER session naming, in parallel with the naming build.

--- a/issues/pr2351-emit-executor-idempotency-key-arc-realloc-staging-docs.md
+++ b/issues/pr2351-emit-executor-idempotency-key-arc-realloc-staging-docs.md
@@ -1,0 +1,33 @@
+# PR #2351 review — cdz-agent-host/src/emit.rs (v-agent-harness-host) — OPEN — 1 provenance (MED) + 1 efficiency (LOW) + 1 doc (LOW) [VERIFIED]
+
+https://github.com/camshaft/cadenza/pull/2351 (EmitExecutor — cross-session messaging host-side routing, the
+operator's cross-session-messaging next; branch cand/v-agent-harness-host-97a17edf70d9). Copilot 3 inline.
+
+## c2 — `perform` drops the dispatch `idempotency_key` (`_idempotency_key`); for a side-effecting emit (sends to another session) the key matters for CRASH-RECOVERY + provenance (Copilot, emit.rs:55, also 98) — provenance [VERIFIED, MED]
+> `perform` receives the dispatch `idempotency_key`, but it is currently marked unused
+> (`_idempotency_key`). Since `emit` is side-effecting (it sends to another session), keeping the key
+> available is important for crash-recovery semantics and provenance.
+VERIFIED: `async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash)` (diff:96) discards the
+key (also the second executor at :98). For an at-least-once cross-session send, the idempotency key is what
+lets a redelivered emit be de-duped on crash-recovery + traced for provenance — dropping it means a replay
+after a crash can double-deliver to B's inbox. MED (the highest-value of the three; it's the
+correctness-of-delivery-semantics question, not just style). RELAYED with the reachability caveat: whether
+the current routing already de-dups elsewhere (or emit is exactly-once by construction) is v-ah-host's call —
+but a side-effecting executor that ignores the idempotency key it's handed is worth a deliberate decision
+(use it in the dedup/provenance path, or document why it's safe to drop). Coordinate w/ v-agent-harness (owns
+the EffectKind::Emit + Inbound kernel side).
+
+## c3 — `SessionId::new(req.target.as_ref())` re-allocates from a cheap-clone `Arc<str>` (Copilot, emit.rs:73) — efficiency [VERIFIED, LOW]
+> `EffectRequest.target` is an `Arc<str>` (cheap-clone). Converting it to `&str` and then back into an
+> `Arc<str>` via `SessionId::new(req.target.as_ref())` allocates a new string; cloning the existing
+> `Arc<str>` avoids the extra allocation.
+VERIFIED: `let target = SessionId::new(req.target.as_ref())` (diff:114) round-trips `Arc<str>`→`&str`→new
+alloc. LOW efficiency. Fix: if `SessionId` wraps `Arc<str>`, construct it by cloning the existing Arc
+(`SessionId::from(req.target.clone())` or similar) — no new allocation per emit.
+
+## c1 — module docs carry staging language ("operator's next"/"v2") that goes stale vs the "document current behavior" guideline (Copilot, emit.rs:16) — doc [VERIFIED, LOW]
+VERIFIED: module header has forward-looking/staging notes. LOW doc-hygiene. Fix: rewrite the header to
+describe the CURRENT routing semantics (+ `cause` provenance once applied) without future-looking notes.
+
+v-agent-harness-host owns cdz-agent-host. PR OPEN → all foldable pre-merge. c2 (idempotency_key) is the one
+that matters — a delivery-semantics decision, not a nit.


### PR DESCRIPTION
Candidate PR for v-cdz-tooling's merge-request (ref 79e9247d5f0f18dad60ec6cadbb324e52f4fa998, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.