### PR TITLE
cdz-agent-host: migrate Session::genesis callers to the 2-arg (spawn_nonce) form — clears the trunk-red from #2392

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/Cargo.lock
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.lock
@@ -582,6 +582,7 @@ dependencies = [
  "aws-sdk-bedrockruntime",
  "bytes",
  "cdz-kernel",
+ "getrandom 0.2.17",
  "reqwest",
  "s2n-quic-dc-metrics",
  "serde",

--- a/implementation/seed/crates/cdz-agent-host/Cargo.toml
+++ b/implementation/seed/crates/cdz-agent-host/Cargo.toml
@@ -101,6 +101,14 @@ tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
 # (all async, single trait each). My `ModelTransport`/`HttpTransport` sub-traits + my native `impl Executor`
 # for the executors use `#[async_trait(?Send)]` (single-threaded host, non-Send transport futures — §15b).
 async-trait = "0.1"
+# getrandom — OS entropy for a fresh session's SPAWN NONCE (§lifecycle I2a). v-agent-harness's
+# `Session::genesis(reducer, spawn_nonce)` made `genesis_hash` (= the host's SessionId) per-session-UNIQUE
+# by hashing a caller-supplied nonce into the seq-0 Genesis event; the HOST mints that nonce (kernel stays
+# clock/entropy-free, §9c). We draw 32 fresh OS-random bytes and hash them into a `Hash` (blake3 semantics
+# via `Hash::of`, NOT `Hash::from_bytes` — the nonce is a HASH of entropy, keeping the type's invariant).
+# Minted ONCE at fresh genesis + recorded in the durable log; replay/recover reads it back FROM the log
+# (never re-mints — a re-mint would change the SessionId on recovery). Tiny, std-only, no network.
+getrandom = "0.2"
 # serde + toml — the daemon's single-TOML config (operator directive: "set the entire thing up via config
 # and not from cli args; the only arg I want is the path to the config"). serde derives the config schema;
 # toml parses the file. Small, always-on (the config layer is part of the daemon's core, not feature-gated

--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -82,6 +82,19 @@ impl SessionId {
     }
 }
 
+/// Mint a fresh SPAWN NONCE for a root session's genesis (§lifecycle I2a) — 32 OS-random bytes hashed into
+/// a [`Hash`]. This is the host-supplied entropy that makes `genesis_hash` (= the SessionId) per-session
+/// UNIQUE: two sessions over the same reducer get different nonces → different ids. We `Hash::of` the
+/// random bytes rather than `Hash::from_bytes` them so the value is a real content hash (blake3 domain),
+/// not raw bytes coerced into the `Hash` type — the nonce is a HASH of entropy, uniformly with every other
+/// `Hash` in the system. `getrandom` panicking is not survivable (no entropy source = we can't safely mint
+/// a unique id), so a failure is a hard error, not a silent weak-nonce fallback.
+fn mint_spawn_nonce() -> Hash {
+    let mut bytes = [0u8; 32];
+    getrandom::getrandom(&mut bytes).expect("OS entropy (getrandom) for a session spawn nonce");
+    Hash::of(&bytes)
+}
+
 /// One running agent: the kernel `Session` plus the collaborators that drive its loop. The host owns all
 /// of them for the session's lifetime, so a registry can drive the session by id (the kernel's `deliver`
 /// borrows reducer/authz/executor per call; bundling them here is what lets the host re-supply them).
@@ -100,6 +113,14 @@ impl HostedSession {
     ///
     /// `reducer` is a `Box<dyn Reducer>`: a pure-Rust reducer is passed as
     /// `Box::new(my_reducer)`, a wasm reducer as `Box::new(AsyncComponentReducer::…)`.
+    ///
+    /// A fresh, OS-random SPAWN NONCE is minted here and hashed into the seq-0 Genesis event (§lifecycle
+    /// I2a): `Session::genesis(reducer, spawn_nonce)` makes `genesis_hash` — the host's SessionId primitive
+    /// — per-session UNIQUE, so two sessions over the SAME reducer no longer collide on their id. The kernel
+    /// stays entropy-free (§9c): the host is the entropy source, the nonce rides the durable log, and
+    /// recovery reads it back from the log (never re-mints) so a recovered session keeps its id. This is a
+    /// ROOT session (`parent = None`); the `lifecycle/spawn` child path (I3) uses
+    /// [`Session::genesis_spawned`] with the parent's genesis hash instead.
     pub fn genesis(
         reducer_hash: Hash,
         reducer: Box<dyn Reducer>,
@@ -107,7 +128,7 @@ impl HostedSession {
         executor: CompositeExecutor,
     ) -> Self {
         HostedSession {
-            session: Session::genesis(reducer_hash),
+            session: Session::genesis(reducer_hash, mint_spawn_nonce()),
             reducer,
             authz,
             executor,
@@ -309,12 +330,14 @@ impl HostedSession {
     /// the SessionId directly, so cross-session routing needs no separate hash→id map — the resolved hash-hex
     /// is the routable id). A caller assigns/validates a [`SessionId`] against `hex(this)`.
     ///
-    /// ⚠️ NOT per-session-unique TODAY: the genesis event carries the reducer hash ALONE (no spawn entropy),
-    /// so two sessions over the SAME reducer produce the SAME genesis_hash — a SessionId COLLISION under the
-    /// identity ruling (see `genesis_hash_of_two_same_reducer_sessions_collides_uniqueness_gap`, which PINS
-    /// that collision). Making it per-session-unique is the documented fix path (spawn-time entropy in the
-    /// genesis event, per the operator's "hash of spawn-time + entropy" instinct — greenlit, owned by
-    /// v-agent-harness's kernel seam), NOT current behavior.
+    /// PER-SESSION UNIQUE (§lifecycle I2a): the genesis event carries a fresh OS-random SPAWN NONCE
+    /// (minted by [`mint_spawn_nonce`] at [`HostedSession::genesis`], or the parent's provenance at
+    /// `Session::genesis_spawned` for a spawned child), hashed into the seq-0 event alongside the reducer
+    /// hash. So two sessions over the SAME reducer get DIFFERENT genesis_hashes → distinct SessionIds — no
+    /// registry-key collision (see `two_same_reducer_sessions_get_distinct_genesis_hashes_uniqueness_gap_closed`).
+    /// The nonce is host-supplied (the kernel stays entropy-free, §9c) and rides the durable log, so a
+    /// recovered/replayed session reconstructs the SAME genesis_hash from its log — the id is stable across
+    /// recovery, never re-minted.
     pub fn genesis_hash(&self) -> Hash {
         self.session.genesis_hash()
     }
@@ -938,16 +961,14 @@ mod tests {
     }
 
     #[test]
-    fn genesis_hash_of_two_same_reducer_sessions_collides_uniqueness_gap() {
-        // ⚠️ SURFACED (flagged to v-agent-harness): the operator's SessionId=genesis-hash ruling assumes a
-        // genesis hash is per-session-UNIQUE, but Session::genesis(reducer) builds a Genesis{reducer} event
-        // with NO entropy — so two sessions over the SAME reducer_hash produce IDENTICAL genesis events →
-        // IDENTICAL genesis_hash. This test PINS that collision as the current (gap) behavior: under
-        // SessionId=hex(genesis_hash), spawning a second same-reducer session would COLLIDE on the registry
-        // key (replace the first). The naming increment needs genesis to carry entropy (spawn-time/nonce, per
-        // the operator's original "hash of spawn-time + entropy" instinct) OR a rule that same-reducer
-        // sessions can't coexist. If this assert_eq ever flips to assert_ne (genesis gains entropy), the gap
-        // is closed — update it then.
+    fn two_same_reducer_sessions_get_distinct_genesis_hashes_uniqueness_gap_closed() {
+        // §lifecycle I2a CLOSED the SessionId-uniqueness gap this test used to PIN. Previously
+        // `Session::genesis(reducer)` carried no entropy, so two sessions over the SAME reducer produced
+        // IDENTICAL genesis events → IDENTICAL genesis_hash → a SessionId COLLISION (a second same-reducer
+        // session would clobber the first in the registry). Now `HostedSession::genesis` mints a fresh
+        // OS-random spawn nonce into the seq-0 Genesis event (via `mint_spawn_nonce`), so two same-reducer
+        // sessions get DIFFERENT nonces → DIFFERENT genesis_hash → distinct SessionIds. This asserts the
+        // gap is closed (assert_ne, flipped from the old assert_eq pin).
         let a = HostedSession::genesis(
             Hash::of(b"same-reducer"),
             Box::new(GenesisRecordingReducer),
@@ -960,11 +981,11 @@ mod tests {
             Box::new(Authorizer::deny_all()),
             CompositeExecutor::new(),
         );
-        assert_eq!(
+        assert_ne!(
             a.genesis_hash(),
             b.genesis_hash(),
-            "two same-reducer sessions collide on genesis_hash today (no genesis entropy) — the \
-             SessionId=genesis-hash uniqueness gap, flagged to v-agent-harness"
+            "two same-reducer sessions now get DISTINCT genesis_hashes (per-session spawn nonce, \
+             §lifecycle I2a) — the SessionId=genesis-hash uniqueness gap is closed"
         );
     }
 

--- a/implementation/seed/crates/cdz-agent-host/tests/agent_runs_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/agent_runs_e2e.rs
@@ -86,7 +86,7 @@ async fn agent_loop_runs_end_to_end_through_the_real_clock_executor() {
     // will be alongside it.
     let mut exec =
         CompositeExecutor::new().with_effect(effect_ct::NOW, Box::new(ClockExecutor::new()));
-    let mut session = Session::genesis(Hash::of(b"clock-agent-v1"));
+    let mut session = Session::genesis(Hash::of(b"clock-agent-v1"), Hash::of(b"clock-agent-v1-nonce"));
 
     session
         .deliver(inbound_go(), None, &reducer, &authz, &mut exec)
@@ -124,7 +124,7 @@ async fn the_recorded_instant_makes_the_run_replayable() {
     let reducer = ClockAgent;
     let mut exec =
         CompositeExecutor::new().with_effect(effect_ct::NOW, Box::new(ClockExecutor::new()));
-    let mut session = Session::genesis(Hash::of(b"clock-agent-v1"));
+    let mut session = Session::genesis(Hash::of(b"clock-agent-v1"), Hash::of(b"clock-agent-v1-nonce"));
     session
         .deliver(inbound_go(), None, &ClockAgent, &now_cap(), &mut exec)
         .await
@@ -154,7 +154,7 @@ async fn a_now_effect_outside_the_grant_is_denied_never_reaching_the_clock() {
     let deny = Authorizer::deny_all();
     let mut exec =
         CompositeExecutor::new().with_effect(effect_ct::NOW, Box::new(ClockExecutor::new()));
-    let mut session = Session::genesis(Hash::of(b"clock-agent-v1"));
+    let mut session = Session::genesis(Hash::of(b"clock-agent-v1"), Hash::of(b"clock-agent-v1-nonce"));
     session
         .deliver(inbound_go(), None, &reducer, &deny, &mut exec)
         .await

--- a/implementation/seed/crates/cdz-agent-host/tests/cedar_authz_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/cedar_authz_e2e.rs
@@ -110,7 +110,7 @@ async fn a_real_agent_is_gated_by_a_real_cedar_decision() {
         let reducer = PolicyProbe;
         let mut exec = CompositeExecutor::new()
             .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(StubModel)));
-        let mut session = Session::genesis(Hash::of(b"cedar-permit-v1"));
+        let mut session = Session::genesis(Hash::of(b"cedar-permit-v1"), Hash::of(b"cedar-permit-v1-nonce"));
         session
             .deliver(inbound("model-ok"), None, &reducer, &authz, &mut exec)
             .await
@@ -136,7 +136,7 @@ async fn a_real_agent_is_gated_by_a_real_cedar_decision() {
         // Http executor isn't even needed to prove the deny (the gate stops it first).
         let mut exec = CompositeExecutor::new()
             .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(StubModel)));
-        let mut session = Session::genesis(Hash::of(b"cedar-deny-v1"));
+        let mut session = Session::genesis(Hash::of(b"cedar-deny-v1"), Hash::of(b"cedar-deny-v1-nonce"));
         session
             .deliver(inbound("http-imds"), None, &reducer, &authz, &mut exec)
             .await

--- a/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
@@ -98,7 +98,7 @@ async fn agent_loop_runs_end_to_end_through_the_http_executor() {
     let reducer = FetchAgent;
     let mut exec = CompositeExecutor::new()
         .with_effect(effect_ct::HTTP, Box::new(HttpExecutor::new(StubHttp)));
-    let mut session = Session::genesis(Hash::of(b"fetch-agent-v1"));
+    let mut session = Session::genesis(Hash::of(b"fetch-agent-v1"), Hash::of(b"fetch-agent-v1-nonce"));
 
     session
         .deliver(inbound_go(), None, &FetchAgent, &host_cap(), &mut exec)
@@ -159,7 +159,7 @@ async fn a_fetch_to_an_unpermitted_host_is_denied_before_the_client() {
     }
     let mut exec = CompositeExecutor::new()
         .with_effect(effect_ct::HTTP, Box::new(HttpExecutor::new(MustNotCall)));
-    let mut session = Session::genesis(Hash::of(b"exfil-agent-v1"));
+    let mut session = Session::genesis(Hash::of(b"exfil-agent-v1"), Hash::of(b"exfil-agent-v1-nonce"));
     session
         .deliver(inbound_go(), None, &ExfilAgent, &host_cap(), &mut exec)
         .await

--- a/implementation/seed/crates/cdz-agent-host/tests/model_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/model_agent_e2e.rs
@@ -96,7 +96,7 @@ async fn agent_loop_runs_end_to_end_through_the_model_executor() {
     let reducer = ModelAgent;
     let mut exec = CompositeExecutor::new()
         .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(StubModel)));
-    let mut session = Session::genesis(Hash::of(b"model-agent-v1"));
+    let mut session = Session::genesis(Hash::of(b"model-agent-v1"), Hash::of(b"model-agent-v1-nonce"));
 
     session
         .deliver(inbound_go(), None, &ModelAgent, &model_cap(), &mut exec)
@@ -186,7 +186,7 @@ async fn one_composite_routes_both_now_and_model_for_one_agent() {
     let mut exec = CompositeExecutor::new()
         .with_effect(effect_ct::NOW, Box::new(ClockExecutor::new()))
         .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(StubModel)));
-    let mut session = Session::genesis(Hash::of(b"clock-then-model-v1"));
+    let mut session = Session::genesis(Hash::of(b"clock-then-model-v1"), Hash::of(b"clock-then-model-v1-nonce"));
 
     session
         .deliver(inbound_go(), None, &ClockThenModel, &authz, &mut exec)
@@ -234,7 +234,7 @@ async fn a_model_call_to_an_unpermitted_id_is_denied_before_the_transport() {
     }
     let mut exec = CompositeExecutor::new()
         .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(MustNotCall)));
-    let mut session = Session::genesis(Hash::of(b"wrong-model-v1"));
+    let mut session = Session::genesis(Hash::of(b"wrong-model-v1"), Hash::of(b"wrong-model-v1-nonce"));
     session
         .deliver(
             inbound_go(),


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 4c837e861, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.