### PR TITLE
rcdzc(rust-async): Option A — emit lambda-lifted async closures via the EnvClosure ABI (unlocks the host-closure async frontier)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/rust/DESIGN-async-lifted-closure-emit.md
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/DESIGN-async-lifted-closure-emit.md
@@ -1,7 +1,14 @@
 # DESIGN — Rust `rust-async` backend: emit for lambda-lifted closures
 
-**Status:** OPTION C LANDED (v-rust-backend, MR `c6f1f3f2`, 2026-07-20) — rust-async 3510→3869/0 (+359).
-Option A (await-in-closure-body, boxed-future ABI + `DynCdzEnv` shim) remains. UNTRACKED scratch.
+**Status:** OPTION A BUILT + GATED (v-rust-backend, 2026-08-06) — the await-in-closure-body slice is DONE
+via the `EnvClosure` per-closure-struct ABI (built on v-runtime's `DynCdzEnv` #2350 + `EnvClosure` #2361).
+`21-host-closures` + `09-functions` rust-async are 0-fail; full rust-async corpus 5778/0 (0 regress vs
+baseline, 3 newly-passing); sync rust byte-identical (5891/0); rcdzc lib 2548/0. **The `Rc<dyn Fn>` ABI
+in the "design crux" below was superseded — a `Fn` closure CANNOT return a future borrowing its own `&mut`
+env (E0271 / lifetime); the object-safe `EnvClosure` trait (a generic `call<'a>` METHOD) is what works.**
+See the "OPTION A AS BUILT" section at the bottom for the delivered shape.
+(Historical: OPTION C LANDED MR `c6f1f3f2`, 2026-07-20, rust-async 3510→3869/0; Option A now subsumes it —
+call-free async closures are ALSO boxed-future under the uniform ABI, so the two are one path.)
 
 ## ✅ Option C landed (call-free closure bodies)
 `emit_lifted_lambda` emits a call-free async lifted body as a plain SYNC `fn` (forced `Mode::Sync` after
@@ -149,3 +156,40 @@ But a `Ty::Fn` TYPE position (a factory RESULT, a consumer PARAM, a struct FIELD
 **THE SOUND RULING (owner decision — ONE async closure ABI):** in async mode ALL lifted closures are BOXED-FUTURE, call-free included. Drop the "call-free async lifted fn stays a sync `fn`" branch of edits 1-3; a call-free async closure becomes `async fn __lifted_k(env: &mut dyn DynCdzEnv, …)` (env unused but present) whose value is the boxed-future `Rc<dyn Fn(&mut dyn DynCdzEnv, A) -> Pin<Box<…>>>`. Then `async_closure_type`'s "every `Ty::Fn` → boxed-future" is CORRECT, because the value form is now uniform — type and value always agree, no per-value fork a type position can't observe. `Core::CallClosure` in async mode is then ALWAYS `Box::pin((c)(env, args)).await` (no `body_has_call` guard needed either — the indirectly-held-closure case that attempt-1 couldn't distinguish is resolved by uniformity).
 
 **BLAST RADIUS (why this is a measure-first MR, not a quiet edit):** the ~294 Option-C cases SWITCH ABI (sync-form → boxed-future). The gate HARNESS (`xtask/main.rs`) drives a host-closure factory/consumer by calling the closure VALUE; under uniform boxed-future it must call EVERY async closure as `Box::pin((clos)(&mut env, args)).await` through `&mut dyn DynCdzEnv` — including the call-free ones it currently calls synchronously. So edit 5 (harness) grows to cover the call-free path too. Sequence the MR: (1) uniform boxed-future in emit_lifted_lambda + Core::Closure + CallClosure (drop the call-free sync branch), (2) `async_closure_type` at sig sites, (3) harness uniform boxed-future call, (4) `cargo xtask gate --check --target rust` byte-identical (0 regress) + `--target rust-async` re-measure — EXPECT the 294 to stay green under the new ABI (not silently drop) + the call-bearing cases to newly pass. If the 294 can't be kept green under uniform boxed-future in one MR, that's the true increment boundary — land uniform-ABI-for-call-free FIRST (re-green the 294 under boxed-future, 0 net new but ABI unified), THEN call-bearing on top. Re-stash edits 1-3 and rework from the uniform-ABI shape, NOT the dual-form shape.
+
+## ✅ OPTION A AS BUILT (2026-08-06) — the `EnvClosure` uniform closure ABI
+The delivered shape (supersedes the `Rc<dyn Fn>`-based crux above, which hits a Rust language wall).
+
+**The ABI.** In `--target rust-async`, EVERY lifted closure is BOXED-FUTURE and uniform:
+- The env is the OBJECT-SAFE `&mut dyn DynCdzEnv` EVERYWHERE — every top-level `async fn` AND every lifted
+  closure fn takes it (no per-fn `<__CdzE: CdzEnv>` generic anymore). Gas charges via `consume_boxed(1)`.
+  Uniform env is why a closure body can call top-level fns (a generic `__CdzE` param rejected the `dyn
+  DynCdzEnv` a closure carries — `dyn DynCdzEnv: CdzEnv` unsatisfied). A concrete caller env unsizes to
+  `&mut dyn DynCdzEnv` at the call site.
+- A closure VALUE is `Rc<dyn cdz_rt::EnvClosure<A, R>>` — a per-closure synth `struct __Clos_k { <captures> }`
+  with `impl EnvClosure<A,R>` whose `call<'a>(&self, env, arg: A) -> Pin<Box<dyn Future<Output=R> + 'a>>`
+  boxes the lifted fn's future. `A` = the single arg (arity 1), a TUPLE of args (arity ≥2), or `()` (arity
+  0) — the flat lifted params tupled into one `A`, destructured inside `call`. `EnvClosure`'s generic
+  `call<'a>` METHOD is what a bare `dyn Fn` can't be: `'a` ties the returned future to the env borrow.
+- `Core::Closure` async → `Rc::new(__Clos_k { .. }) as Rc<dyn EnvClosure<A,R>>`; `Core::CallClosure` async →
+  `closure.call(env, arg).await` (hoisting any `.await`-bearing operand into a `let` first, else two live
+  `&mut env` borrows = E0499). `Box::pin`/`Pin<Box<..>>` are fully qualified `::std::boxed::Box` (a user sum
+  named `Box` emits `enum Box` which would shadow std `Box`).
+
+**Type positions.** `types::async_closure_type` mirrors `rust_type` but every `Ty::Fn` → `Rc<dyn
+EnvClosure<A,R>>` (recursing compounds). Applied via `mod::async_or_rust_type(ty, mode)` at ALL async
+signature-emit sites: def/lifted param+result, `Core::Closure` dyn_ty, collection VALUE/element annotations
+(`Core::MapNew`/`Core::ListNew`), and ENUM PAYLOAD types (`enums::render_payload_ty` threads `mode`, so a
+closure-payload sum's `enum` field matches the `Rc<dyn EnvClosure>` value a `Core::SumNew` builds). Sync mode
++ any closure-free type is byte-identical to `rust_type`.
+
+**Gate harness (`xtask/main.rs`).** `names_closure_value` recognizes both `Rc<dyn Fn(` and `Rc<dyn
+[cdz_rt::]EnvClosure<`. A factory's returned closure is driven `{ let __h = block_on(factory);
+block_on(__h.call(&mut env, arg)) }`; a consumer's producer-supplied closure is a `block_on(prog::mk(&mut
+env))` handle passed to the consumer (whose body `.call`s it). A NULLARY async factory returning `Rc<dyn
+EnvClosure>` is classified `Factory{cap:0}` (a peeled-fn-item coercion can't wrap an async fn).
+
+**cdz-rt (v-runtime).** `DynCdzEnv` (object-safe `consume_boxed`, #2350) + `EnvClosure<A,R>` (#2361) — both
+additive rlib-only, no `REQUIRED_RUNTIME_HASH` bump. The env-ABI perf tradeoff (dyn-dispatch gas vs
+monomorphized) is backlogged to the concierge: option B (`impl CdzEnv for dyn DynCdzEnv`, a v-runtime land)
+keeps top-level→top-level monomorphized if async perf ever matters. Not gate-measured as hot; deferred.

--- a/implementation/seed/crates/rcdzc/src/backend/rust/enums.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/enums.rs
@@ -25,7 +25,7 @@ use crate::diag::Reject;
 /// A declaration whose variant payloads have no native mapping (or that is recursive) is SKIPPED here —
 /// a use of such a sum declines at `rust_type`/selection, attributed to this target, so skipping its
 /// declaration is consistent (no enum is emitted that no compilable code names).
-pub fn emit_enum_decls(db: &mut Db) -> String {
+pub fn emit_enum_decls(db: &mut Db, mode: super::Mode) -> String {
     let mut out = String::new();
     let n = db.type_decls.len();
     // DEDUP by emitted enum IDENTIFIER: a LINKED multi-module program can carry two declarations that emit
@@ -38,7 +38,7 @@ pub fn emit_enum_decls(db: &mut Db) -> String {
     // fails loudly rather than silently dropping a distinct type.
     let mut emitted: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     for i in 0..n {
-        if let Ok(decl_src) = emit_one_enum(db, i) {
+        if let Ok(decl_src) = emit_one_enum(db, i, mode) {
             let ident = types::sum_ident(&db.type_decls[i].name);
             match emitted.get(&ident) {
                 // A same-ident decl already emitted with identical source — skip (dedup the linked twin).
@@ -75,7 +75,10 @@ pub fn emit_sum_descriptors(db: &mut Db) -> String {
         let decl = db.type_decls[i].clone();
         // Only a sum whose enum actually emits (non-built-in, non-recursive, native payloads). A GENERIC
         // sum now gets a descriptor too (payloads as `T{k}` placeholders); a monomorphic one has no params.
-        if emit_one_enum(db, i).is_err() {
+        // Mode-INVARIANT check: a payload is representable in both modes (only a closure's SPELLING differs —
+        // `Rc<dyn Fn>` vs `Rc<dyn EnvClosure>`, both native), and this descriptor path emits no closure type
+        // into the module. `Sync` suffices to decide "does the enum emit at all".
+        if emit_one_enum(db, i, super::Mode::Sync).is_err() {
             continue;
         }
         // Key the descriptor by the CADENZA name (`decl.name`) — the SAME string `cdz-return` emits (a
@@ -256,7 +259,7 @@ fn variant_payload_renders(db: &mut Db, variant: &crate::db::Variant) -> Vec<Str
 
 /// Emit one sum declaration `db.type_decls[i]` as a Rust `enum`, or decline (a variant payload with no
 /// native mapping, or a recursive sum). `Err` means "skip this declaration" — the caller drops it.
-fn emit_one_enum(db: &mut Db, i: usize) -> Result<String, Reject> {
+fn emit_one_enum(db: &mut Db, i: usize, mode: super::Mode) -> Result<String, Reject> {
     let decl = db.type_decls[i].clone();
     // The BUILT-IN `Option`/`Result` map to RUST'S OWN `Option`/`Result` (the operator's ask — idiomatic
     // + trivially usable from Rust), so DON'T emit a synthetic `enum Option { … }` that would shadow
@@ -303,7 +306,7 @@ fn emit_one_enum(db: &mut Db, i: usize) -> Result<String, Reject> {
         // `T{k}`. A payload with no native mapping declines the whole enum.
         let mut payloads = Vec::with_capacity(variant.payloads.len());
         for &pty_occ in &variant.payloads {
-            payloads.push(payload_rust_type(db, pty_occ, &decl)?);
+            payloads.push(payload_rust_type(db, pty_occ, &decl, mode)?);
         }
         // A RECURSIVE variant — one whose payload mentions THIS sum (`(Cons Int64 L)`, `(Node L L)`) —
         // BOXES its whole payload field: a Rust enum containing itself by value is infinitely sized, so
@@ -471,6 +474,7 @@ fn payload_rust_type(
     db: &mut Db,
     pty_occ: crate::ast::StructId,
     decl: &crate::db::TypeDecl,
+    mode: super::Mode,
 ) -> Result<String, Reject> {
     // A bare type-parameter payload — the payload type-expr is a lowercase name that IS one of the
     // declaration's params. Render it as the corresponding `T{k}` (the enum's type parameter).
@@ -498,7 +502,7 @@ fn payload_rust_type(
         sentinel_payload_ty(db, decl, pty_occ)
             .ok_or_else(|| Reject::decline("a variant payload type does not resolve"))?
     };
-    render_payload_ty(&ty, decl).ok_or_else(|| {
+    render_payload_ty(&ty, decl, mode).ok_or_else(|| {
         Reject::decline(format!(
             "a variant payload type {} has no native Rust representation",
             ty.render_name()
@@ -558,7 +562,11 @@ fn sentinel_payload_ty(
 /// whatever args the bare self-mention carries (none). This is what makes a generic recursive sum's
 /// self-referential payload name the enum correctly (E0107 otherwise). Non-self sums/compounds delegate to
 /// `types::rust_type` (their args are concrete). `None` for a type with no native Rust form.
-fn render_payload_ty(ty: &crate::ty::Ty, decl: &crate::db::TypeDecl) -> Option<String> {
+fn render_payload_ty(
+    ty: &crate::ty::Ty,
+    decl: &crate::db::TypeDecl,
+    mode: super::Mode,
+) -> Option<String> {
     use crate::ty::Ty;
     // A SENTINEL param var (`PARAM_SENTINEL_BASE + k`) is the sum's k-th type parameter — render `T{k}`.
     // This is what lets a param appearing ANYWHERE in a payload (nested in `Option`/`Tuple`/a self-ref's
@@ -582,7 +590,7 @@ fn render_payload_ty(ty: &crate::ty::Ty, decl: &crate::db::TypeDecl) -> Option<S
         // to the positional `T{k}` if an arg is missing (a bare self-mention with no args).
         let ps: Vec<String> = if args.len() == decl.params.len() {
             args.iter()
-                .map(|a| render_payload_ty(a, decl))
+                .map(|a| render_payload_ty(a, decl, mode))
                 .collect::<Option<Vec<_>>>()?
         } else {
             (0..decl.params.len()).map(|k| format!("T{k}")).collect()
@@ -594,8 +602,10 @@ fn render_payload_ty(ty: &crate::ty::Ty, decl: &crate::db::TypeDecl) -> Option<S
     // to `types::rust_type`.
     match ty {
         Ty::Tuple(elems) => {
-            let parts: Option<Vec<String>> =
-                elems.iter().map(|e| render_payload_ty(e, decl)).collect();
+            let parts: Option<Vec<String>> = elems
+                .iter()
+                .map(|e| render_payload_ty(e, decl, mode))
+                .collect();
             let parts = parts?;
             match parts.len() {
                 0 => Some("()".to_string()),
@@ -608,16 +618,20 @@ fn render_payload_ty(ty: &crate::ty::Ty, decl: &crate::db::TypeDecl) -> Option<S
         // concrete monomorphic sum name). The head name uses the built-in std mapping for Option/Result
         // via `types::rust_type` on the ARGS-STRIPPED shape is not needed — render the name + args here.
         Ty::Sum { name, args, .. } if !args.is_empty() => {
-            let parts: Option<Vec<String>> =
-                args.iter().map(|a| render_payload_ty(a, decl)).collect();
+            let parts: Option<Vec<String>> = args
+                .iter()
+                .map(|a| render_payload_ty(a, decl, mode))
+                .collect();
             let ident = types::sum_ident(name);
             Some(format!("{ident}<{}>", parts?.join(", ")))
         }
         // A `List`/`Map`/`Set` element is NOT rendered (collections-as-values are unrealized on the Rust
         // backend — `types::rust_type` has no arm; a `Vec<…>` field would be an enum the construct/match
-        // paths can't handle). Delegate to `types::rust_type`, which declines — consistent with a bare
-        // `List` payload declining.
-        _ => types::rust_type(ty),
+        // paths can't handle). A closure payload (`Ty::Fn`) delegates to the MODE-AWARE spelling: in async
+        // mode a closure crosses as `Rc<dyn EnvClosure<A,R>>` (the enum FIELD must match the `Rc<dyn
+        // EnvClosure>` VALUE a `Core::SumNew` constructs — else E0308), in sync mode the plain `Rc<dyn Fn>`.
+        // A closure-free leaf is byte-identical (`async_closure_type` == `rust_type` off `Ty::Fn`).
+        _ => super::async_or_rust_type(ty, mode),
     }
 }
 
@@ -945,7 +959,9 @@ fn decl_emits(db: &mut Db, decl: &crate::db::TypeDecl) -> bool {
         variant
             .payloads
             .iter()
-            .all(|&pty| payload_rust_type(db, pty, decl).is_ok())
+            // Mode-INVARIANT: a closure payload is representable in both modes (only the SPELLING differs);
+            // this is a yes/no representability check, not an emit, so `Sync` decides it.
+            .all(|&pty| payload_rust_type(db, pty, decl, super::Mode::Sync).is_ok())
     })
 }
 

--- a/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
@@ -352,6 +352,100 @@ pub(super) fn lifted_ident(k: usize) -> String {
     format!("__lifted_{k}")
 }
 
+/// The Rust identifier for the per-closure `EnvClosure` synth STRUCT of lifted slot `k` (Option A, async
+/// mode) — `__Clos_{k}`, a backend-reserved (`__`) name that cannot collide with a source type. The struct
+/// carries the closure's captures as fields; its `EnvClosure::call` impl forwards them + the env into the
+/// async lifted fn `__lifted_{k}`. Emitted at module level (see `emit_closure_struct`) beside the lifted fn.
+pub(super) fn closure_struct_ident(k: usize) -> String {
+    format!("__Clos_{k}")
+}
+
+/// Wrap a closure VALUE expression for emission: `{ <cap_lets><expr> }` when there are capture `let`s to
+/// scope, else the bare `<expr>`. A no-capture closure has no `let`s, so a `{ expr }` block around it is
+/// needless and trips `unused_braces` under the gate's `-D warnings` (the value appears in arbitrary
+/// positions — a `.call(..)` argument, a function/return value — each of which the lint flags). Shared by
+/// the sync (`Rc<dyn Fn>`) and async (`Rc<dyn EnvClosure>`) `Core::Closure` emits so both stay warning-clean.
+fn wrap_closure_value(cap_lets: &str, closure_expr: &str) -> String {
+    if cap_lets.is_empty() {
+        closure_expr.to_string()
+    } else {
+        format!("{{ {cap_lets}{closure_expr} }}")
+    }
+}
+
+/// Emit the per-closure `EnvClosure` STRUCT + impl for lifted slot `k`, async mode (Option A). The struct
+/// holds the captures as fields `__c{j}: <capture-ty>` (async spelling); its `call` clones each capture,
+/// destructures the single `A` arg back into the lifted lambda's flat params, and forwards `env` + captures
+/// + params into the async `__lifted_{k}`, boxing the returned future. This is the object-safe closure VALUE
+/// a `Core::Closure` builds (`Rc::new(__Clos_{k} { … }) as Rc<dyn EnvClosure<A,R>>`). Declines if a capture,
+/// param, or result type has no async representation (the lifted fn itself would already have declined).
+pub(super) fn emit_closure_struct(
+    db: &mut Db,
+    k: usize,
+    layout: &Layout,
+) -> Result<String, Reject> {
+    let lam = layout.lifted[k].clone();
+    let struct_ident = closure_struct_ident(k);
+    let lifted = lifted_ident(k);
+    // Capture FIELDS: `__c{j}: <async ty of the captured binding>` (same type the lifted fn's leading
+    // capture params take, so the forward type-checks). A capture with no async rep declines.
+    let mut fields = Vec::with_capacity(lam.captures.len());
+    let mut field_clones = Vec::with_capacity(lam.captures.len());
+    for (j, &cap_binder) in lam.captures.iter().enumerate() {
+        let cty = type_of(db, cap_binder);
+        let rty = types::async_closure_type(&cty).ok_or_else(|| {
+            Reject::decline(format!(
+                "async closure capture {j} type {} has no native Rust representation",
+                cty.render_name()
+            ))
+        })?;
+        fields.push(format!("    __c{j}: {rty},"));
+        // Clone each capture into the forwarded call — `call` takes `&self`, so it may not MOVE a field out
+        // (it is callable repeatedly). A Copy field's `.clone()` is a plain copy.
+        field_clones.push(format!("self.__c{j}.clone()"));
+    }
+    // The single `A` arg destructured back into the flat lifted params. Arity 0 → `()` (ignore); arity 1 →
+    // the bare `__a0`; arity ≥2 → a tuple pattern `(__a0, __a1, …)`. `EnvClosure::call`'s `arg: A` binds it.
+    let arity = lam.params.len();
+    let arg_pat = match arity {
+        0 => "_".to_string(),
+        1 => "__a0".to_string(),
+        _ => format!(
+            "({})",
+            (0..arity)
+                .map(|i| format!("__a{i}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    };
+    // The forwarded arguments into `__lifted_k(env, caps…, params…)`: env first, then cloned captures, then
+    // the destructured params in order.
+    let mut fwd = vec![super::ENV_PARAM.to_string()];
+    fwd.extend(field_clones);
+    fwd.extend((0..arity).map(|i| format!("__a{i}")));
+    // `A`/`R` for the `impl EnvClosure<A,R>` header — the SAME spelling the value cast + type positions use.
+    let (a_ty, r_ty) = types::env_closure_args(&lam.params, &lam.ret_ty).ok_or_else(|| {
+        Reject::decline("an async closure's arg/result type has no native Rust representation")
+    })?;
+    // `#[derive(Clone)]`: a closure value is `Rc<dyn EnvClosure>` (shared via Rc clone), but a captured
+    // closure-in-closure or a clone-on-read of the struct itself needs Clone; deriving it is harmless (all
+    // fields are Clone — they are captured values, each `needs_clone_on_read`-safe).
+    let fields_src = if fields.is_empty() {
+        String::new()
+    } else {
+        format!("\n{}\n", fields.join("\n"))
+    };
+    // `Box` is fully qualified as `::std::boxed::Box` throughout: a USER sum named `Box` (`(type Box (Bin
+    // …))`) emits `enum Box`, which would shadow the std `Box` in `Box::pin`/`Pin<Box<…>>` → E0107 "enum
+    // Box takes 0 generic arguments". The fully-qualified path can never be shadowed. (Mirrors the async
+    // `Core::Call` arm's `::std::boxed::Box::pin`.)
+    Ok(format!(
+        "// cdz-closure-struct[{k}]\n#[derive(Clone)]\nstruct {struct_ident} {{{fields_src}}}\nimpl cdz_rt::EnvClosure<{a_ty}, {r_ty}> for {struct_ident} {{\n    fn call<'a>(&self, {env}: &'a mut dyn cdz_rt::DynCdzEnv, arg: {a_ty}) -> std::pin::Pin<::std::boxed::Box<dyn core::future::Future<Output = {r_ty}> + 'a>> {{\n        let {arg_pat} = arg;\n        ::std::boxed::Box::pin({lifted}({}))\n    }}\n}}\n",
+        fwd.join(", "),
+        env = super::ENV_PARAM,
+    ))
+}
+
 /// Emit lambda-lifted closure slot `k` as a private `fn __lifted_{k}(<captures…>, <params…>) -> <ret>`.
 ///
 /// The lifted lambda (`layout.lifted[k]` — a [`crate::lower::LiftedLambda`]) is the body of a `(fn …)`
@@ -371,30 +465,37 @@ pub(super) fn emit_lifted_lambda(
 ) -> Result<String, Reject> {
     // Clone the lifted lambda's shape out of the layout so `db` can be borrowed mutably while emitting.
     let lam = layout.lifted[k].clone();
-    // Async lifted lambdas: a closure body that reaches a runtime `Core::Call` would name an async callee
-    // (which needs the gas/yield `env` threaded in) and cannot be a plain `Fn(A) -> R` — that boxed-future
-    // ABI is the deferred slice. But a CALL-FREE body (pure arithmetic / branches / runtime ops — the bulk
-    // of the host-closure corpus, e.g. `(fn (x) (+ x 1))`) emits BYTE-IDENTICALLY in sync and async mode:
-    // the only body-emit site that threads `env`/awaits is the `Core::Call` arm (`emit`'s async branch),
-    // and a call-free body never hits it. So such a body is emitted as an ORDINARY SYNC `fn` even under
-    // `--target rust-async`; the enclosing `async fn` awaits the closure's value, not its (sync) call. A
-    // body WITH a call stays a clean decline until the boxed-future closure ABI lands.
-    if mode.is_async() && crate::layout::body_has_call(db, lam.body) {
-        return Err(Reject::decline(
-            "an async lambda-lifted closure whose body makes a call is not yet emitted by the Rust backend",
-        ));
-    }
-    // Emit the body in SYNC mode: a lifted lambda becomes a sync `fn` on both targets (an async body would
-    // have declined just above), so its inner emit must not thread `env` — force the sync path.
-    let mode = Mode::Sync;
+    // OPTION A — UNIFORM async closure ABI. In async mode EVERY lifted closure is emitted as an `async fn`
+    // taking the gas/yield env as `&mut dyn DynCdzEnv` (the object-safe facet — NOT the generic `&mut __CdzE`
+    // a TOP-LEVEL async fn takes, because the closure VALUE that wraps this fn is `Rc<dyn EnvClosure<A,R>>`
+    // and a trait object cannot be generic over `__CdzE`). The body emits in Async mode so its `Core::Call`s
+    // thread env/await; entry gas is charged via the object-safe `consume_boxed`. This is UNIFORM (a
+    // call-free async body becomes an async fn too — env unused but present) so the closure VALUE form is one
+    // ABI everywhere, letting a `Ty::Fn` TYPE position spell it (`async_closure_type`) without needing to
+    // observe `body_has_call` (a per-value property a type can't see). In SYNC mode a lifted lambda stays an
+    // ordinary sync `fn` — its inner emit must not thread env.
+    let closure_async = mode.is_async();
+    let mode = if closure_async {
+        Mode::Async
+    } else {
+        Mode::Sync
+    };
     let mut params_src = String::new();
     let mut env: Env = HashMap::new();
     let mut first = true;
+    // A UNIFORM async lifted fn threads the env as its FIRST parameter, as the object-safe `&mut dyn
+    // DynCdzEnv` (see above). The `EnvClosure::call` wrapper forwards its own `env` into this fn.
+    if closure_async {
+        params_src.push_str(&format!("{}: &mut dyn DynCdzEnv", super::ENV_PARAM));
+        first = false;
+    }
     // Captures FIRST — each an ordinary leading parameter `__cap{j}: <ty>`. `Core::Captured{index:j}`
     // reads it. The capture's TYPE is the solved type of the captured binding (read off its occurrence).
     for (j, &cap_binder) in lam.captures.iter().enumerate() {
         let cty = type_of(db, cap_binder);
-        let rty = types::rust_type(&cty).ok_or_else(|| {
+        // Async: a captured CLOSURE spells the `EnvClosure` ABI (a captured closure value is `Rc<dyn
+        // EnvClosure>`); `async_closure_type` == `rust_type` for a closure-free capture.
+        let rty = super::async_or_rust_type(&cty, mode).ok_or_else(|| {
             Reject::decline(format!(
                 "lifted lambda capture {j} type {} has no native Rust representation",
                 cty.render_name()
@@ -410,7 +511,8 @@ pub(super) fn emit_lifted_lambda(
     }
     // Then the lambda's own PARAMETERS, in order.
     for (i, (binder, ty)) in lam.params.iter().enumerate() {
-        let rty = types::rust_type(ty).ok_or_else(|| {
+        // Async: a closure-typed param (a higher-order lifted lambda) spells the `EnvClosure` ABI.
+        let rty = super::async_or_rust_type(ty, mode).ok_or_else(|| {
             Reject::decline(format!(
                 "lifted lambda parameter {i} type {} has no native Rust representation",
                 ty.render_name()
@@ -424,7 +526,8 @@ pub(super) fn emit_lifted_lambda(
         env.insert(*binder, pname);
         first = false;
     }
-    let ret = types::rust_type(&lam.ret_ty).ok_or_else(|| {
+    // Async: a closure-typed RESULT (a lifted lambda returning a closure) spells the `EnvClosure` ABI.
+    let ret = super::async_or_rust_type(&lam.ret_ty, mode).ok_or_else(|| {
         Reject::decline(format!(
             "lifted lambda result type {} has no native Rust representation",
             lam.ret_ty.render_name()
@@ -443,6 +546,16 @@ pub(super) fn emit_lifted_lambda(
     };
     let body = emit(db, lam.body, &env, &ctx)?;
     let ident = lifted_ident(k);
+    if closure_async {
+        // A UNIFORM async lifted closure body → `async fn` charging entry gas via the OBJECT-SAFE
+        // `consume_boxed` (the `&mut dyn DynCdzEnv` env can't call the RPITIT `consume`). Mirrors a
+        // top-level async fn's `env.consume(1).await`. The per-closure `EnvClosure` struct (emitted in
+        // `mod.rs`) wraps this fn into the `Rc<dyn EnvClosure<A,R>>` value.
+        return Ok(format!(
+            "// cdz-lifted[{k}]\nasync fn {ident}({params_src}) -> {ret} {{\n    {}.consume_boxed(1).await;\n    {body}\n}}\n",
+            super::ENV_PARAM
+        ));
+    }
     Ok(format!(
         "// cdz-lifted[{k}]\nfn {ident}({params_src}) -> {ret} {{\n    {body}\n}}\n"
     ))
@@ -1601,9 +1714,12 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
             // bare `vec![…]` (byte-identical to before). An empty list whose element type is NOT representable
             // (a free var, a fn) emits the bare `vec![]` and relies on downstream inference as before (no
             // regression — the annotation is a pure ADD when we can spell the type).
+            // ASYNC: a list of CLOSURES spells `Vec<Rc<dyn EnvClosure<A,R>>>`, so the element annotation uses
+            // `async_closure_type` (via `async_or_rust_type`) — else a `Vec::<Rc<dyn Fn>>::new()` mismatches
+            // the `Rc<dyn EnvClosure>` closures pushed in (E0308). Byte-identical for a closure-free element.
             if elems.is_empty()
                 && let Ty::List(elem) = type_of(db, id).strip_nominal()
-                && let Some(rust_elem) = types::rust_type(elem)
+                && let Some(rust_elem) = super::async_or_rust_type(elem, ctx.mode)
             {
                 return Ok(format!("Vec::<{rust_elem}>::new()"));
             }
@@ -1617,7 +1733,7 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
             if elems.is_empty()
                 && let Some(exp) = ctx.expected_ty.as_ref()
                 && let Ty::List(elem) = exp.strip_nominal()
-                && let Some(rust_elem) = types::rust_type(elem)
+                && let Some(rust_elem) = super::async_or_rust_type(elem, ctx.mode)
             {
                 return Ok(format!("Vec::<{rust_elem}>::new()"));
             }
@@ -1782,11 +1898,17 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
             // case. (Earlier this was a bare `new()`, which E0282'd an empty-Map handler state — a
             // Todo→Fail regression once the effects inline/hoist fix made that shape reach the rust emit.)
             let map_ty = type_of(db, id);
+            // In ASYNC mode a Map VALUE that is a closure spells `Rc<dyn EnvClosure<A,R>>`, so the `__m`
+            // annotation must use `async_closure_type` (via `async_or_rust_type`) — else a
+            // `BTreeMap<K, Rc<dyn Fn>>` annotation mismatches the `Rc<dyn EnvClosure>` values inserted (a
+            // closure-as-map-value case: E0308). A closure-free map annotation is byte-identical to `rust_type`.
+            let map_type_str =
+                |t: &Ty| -> Option<String> { super::async_or_rust_type(t, ctx.mode) };
             let ann = if ctx.map_typed_by_enclosing_insert {
                 // The enclosing `.insert`/`.remove` will fix K/V — a bare `new()` infers, and an annotation
                 // would OVER-CONSTRAIN (grounding an open var here clashes with a Rational/String/Bytes key
                 // the insert actually uses → E0308). Leave it unannotated; rustc reads the types from the use.
-                match types::rust_type(&map_ty) {
+                match map_type_str(&map_ty) {
                     Some(t) => format!(": {t}"),
                     None => String::new(),
                 }
@@ -1797,7 +1919,7 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
             {
                 // Empty `Map.empty` at a CALL-ARG position: annotate from the callee param's concrete `Map`
                 // type, not the default ground (the Set-twin of the empty-Set-at-call-arg E0308 fix).
-                match types::rust_type(exp) {
+                match map_type_str(exp) {
                     Some(t) => format!(": {t}"),
                     None => String::new(),
                 }
@@ -1806,7 +1928,7 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
                 // state): GROUND the open vars so the annotation is spellable (else E0282). See
                 // `ground_open_vars` for why grounding to the default is safe (a wrong ground → loud rustc
                 // error, never a silent miscompile).
-                match types::rust_type(&types::ground_open_vars(&map_ty)) {
+                match map_type_str(&types::ground_open_vars(&map_ty)) {
                     Some(t) => format!(": {t}"),
                     None => String::new(),
                 }
@@ -2498,6 +2620,34 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
             // string for two closures of the same lifted signature, so the `as` cast still unifies them in a
             // list/if/match. Fall back to `type_of(id)` only if a `lam` param/result somehow does not map
             // (it would already have declined at the lifted-fn emit, so this is belt-and-suspenders).
+            // ASYNC (Option A uniform ABI): the closure VALUE is `Rc<dyn EnvClosure<A,R>>` — a per-closure
+            // synth `struct Clos_{code}` (its captures as fields, emitted at module level in `mod.rs`) whose
+            // `EnvClosure::call` forwards `env` + its cloned captures + the (destructured) arg into the async
+            // lifted fn and boxes the future. Here we build the VALUE: `Rc::new(Clos_{code} { __c0, … }) as
+            // Rc<dyn EnvClosure<A,R>>`. The captures are the already-`move`d `__c{j}` locals (bound by
+            // `cap_lets`); the struct owns them. `A`/`R` come from the lifted lambda's own params/ret via
+            // `env_closure_args` (the SAME spelling `async_closure_type(Ty::Fn)` produces at a type position,
+            // so this value fits a param/result/field slot spelled by `async_closure_type`).
+            if ctx.mode.is_async() {
+                let (a_ty, r_ty) = types::env_closure_args(&lam.params, &lam.ret_ty).ok_or_else(|| {
+                    Reject::decline(
+                        "an async closure whose function type is not fully representable has no native Rust representation",
+                    )
+                })?;
+                let struct_ident = closure_struct_ident(code);
+                // The struct literal fields: `__c{j}: __c{j}` (field name == the moved local name).
+                let field_inits: Vec<String> = (0..cap_names.len())
+                    .map(|j| format!("__c{j}: __c{j}"))
+                    .collect();
+                let closure_expr = format!(
+                    "std::rc::Rc::new({struct_ident} {{ {} }}) as std::rc::Rc<dyn cdz_rt::EnvClosure<{a_ty}, {r_ty}>>",
+                    field_inits.join(", ")
+                );
+                // Wrap in a block ONLY when there are capture `let`s to scope — a NO-capture closure is a bare
+                // expression, and `{ expr }` around it trips `unused_braces` under the gate's `-D warnings`
+                // (the block appears in an arbitrary position: a `.call(...)` arg, a return value, …).
+                return Ok(wrap_closure_value(&cap_lets, &closure_expr));
+            }
             let dyn_ty = {
                 let mut param_tys = Vec::with_capacity(lam.params.len());
                 let mut ok = true;
@@ -2529,14 +2679,56 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
                 params.join(", "),
                 call_args.join(", ")
             );
-            Ok(format!("{{ {cap_lets}{closure_expr} }}"))
+            Ok(wrap_closure_value(&cap_lets, &closure_expr))
         }
-        // Apply a runtime closure at full arity → a direct call of the `Rc<dyn Fn>`: `(<closure>)(<a0>,…)`.
+        // Apply a runtime closure at full arity → a direct call. SYNC: `(<closure>)(<a0>,…)`. ASYNC (Option A):
+        // `<closure>.call(env, <arg-or-tuple>).await` — the `EnvClosure::call` takes the env at the call +
+        // one `A` arg (a multi-arg closure tuples its args into `A`, matching the lifted convention), and its
+        // returned future is awaited. `.await` inside an async fn body is the same shape a `Core::Call` uses.
         Core::CallClosure { closure, args } => {
             let c = emit(db, closure, env, ctx)?;
             let mut rendered = Vec::with_capacity(args.len());
             for &a in &args {
                 rendered.push(emit(db, a, env, ctx)?);
+            }
+            if ctx.mode.is_async() {
+                // `.call(env, arg).await` reborrows `env` for the whole call — so if the CLOSURE expr `c` OR
+                // any ARG contains its own `.await` (a nested async call `foldn(env,…).await`, e.g. the shape
+                // `(f (foldn f z m))`), that inner reborrow of `env` is still LIVE while `.call` reborrows it
+                // → E0499 "borrow `*__cdz_env` as mutable more than once". HOIST every `.await`-containing
+                // operand into a `let` BEFORE the `.call`: each hoisted reborrow completes (its `.await`
+                // releases `env`) before the next statement, so no two are ever live together. This mirrors
+                // the async `Core::Call` arm's `needs_hoist`. Operands with no `.await` (scalars, field reads,
+                // a bare closure local) stay inline.
+                let mut binds = String::new();
+                let hoist = |expr: String, tmp: &str, binds: &mut String| -> String {
+                    if expr.contains(".await") {
+                        binds.push_str(&format!("let {tmp} = {expr}; "));
+                        tmp.to_string()
+                    } else {
+                        expr
+                    }
+                };
+                let c = hoist(c, "__cclos", &mut binds);
+                let hoisted_args: Vec<String> = rendered
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, a)| hoist(a, &format!("__carg{i}"), &mut binds))
+                    .collect();
+                // Tuple ≥2 args into the single `A` (arity 1 = the bare arg; arity 0 = `()`), matching
+                // `env_closure_args`/`async_closure_type`'s `A` convention + the struct's `call` destructure.
+                let arg = match hoisted_args.len() {
+                    0 => "()".to_string(),
+                    1 => hoisted_args.into_iter().next().unwrap(),
+                    _ => format!("({})", hoisted_args.join(", ")),
+                };
+                let call = format!("({c}).call({}, {arg}).await", super::ENV_PARAM);
+                // Wrap in a block only when we hoisted (else a bare braced expr trips `unused_braces`).
+                return Ok(if binds.is_empty() {
+                    call
+                } else {
+                    format!("{{ {binds}{call} }}")
+                });
             }
             Ok(format!("({c})({})", rendered.join(", ")))
         }

--- a/implementation/seed/crates/rcdzc/src/backend/rust/mod.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/mod.rs
@@ -500,18 +500,28 @@ impl Mode {
     }
 }
 
-/// The Rust type-PARAMETER name for the async gas/yield env (`async fn f<__CdzE: CdzEnv>(env: &mut
-/// __CdzE, …)`). A `__`-prefixed reserved name — NOT a bare `E` — so it cannot collide with a user sum's
-/// Rust type name (a `(type E …)` maps to `enum E`, which a bare `E` type param would shadow, breaking
-/// `E::Variant`). Matches the `__pay`/`__p` reserved-local convention the expression emitter uses.
-const ENV_TYPE_PARAM: &str = "__CdzE";
+// (The `__CdzE` generic env TYPE-PARAMETER was removed with the uniform-env change: every async fn now
+// takes the object-safe `&mut dyn DynCdzEnv` — the same env a lifted closure fn takes — so there is no
+// per-fn generic env type param to name. See the async signature emit + the `ENV_PARAM` note below.)
 
-/// The Rust VALUE-PARAMETER name for the async gas/yield env (`async fn f(<this>: &mut __CdzE, …)`),
+/// The Rust VALUE-PARAMETER name for the async gas/yield env (`async fn f(<this>: &mut dyn DynCdzEnv, …)`),
 /// threaded into every emitted call. A `__`-prefixed RESERVED name — NOT a bare `env` — so it cannot
 /// collide with a SOURCE parameter literally named `env` (`(def (ev e env) …)`), which a bare `env` would
 /// duplicate in the signature (rustc E0415 "bound more than once"). Matches the `__CdzE`/`__pay`/`__p`
 /// reserved-name convention; user idents never begin with `__` (the sanitizer does not emit it).
 pub(super) const ENV_PARAM: &str = "__cdz_env";
+
+/// The Rust type for a solved Cadenza type, mode-aware: in ASYNC mode a closure-typed position spells the
+/// uniform `Rc<dyn EnvClosure<A,R>>` ABI (Option A) via [`types::async_closure_type`]; in SYNC mode (and for
+/// any closure-free type in either mode) it is the plain [`types::rust_type`]. Use at every SIGNATURE-emit
+/// site (def/lifted param + result) so a closure value (`Rc<dyn EnvClosure>` in async) fits its slot.
+pub(super) fn async_or_rust_type(ty: &crate::ty::Ty, mode: Mode) -> Option<String> {
+    if mode.is_async() {
+        types::async_closure_type(ty)
+    } else {
+        types::rust_type(ty)
+    }
+}
 
 /// Emit a Rust-source artifact for the program in `db` under the boundary `layout`. Produces one
 /// `pub fn` per export (verbatim name, native scalar signature), reading the shared columns on demand.
@@ -551,7 +561,7 @@ pub fn emit(db: &mut Db, layout: &Layout, mode: Mode) -> Result<Vec<u8>, Reject>
     // Every sum type the program declares becomes a Rust `enum` (emitted before the functions that
     // construct/match/return it). A declaration with no native form (a recursive sum, an unrepresentable
     // payload) is skipped — a use of it declines at selection, so no orphan enum is emitted.
-    out.push_str(&enums::emit_enum_decls(db));
+    out.push_str(&enums::emit_enum_decls(db, mode));
     // A machine-readable descriptor per user sum (variant names + payload types in discriminant order) —
     // inert to rustc (`//` comments), read by the corpus gate to render a user-sum boundary value to its
     // canonical bare form. The enum decls above give rustc the types; these give the gate the structure.
@@ -640,6 +650,14 @@ pub fn emit(db: &mut Db, layout: &Layout, mode: Mode) -> Result<Vec<u8>, Reject>
             let f = expr::emit_lifted_lambda(db, k, layout, mode)?;
             out.push('\n');
             out.push_str(&f);
+            // ASYNC (Option A uniform ABI): the lifted fn is an `async fn`, and its closure VALUE is
+            // `Rc<dyn EnvClosure<A,R>>` — a per-closure synth struct + impl forwarding into the lifted fn.
+            // Emit it right after the lifted fn (a `Core::Closure` builds `Rc::new(__Clos_k { … })`).
+            if mode.is_async() {
+                let s = expr::emit_closure_struct(db, k, layout)?;
+                out.push('\n');
+                out.push_str(&s);
+            }
         }
     }
     // A Float-keyed set/map emits a total-order float wrapper (a bare `f32`/`f64` is not `Ord`). Two
@@ -690,7 +708,13 @@ pub fn emit(db: &mut Db, layout: &Layout, mode: Mode) -> Result<Vec<u8>, Reject>
 /// each module — so an application implements it ONCE for `RcRuntime`/its own env type and every emitted
 /// module uses that same trait (two modules interoperate). A downstream build depends on `cdz-rt`; the
 /// corpus gate links it via `--extern cdz_rt=<rlib>`.
-const CDZ_RT_IMPORTS: &str = "use cdz_rt::CdzEnv;\n";
+// `CdzEnv` is used by EVERY async fn (the gas param); `DynCdzEnv`/`EnvClosure` are used only by a module
+// that emits an async CLOSURE value (its per-closure struct impls `EnvClosure` + charges via `DynCdzEnv`).
+// A closure-free async program imports them unused, which `-D warnings` (`unused_imports`) would reject —
+// so `#[allow(unused_imports)]` the whole `use` (a mechanically-emitted preamble import, like the backend's
+// other synthesized `#[allow(dead_code)]` helpers). Simpler + robust vs. threading closure-presence up here.
+const CDZ_RT_IMPORTS: &str =
+    "#[allow(unused_imports)] use cdz_rt::{CdzEnv, DynCdzEnv, EnvClosure};\n";
 
 /// The file preamble — a header comment marking the source as generated, and the lint allowances a
 /// mechanically-emitted file needs (its names come verbatim from the source program, so they will not
@@ -1042,9 +1066,16 @@ fn emit_signature(
     let loops = !params.is_empty() && expr::body_loops(db, def);
     let mut param_src = String::new();
     // In async/gas mode, the FIRST parameter is the caller-supplied gas/yield env, threaded into every
-    // call. It precedes the source parameters; the source params keep their positions after it.
+    // call. It precedes the source parameters; the source params keep their positions after it. The env is
+    // the OBJECT-SAFE `&mut dyn DynCdzEnv` — NOT a generic `&mut __CdzE: CdzEnv` — so a top-level async fn
+    // takes the SAME env type a lifted CLOSURE fn does (a closure value is `Rc<dyn EnvClosure>` holding a
+    // `&mut dyn DynCdzEnv`, and its body CALLS these top-level fns; a generic `__CdzE` param would reject the
+    // `dyn DynCdzEnv` the closure passes — `dyn DynCdzEnv: CdzEnv` is unsatisfied). Uniform env everywhere =
+    // one env type across fns + closures, and it also drops the per-fn `<__CdzE: CdzEnv>` generic. A concrete
+    // caller env (`&mut GateEnv`) unsizes to `&mut dyn DynCdzEnv` at the call site. Gas charges via the
+    // object-safe `consume_boxed` (the RPITIT `consume` is not callable on a `dyn`).
     if mode.is_async() {
-        param_src.push_str(&format!("{ENV_PARAM}: &mut {ENV_TYPE_PARAM}"));
+        param_src.push_str(&format!("{ENV_PARAM}: &mut dyn DynCdzEnv"));
     }
     for (i, (binder, ty)) in params.iter().enumerate() {
         if i > 0 || mode.is_async() {
@@ -1066,7 +1097,10 @@ fn emit_signature(
         if let Some(reject) = ill_formed_int_width_reject(ty) {
             return Err(reject);
         }
-        let rty = types::rust_type(ty).ok_or_else(|| {
+        // In ASYNC mode a closure-typed param spells the uniform `Rc<dyn EnvClosure<A,R>>` ABI (a closure
+        // value flowing in is `Rc<dyn EnvClosure>`, not `Rc<dyn Fn>`); `async_closure_type` == `rust_type`
+        // for any closure-free type, so a scalar/compound param is byte-identical in both modes.
+        let rty = async_or_rust_type(ty, mode).ok_or_else(|| {
             Reject::decline(format!(
                 "`{name}`: parameter type {} has no native Rust representation",
                 ty.render_name()
@@ -1107,7 +1141,8 @@ fn emit_signature(
     let ret = if diverges {
         "!".to_string()
     } else {
-        types::rust_type(result).ok_or_else(|| {
+        // Async: a closure-typed RESULT (a factory export returning a closure) spells the `EnvClosure` ABI.
+        async_or_rust_type(result, mode).ok_or_else(|| {
             Reject::decline(format!(
                 "`{name}`: result type {} has no native Rust representation",
                 result.render_name()
@@ -1235,13 +1270,13 @@ fn emit_signature(
     let ret_note =
         format!("{ret_note}{unit_note}{qty_at_notes}{param_shapes_note}{produces_closure_note}");
     if mode.is_async() {
-        // `async fn <name><__CdzE: CdzEnv>(env: &mut __CdzE, …) -> <ret> { env.consume(1).await; <body> }`
-        // — the per-call fuel charge + cooperative-yield point at entry. The env TYPE PARAMETER is named
-        // `__CdzE` (not a bare `E`) so it can NEVER collide with a user sum's Rust type name (a sum named
-        // `E` would otherwise shadow the type param, making `E::Variant` unresolvable) — the `__` prefix
-        // marks it backend-reserved, matching the emitted `__pay`/`__p` locals.
+        // `async fn <name>(env: &mut dyn DynCdzEnv, …) -> <ret> { env.consume_boxed(1).await; <body> }` —
+        // the per-call fuel charge + cooperative-yield point at entry. The env is the OBJECT-SAFE `&mut dyn
+        // DynCdzEnv` (see the param assembly above): uniform with a lifted closure fn's env, so a closure
+        // body can call these top-level fns. Gas charges via `consume_boxed` (the object-safe method — the
+        // RPITIT `CdzEnv::consume` is not callable through a `dyn`). No per-fn `<__CdzE: CdzEnv>` generic.
         Ok(format!(
-            "{ret_note}{vis}async fn {ident}<{ENV_TYPE_PARAM}: CdzEnv>({param_src}) -> {ret} {{\n    {ENV_PARAM}.consume(1).await;\n{body_src}\n}}\n"
+            "{ret_note}{vis}async fn {ident}({param_src}) -> {ret} {{\n    {ENV_PARAM}.consume_boxed(1).await;\n{body_src}\n}}\n"
         ))
     } else {
         Ok(format!(

--- a/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
@@ -4983,21 +4983,31 @@ fn async_mode_emits_env_threaded_gas_metered_fns() {
     );
     // The gas/yield trait now lives in the SHARED `cdz-rt` crate (NOT re-declared per module); the
     // module brings it into scope with a `use`, so an application implements `CdzEnv` once for all.
-    assert!(rs.contains("use cdz_rt::CdzEnv;"), "cdz_rt import:\n{rs}");
+    assert!(
+        rs.contains("use cdz_rt::{CdzEnv, DynCdzEnv, EnvClosure};"),
+        "cdz_rt import (async closures also import DynCdzEnv + EnvClosure for the boxed-future ABI):\n{rs}"
+    );
+    // The import is `#[allow(unused_imports)]`-guarded: a closure-free async program imports DynCdzEnv/
+    // EnvClosure unused, which `-D warnings` would reject.
+    assert!(
+        rs.contains("#[allow(unused_imports)] use cdz_rt::{CdzEnv, DynCdzEnv, EnvClosure};"),
+        "the cdz_rt import is unused-imports-guarded:\n{rs}"
+    );
     assert!(
         !rs.contains("pub trait CdzEnv"),
         "must NOT re-declare the trait:\n{rs}"
     );
-    // The fn is async, takes `__cdz_env: &mut __CdzE`, and charges gas at entry. Both the env TYPE param
-    // (`__CdzE`) and the env VALUE param (`__cdz_env`) are reserved `__`-names so neither collides with a
-    // user sum's Rust type nor a source parameter literally named `env`.
+    // The fn is async and takes the OBJECT-SAFE env `__cdz_env: &mut dyn DynCdzEnv` (uniform-env ABI — the
+    // same env a lifted closure fn takes, so a closure body can call top-level fns; no per-fn `<__CdzE>`
+    // generic). The env VALUE param is the reserved `__cdz_env` (never collides with a source `env`).
     assert!(
-        rs.contains("pub async fn sum_to<__CdzE: CdzEnv>(__cdz_env: &mut __CdzE, n: i64)"),
-        "signature:\n{rs}"
+        rs.contains("pub async fn sum_to(__cdz_env: &mut dyn DynCdzEnv, n: i64)"),
+        "signature (uniform &mut dyn DynCdzEnv env, no generic):\n{rs}"
     );
+    // Gas charges via the OBJECT-SAFE `consume_boxed` (the RPITIT `consume` is not callable on a `dyn`).
     assert!(
-        rs.contains("__cdz_env.consume(1).await;"),
-        "gas charge:\n{rs}"
+        rs.contains("__cdz_env.consume_boxed(1).await;"),
+        "gas charge via consume_boxed:\n{rs}"
     );
     // The recursive call is boxed-and-awaited, threading the env first.
     assert!(
@@ -5060,17 +5070,21 @@ fn async_boxes_only_a_call_whose_future_is_self_referential() {
 
 #[test]
 fn async_env_type_param_does_not_collide_with_a_user_sum_named_e() {
-    // REGRESSION: the async env type param was a bare `E`; a user sum `(type E …)` maps to `enum E`, so
-    // `E::A` in the constructing code resolved to the type PARAMETER, not the enum (`no associated item
-    // named A`). The param is now the reserved `__CdzE`, so the enum `E` is unshadowed and constructs.
+    // The async env is now the OBJECT-SAFE `&mut dyn DynCdzEnv` VALUE param — there is NO generic env TYPE
+    // parameter at all, so a user sum `(type E …)` → `enum E` can never be shadowed by one (the earlier
+    // bare-`E`-type-param collision is structurally impossible now). Pin that: the enum emits + constructs,
+    // and no async fn header carries ANY generic env param.
     let rs = compile_rust_async(
         "(module m (type E (A Int64) (B Int64)) (def (main) (E.B 7)) (export main))",
     );
     assert!(rs.contains("pub enum E {"), "user enum E emitted:\n{rs}");
-    assert!(rs.contains("<__CdzE: CdzEnv>"), "reserved env param:\n{rs}");
     assert!(
-        !rs.contains("<E: CdzEnv>"),
-        "no bare-E param collision:\n{rs}"
+        rs.contains("pub async fn main(__cdz_env: &mut dyn DynCdzEnv)"),
+        "uniform-env signature, no generic env param:\n{rs}"
+    );
+    assert!(
+        !rs.contains(": CdzEnv>"),
+        "no generic env type param on any async fn:\n{rs}"
     );
     // It compiles (the enum `E` and the env param no longer collide).
     let driver = r#"
@@ -6637,63 +6651,100 @@ fn rustc_roundtrip_host_closure_factory_compound_result_s3() {
 }
 
 #[test]
-fn async_lifted_closure_with_a_call_free_body_emits_a_sync_fn() {
-    // HOST-CLOSURE on `--target rust-async`: a lambda-lifted closure whose body makes NO runtime call
-    // (pure arithmetic / branches / runtime ops — the bulk of the host-closure corpus) emits as an
-    // ORDINARY SYNC `fn __lifted_k` even under async mode. The only body-emit site that threads the
-    // gas/yield `env` (and awaits) is the `Core::Call` arm, so a call-free body compiles byte-identically
-    // to sync; the ENCLOSING factory is the `async fn` that awaits the closure VALUE, not its call.
+fn async_lifted_closure_call_free_body_emits_env_closure_uniform_abi() {
+    // OPTION A (uniform async closure ABI): on `--target rust-async` EVERY lifted closure — call-free
+    // included — emits as an `async fn __lifted_k(env: &mut dyn DynCdzEnv, …)` whose VALUE is
+    // `Rc<dyn EnvClosure<A,R>>` (a per-closure synth `struct __Clos_k` + `impl EnvClosure`). Uniform so a
+    // `Ty::Fn` TYPE position can spell the value form (`async_closure_type`) without observing
+    // `body_has_call` (which a type can't see). A call-free body's env is present-but-unused.
     let both = compile_rust_async(
         "(module m (def (both (: a Int64) (: b Int64)) (fn ((: x Int64)) (+ (+ a b) x))) (export both))",
     );
-    // The factory is an async fn returning the Rc<dyn Fn> handle (its captures leading its own params).
+    // The factory is an async fn RETURNING the EnvClosure handle (its captures lead its own params). Its
+    // env is the uniform object-safe `&mut dyn DynCdzEnv` (no generic).
     assert!(
         both.contains(
-            "pub async fn both<__CdzE: CdzEnv>(__cdz_env: &mut __CdzE, a: i64, b: i64) -> std::rc::Rc<dyn Fn(i64) -> i64>"
+            "pub async fn both(__cdz_env: &mut dyn DynCdzEnv, a: i64, b: i64) -> std::rc::Rc<dyn cdz_rt::EnvClosure<i64, i64>>"
         ),
-        "the factory is an async fn returning the closure handle:\n{both}"
+        "the factory is an async fn returning the EnvClosure handle:\n{both}"
     );
-    // The lifted closure body itself is a plain SYNC `fn` — NOT `async fn __lifted`, NO env param.
+    // The lifted closure body is now an `async fn` taking the object-safe `&mut dyn DynCdzEnv` (uniform ABI).
     assert!(
-        both.contains("fn __lifted_0(__cap0: i64, __cap1: i64, x: i64) -> i64")
-            && !both.contains("async fn __lifted_0"),
-        "the call-free lifted closure body is a sync fn (no env/await):\n{both}"
+        both.contains("async fn __lifted_0(__cdz_env: &mut dyn DynCdzEnv, __cap0: i64, __cap1: i64, x: i64) -> i64"),
+        "the call-free lifted closure body is an async fn threading &mut dyn DynCdzEnv:\n{both}"
     );
-    // A no-capture closure (`(fn (x) (+ x 1))`) likewise: async factory, sync lifted body.
-    let inc =
-        compile_rust_async("(module m (def (main) (fn ((: x Int64)) (+ x 1))) (export main))");
+    // The per-closure synth struct carries the captures + impls EnvClosure, forwarding env + caps + arg.
     assert!(
-        inc.contains("pub async fn main<__CdzE: CdzEnv>(__cdz_env: &mut __CdzE) -> std::rc::Rc<dyn Fn(i64) -> i64>")
-            && inc.contains("fn __lifted_0(x: i64) -> i64")
-            && !inc.contains("async fn __lifted_0"),
-        "a no-capture closure crosses on rust-async as a sync lifted fn under an async factory:\n{inc}"
+        both.contains("struct __Clos_0")
+            && both.contains("impl cdz_rt::EnvClosure<i64, i64> for __Clos_0")
+            && both.contains(
+                "Box::pin(__lifted_0(__cdz_env, self.__c0.clone(), self.__c1.clone(), __a0))"
+            ),
+        "the closure value is a per-closure struct impl'ing EnvClosure:\n{both}"
+    );
+    // The `Core::Closure` VALUE builds the struct + casts to `Rc<dyn EnvClosure>`.
+    assert!(
+        both.contains("std::rc::Rc::new(__Clos_0 { __c0: __c0, __c1: __c1 }) as std::rc::Rc<dyn cdz_rt::EnvClosure<i64, i64>>"),
+        "the closure value is Rc::new(__Clos_0{{..}}) as Rc<dyn EnvClosure>:\n{both}"
     );
 }
 
 #[test]
-fn async_lifted_closure_whose_body_makes_a_call_still_declines() {
-    // The BOUNDARY of the option-C slice: a lifted closure whose body reaches a runtime `Core::Call` would
-    // name an async callee (needing `env` threaded in) and cannot be a plain `Fn(A) -> R` — that boxed-
-    // future closure ABI is the deferred slice. Such a body must DECLINE cleanly on rust-async (not emit
-    // an uncompilable sync call to an async fn). A closure that captures a recursive helper it calls is the
-    // shape: the closure body's `(rec …)` is a `Core::Call`. (The SAME program compiles on sync `rust`.)
+fn async_lifted_closure_whose_body_makes_a_call_now_emits_env_closure() {
+    // OPTION A UNLOCK: a lifted closure whose body reaches a runtime `Core::Call` (an async callee needing
+    // env threaded + awaited) — previously a clean DECLINE — now EMITS under the EnvClosure ABI: the lifted
+    // fn is an `async fn` whose body awaits the call, and the closure value is `Rc<dyn EnvClosure>`. This is
+    // the shape that defeated the `Rc<dyn Fn>` attempts (a `Fn` closure can't return a future borrowing its
+    // own `&mut` env); `EnvClosure`'s generic `call<'a>` method ties the future to the env borrow.
+    // A recursive higher-order consumer `ap` keeps the closure as a RUNTIME VALUE it applies via `.call`.
     let src = "(module m \
-       (def (rec (: n Int64)) (if (= n 0) 0 (+ n (rec (+ n -1))))) \
-       (def (mk (: base Int64)) (fn ((: x Int64)) (+ base (rec x)))) (export mk))";
-    // Sync rust emits it (the lifted body's call is a plain sync call).
+       (def (ap (: g (-> Int64 Int64)) (: n Int64) (: x Int64)) (if (= n 0) x (ap g (+ n -1) (g x)))) \
+       (def (run) (let ((inc (fn ((: y Int64)) (+ y 1)))) (ap inc 5 10))) (export run))";
+    // Sync rust emits it (the closure is a plain `Rc<dyn Fn>` applied `(g)(x)`).
     assert!(
         compile_rust_result(src).is_ok(),
-        "the call-in-closure-body program compiles on SYNC rust"
+        "the higher-order closure program compiles on SYNC rust"
     );
-    // Async rust declines it cleanly (the deferred boxed-future closure ABI), with the specific message.
-    match compile_rust_async_result(src) {
-        Ok(s) => panic!("expected a clean async decline, but it emitted:\n{s}"),
-        Err(diags) => assert!(
-            diags
-                .iter()
-                .any(|d| d.contains("async lambda-lifted closure whose body makes a call")),
-            "declines with the call-in-body message, got: {diags:?}"
-        ),
+    // Async rust now EMITS it (no decline): the consumer takes `g: Rc<dyn EnvClosure<i64,i64>>` and applies
+    // it `g.call(env, x).await`, and the closure value builds an `EnvClosure` struct.
+    let a = compile_rust_async(src);
+    assert!(
+        a.contains("g: std::rc::Rc<dyn cdz_rt::EnvClosure<i64, i64>>"),
+        "the recursive consumer takes the EnvClosure by value:\n{a}"
+    );
+    assert!(
+        a.contains(".call(__cdz_env,") && a.contains(".await"),
+        "the consumer applies the closure via .call(env, arg).await:\n{a}"
+    );
+    assert!(
+        a.contains("impl cdz_rt::EnvClosure<i64, i64> for __Clos_0"),
+        "the closure value impls EnvClosure:\n{a}"
+    );
+    // e2e: rustc-roundtrip against cdz-rt proves the language wall is cleared (the `Rc<dyn Fn>` attempts
+    // could not compile THIS shape — a closure value passed to a recursive consumer + `.call`ed through
+    // `&mut dyn DynCdzEnv`). inc applied 5× to 10 = 15.
+    let driver = r#"
+struct Meter;
+impl cdz_rt::CdzEnv for Meter {
+    async fn consume(&mut self, _g: u64) {}
+}
+fn block_on<F: core::future::Future>(mut f: F) -> F::Output {
+    use core::task::*;
+    fn n(_: *const ()) {} fn c(_: *const ()) -> RawWaker { r() }
+    fn r() -> RawWaker { RawWaker::new(core::ptr::null(), &V) }
+    static V: RawWakerVTable = RawWakerVTable::new(c, n, n, n);
+    let w = unsafe { Waker::from_raw(r()) };
+    let mut cx = Context::from_waker(&w);
+    let mut f = unsafe { core::pin::Pin::new_unchecked(&mut f) };
+    loop { if let Poll::Ready(v) = f.as_mut().poll(&mut cx) { return v; } }
+}
+fn main() {
+    let mut e = Meter;
+    println!("{}", block_on(prog::run(&mut e)));
+}
+"#;
+    if let Some(out) = rustc_run_driver(&a, driver) {
+        assert_eq!(out, "15", "inc applied 5 times to 10 = 15:\n{a}");
     }
 }
 

--- a/implementation/seed/crates/rcdzc/src/backend/rust/types.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/types.rs
@@ -187,6 +187,123 @@ pub fn rust_type(ty: &Ty) -> Option<String> {
     }
 }
 
+/// The ASYNC-mode Rust type for a solved Cadenza type — identical to [`rust_type`] EXCEPT a function type
+/// `Ty::Fn` spells the UNIFORM async closure ABI `std::rc::Rc<dyn cdz_rt::EnvClosure<A, R>>` instead of the
+/// sync `Rc<dyn Fn(A…)->R>`. Under `--target rust-async` a lifted closure VALUE is `Rc<dyn EnvClosure<A,R>>`
+/// (its `call` future borrows the `&mut dyn DynCdzEnv` passed AT the call — a `dyn Fn` cannot express that;
+/// see `cdz_rt::EnvClosure`). So every SIGNATURE position that spells a closure type in async mode — a def
+/// param/result, a lifted-fn param/result, the `Core::Closure` value cast — must use THIS spelling, or the
+/// closure value (built as `Rc<dyn EnvClosure>`) mismatches its slot (E0308). `A`/`R` follow the
+/// lifted-lambda calling convention: `R` is the (non-arrow) result; `A` is the SINGLE arg for a 1-param
+/// closure, a TUPLE of the args for a multi-param closure (the flat lifted params tupled into `A`), and `()`
+/// for a 0-param closure. A closure NESTED inside a compound (a `(List (-> Int Int))`, a tuple element) is
+/// spelled async too — the walk recurses with `async_closure_type` through every compound arm, delegating a
+/// scalar/leaf to [`rust_type`] (which is mode-agnostic for non-function types). `None` on any
+/// non-representable component, exactly like `rust_type`.
+pub(super) fn async_closure_type(ty: &Ty) -> Option<String> {
+    match ty {
+        // A FUNCTION → the uniform async closure ABI. Peel the arrow SPINE (flat, like `rust_type`): the
+        // args are the spine's params, the result is the final non-arrow tail. Each arg + the result is
+        // itself spelled ASYNC (a higher-order closure arg/result is also `EnvClosure`).
+        Ty::Fn(_, _) => {
+            let mut args = Vec::new();
+            let mut cur = ty;
+            while let Ty::Fn(p, r) = cur {
+                args.push(async_closure_type(p)?);
+                cur = r;
+            }
+            let ret = async_closure_type(cur)?;
+            // `A` = () for 0 args, the single type for 1, a tuple for ≥2 (the lifted convention tuples a
+            // multi-arg closure's args into one `A`; `EnvClosure::call` destructures it).
+            let a = match args.len() {
+                0 => "()".to_string(),
+                1 => args.into_iter().next().unwrap(),
+                _ => format!("({})", args.join(", ")),
+            };
+            Some(format!("std::rc::Rc<dyn cdz_rt::EnvClosure<{a}, {ret}>>"))
+        }
+        // Compounds that can CONTAIN a closure recurse with `async_closure_type`; the spelling is otherwise
+        // identical to `rust_type`'s (same wrapper types), so a closure-free compound maps byte-identically.
+        Ty::Tuple(elems) => {
+            let mut parts = Vec::with_capacity(elems.len());
+            for e in elems.iter() {
+                parts.push(async_closure_type(e)?);
+            }
+            Some(if parts.len() == 1 {
+                format!("({},)", parts[0])
+            } else {
+                format!("({})", parts.join(", "))
+            })
+        }
+        Ty::Record(fields) => {
+            let mut parts = Vec::with_capacity(fields.len());
+            for v in fields.values() {
+                parts.push(async_closure_type(v)?);
+            }
+            Some(if parts.len() == 1 {
+                format!("({},)", parts[0])
+            } else {
+                format!("({})", parts.join(", "))
+            })
+        }
+        Ty::Sum { name, args, .. } => {
+            let ident = sum_ident(name);
+            if args.is_empty() {
+                Some(ident)
+            } else {
+                let mut params = Vec::with_capacity(args.len());
+                for a in args.iter() {
+                    params.push(async_closure_type(a)?);
+                }
+                Some(format!("{ident}<{}>", params.join(", ")))
+            }
+        }
+        Ty::Nominal { inner, .. } => async_closure_type(inner),
+        Ty::List(elem) => Some(format!("Vec<{}>", async_closure_type(elem)?)),
+        // A Map/Set KEY cannot be a closure (not `Ord`), so the key keeps `ord_key_type`; only the Map VALUE
+        // can carry a closure, so it recurses. (A closure-keyed collection would have declined upstream.)
+        Ty::Map(k, v) => Some(format!(
+            "std::collections::BTreeMap<{}, {}>",
+            ord_key_type(k)?,
+            async_closure_type(v)?
+        )),
+        Ty::Set(elem) => Some(format!(
+            "std::collections::BTreeSet<{}>",
+            ord_key_type(elem)?
+        )),
+        Ty::Qty { inner, unit }
+            if unit.scale() == (1, 1) || qty_scale_supported(inner, unit.scale()) =>
+        {
+            async_closure_type(inner)
+        }
+        // Every other type (scalars, Bytes, String, Symbol, …) has no closure inside — delegate to the
+        // mode-agnostic `rust_type` (identical spelling in both modes).
+        _ => rust_type(ty),
+    }
+}
+
+/// The `(A, R)` type-argument spelling for a lifted lambda's `EnvClosure<A, R>` impl, in ASYNC mode: `R` is
+/// the lambda's result type, `A` is the single param type (arity 1), a tuple of the param types (arity ≥2),
+/// or `()` (arity 0) — the SAME convention [`async_closure_type`]'s `Ty::Fn` arm produces, so a closure
+/// VALUE's `Rc<dyn EnvClosure<A,R>>` and its TYPE-position spelling agree. `None` if any param/result has no
+/// async representation.
+pub(super) fn env_closure_args(
+    params: &[(crate::ast::StructId, Ty)],
+    ret: &Ty,
+) -> Option<(String, String)> {
+    let mut arg_tys = Vec::with_capacity(params.len());
+    for (_, t) in params {
+        arg_tys.push(async_closure_type(t)?);
+    }
+    let a = match arg_tys.len() {
+        0 => "()".to_string(),
+        1 => arg_tys.into_iter().next().unwrap(),
+        _ => format!("({})", arg_tys.join(", ")),
+    };
+    let r = async_closure_type(ret)?;
+    Some((a, r))
+}
+
 /// The Rust type for a Set ELEMENT / Map KEY position — like [`rust_type`], except a bare `Float` maps to a
 /// WIDTH-SPECIFIC total-order wrapper (a `BTreeSet`/`BTreeMap` needs `Ord`, which `f32`/`f64` lack). The
 /// wrapper MUST match the float's width: a `Float64` → `__CdzF64` (over `u64` bits), a `Float32` → `__CdzF32`

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2080,8 +2080,19 @@ fn run_program_rust(
             } else {
                 format!("prog::{export}(&mut env, {caps})")
             };
-            // `block_on` awaits the factory's future to obtain the closure handle, then applies it.
-            format!("block_on({factory}){application}")
+            // OPTION A: the factory returns `Rc<dyn EnvClosure<A,R>>` (NOT a sync `Rc<dyn Fn>`), so its
+            // returned closure is applied via `handle.call(&mut env, arg).await`, NOT the sync `(applied)`.
+            // `block_on(factory)` yields the handle; bind it to `__h` FIRST so the `.call(&mut env, …)` env
+            // borrow doesn't overlap the factory's (E0499). `application` is `(applied…)` — the flat applied
+            // args; `EnvClosure::call` takes ONE `A` (a multi-arg closure tuples them, matching the lifted
+            // convention + the emit's CallClosure). Strip the parens and tuple ≥2 args into one `A`.
+            let applied = application
+                .strip_prefix('(')
+                .and_then(|s| s.strip_suffix(')'))
+                .unwrap_or("")
+                .trim();
+            let arg = env_closure_call_arg(applied);
+            format!("{{ let __h = block_on({factory}); block_on(__h.call(&mut env, {arg})) }}")
         } else if call_expr.ends_with("()") {
             format!("block_on(prog::{export}(&mut env))")
         } else {
@@ -2424,6 +2435,34 @@ fn cdz_render_bytes_list(ty: &str) -> String {
 /// closure is not applied). The split is the FIRST `)` at paren-depth 0 that is immediately followed by a
 /// `(` — a nested `)(` inside a compound argument (`both((tuple 1 2), (record …))`) sits at depth > 0 and is
 /// skipped, so only the real factory/application seam matches.
+/// The single `EnvClosure::call` `A` argument from a flat applied-args string (`"5"`, `"3, 4"`, `""`). A
+/// 0-arg closure takes `()`; a 1-arg closure the bare arg; a ≥2-arg closure a TUPLE `(a, b)` — matching the
+/// lifted-lambda calling convention the backend's `Core::CallClosure`/`EnvClosure` impl uses (a multi-arg
+/// closure tuples its flat args into one `A`, destructured inside `call`). Splits on TOP-LEVEL commas only
+/// (a compound arg `(tuple 1 2)` / `Rc::new(..)` keeps its inner commas), so `(a, (x, y))` stays two args.
+fn env_closure_call_arg(applied: &str) -> String {
+    let applied = applied.trim();
+    if applied.is_empty() {
+        return "()".to_string();
+    }
+    let bytes = applied.as_bytes();
+    let mut depth = 0usize;
+    let mut n_top_commas = 0usize;
+    for &b in bytes {
+        match b {
+            b'(' | b'<' | b'[' => depth += 1,
+            b')' | b'>' | b']' => depth = depth.saturating_sub(1),
+            b',' if depth == 0 => n_top_commas += 1,
+            _ => {}
+        }
+    }
+    if n_top_commas == 0 {
+        applied.to_string() // 1 arg → the bare arg
+    } else {
+        format!("({applied})") // ≥2 args → a tuple of them
+    }
+}
+
 fn split_factory_application(call_expr: &str) -> Option<(String, String)> {
     let bytes = call_expr.as_bytes();
     let mut depth = 0usize;
@@ -2539,9 +2578,21 @@ fn is_env_param(param: &str) -> bool {
     param.trim_start().starts_with("__cdz_env") || param.contains("&mut __CdzE")
 }
 
-/// Whether a parameter slice (`<name>: <type>`) is a closure — its type is an `Rc<dyn Fn(…)>`.
+/// Whether a type string names a runtime closure VALUE — either the SYNC `Rc<dyn Fn(…)>` or the ASYNC
+/// (Option A) `Rc<dyn cdz_rt::EnvClosure<A, R>>` (a lifted async closure crosses as an `EnvClosure` trait
+/// object, not a `dyn Fn`, since its `call` future borrows the `&mut env` — see `cdz_rt::EnvClosure`). Both
+/// closure-detection sites (a PARAM type, a factory RESULT type) key off this so the async host-closure
+/// cases are recognized as factories/consumers/producers exactly like the sync ones.
+fn names_closure_value(ty: &str) -> bool {
+    ty.contains("Rc<dyn Fn(")
+        || ty.contains("Rc<dyn cdz_rt::EnvClosure<")
+        || ty.contains("Rc<dyn EnvClosure<")
+}
+
+/// Whether a parameter slice (`<name>: <type>`) is a closure — sync `Rc<dyn Fn(…)>` or async `Rc<dyn
+/// EnvClosure<…>>`.
 fn is_closure_param(param: &str) -> bool {
-    param.contains("std::rc::Rc<dyn Fn(") || param.contains("Rc<dyn Fn(")
+    names_closure_value(param)
 }
 
 /// The closure TYPE of a parameter slice (`g: std::rc::Rc<dyn Fn(i64) -> i64>`) → the `Rc<dyn Fn…>` text,
@@ -2553,9 +2604,16 @@ fn is_closure_param(param: &str) -> bool {
 /// to a higher-order producer `Rc<dyn Fn(Rc<dyn Fn(i64)->i64>)->i64>` (the former is a substring of the
 /// latter), so the pairing must compare EXACT balanced closure types (`ty_matches` uses `==` — see there).
 fn closure_param_type(param: &str) -> Option<&str> {
+    // Locate the `Rc<…>` closure type — sync `Rc<dyn Fn(` or async `Rc<dyn [cdz_rt::]EnvClosure<`. The
+    // balanced `<`/`>` walk below then extracts the whole `Rc<…>` (the `EnvClosure<A, R>`'s inner `<>` and
+    // the `Fn(A) -> R`'s `->` are both handled by the depth counter + the `->` guard), so an async closure
+    // param `g: std::rc::Rc<dyn cdz_rt::EnvClosure<i64, i64>>` yields exactly its `Rc<…>` type.
     let start = param
         .find("std::rc::Rc<dyn Fn(")
-        .or_else(|| param.find("Rc<dyn Fn("))?;
+        .or_else(|| param.find("std::rc::Rc<dyn cdz_rt::EnvClosure<"))
+        .or_else(|| param.find("Rc<dyn Fn("))
+        .or_else(|| param.find("Rc<dyn cdz_rt::EnvClosure<"))
+        .or_else(|| param.find("Rc<dyn EnvClosure<"))?;
     let rest = &param[start..];
     // Find the `<` that opens `Rc<` and walk to its MATCHING `>` (depth-balanced over `<`/`>`), so a nested
     // `Rc<dyn Fn(Rc<…>)…>` returns its whole self and a trailing `, x: i64` is excluded. CRITICAL: the
@@ -2590,12 +2648,15 @@ fn param_type_of(param: &str) -> String {
     }
 }
 
-/// The `Rc<dyn Fn(…)>` closure type out of a return-head (`-> std::rc::Rc<dyn Fn(i64) -> i64>`), trimming
-/// the leading `->`. `None` if the return is not a closure type.
+/// The closure type out of a return-head — sync `-> std::rc::Rc<dyn Fn(i64) -> i64>` or async `-> std::rc::
+/// Rc<dyn cdz_rt::EnvClosure<i64, i64>>` — trimming the leading `->`. `None` if the return is not a closure.
 fn closure_ret_type(ret_head: &str) -> Option<String> {
     let start = ret_head
         .find("std::rc::Rc<dyn Fn(")
-        .or_else(|| ret_head.find("Rc<dyn Fn("))?;
+        .or_else(|| ret_head.find("std::rc::Rc<dyn cdz_rt::EnvClosure<"))
+        .or_else(|| ret_head.find("Rc<dyn Fn("))
+        .or_else(|| ret_head.find("Rc<dyn cdz_rt::EnvClosure<"))
+        .or_else(|| ret_head.find("Rc<dyn EnvClosure<"))?;
     Some(ret_head[start..].trim().to_string())
 }
 
@@ -2677,9 +2738,13 @@ fn build_closure_consumer_call(
             continue;
         };
         let src_params: Vec<&&str> = psig.params.iter().filter(|p| !is_env_param(p)).collect();
-        if psig.ret_head.contains("Rc<dyn Fn(") {
-            // FACTORY: result is a closure. Its `cdz-return[ident]` note is the arrow render-name (the
-            // pre-erasure closure shape) — captured for the collision-disambiguation pairing below.
+        if names_closure_value(&psig.ret_head) {
+            // FACTORY: result is a closure (sync `Rc<dyn Fn(` or async `Rc<dyn EnvClosure<`). A NULLARY
+            // factory (cap = 0) returning a closure value is the common host-closure producer `(def (mk) (fn
+            // (n) …))`; classifying it here (not as a Peeled fn-item, which an async closure can't be) is what
+            // lets the async consumer path drive it via `block_on(prog::mk(&mut env))` → the `Rc<dyn
+            // EnvClosure>` handle. Its `cdz-return[ident]` note is the arrow render-name (pre-erasure closure
+            // shape) — captured for the collision-disambiguation pairing below.
             let cty = closure_ret_type(&psig.ret_head)?;
             let shape = cdz_return_type(module, &ident);
             producers.push(Producer::Factory {
@@ -2849,8 +2914,9 @@ fn build_closure_consumer_call(
 
 fn rust_factory_param_count(module: &str, name: &str, async_mode: bool) -> Option<usize> {
     let sig = parse_emitted_sig(module, name, async_mode)?;
-    // A FACTORY's return type is a closure (`-> …Rc<dyn Fn(`) — only then is this a producer.
-    if !sig.ret_head.contains("Rc<dyn Fn(") {
+    // A FACTORY's return type is a closure (`-> …Rc<dyn Fn(` or async `-> …Rc<dyn EnvClosure<`) — only
+    // then is this a producer.
+    if !names_closure_value(&sig.ret_head) {
         return None;
     }
     // The factory's CAPTURE params = its source params minus the async env param (which is backend


### PR DESCRIPTION
Candidate PR for v-rust-backend's merge-request (ref c73a0a096, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.