### PR TITLE
rcdzc(rust-async): drive host/@param cases on rust-async — lift the blanket async-host DECLINE guard (+103 newly-passing)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/rust/mod.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/mod.rs
@@ -715,8 +715,11 @@ pub fn emit(db: &mut Db, layout: &Layout, mode: Mode) -> Result<Vec<u8>, Reject>
 //   - `EnvClosure` — only a module that emits an async CLOSURE value (its per-closure struct `impl
 //     EnvClosure`) names it directly.
 //   - `CdzEnv` — the base trait an APPLICATION/the gate harness impls for its concrete env; an emitted
-//     module no longer names it directly (async fns take `dyn DynCdzEnv`, not a generic `<__CdzE: CdzEnv>`),
-//     but it stays in the `use` so the blanket `impl<E: CdzEnv> DynCdzEnv for E` (cdz-rt) is in scope.
+//     module no longer names it directly (async fns take `dyn DynCdzEnv`, not a generic `<__CdzE: CdzEnv>`).
+//     It is kept in the `use` only to avoid conditionalizing the preamble on which traits a given module
+//     references (simpler to always import all three); its presence does NOT affect the cdz-rt blanket
+//     `impl<E: CdzEnv> DynCdzEnv for E` — a blanket impl applies regardless of whether the trait is imported
+//     at the use site. Harmless under the `#[allow(unused_imports)]` below.
 // A closure-free (or trait-unreferencing) async program imports some of these unused, which `-D warnings`
 // (`unused_imports`) would reject — so `#[allow(unused_imports)]` the whole `use` (a mechanically-emitted
 // preamble import, like the backend's other synthesized `#[allow(dead_code)]` helpers). Simpler + robust

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5788,129 +5788,129 @@ pass	zero divided by a runtime value folds to zero but keeps the zero-divisor gu
 pass	α-equivalence (aconv) recognizes (λx.x) and (λy.y) as the same term up to bound-variable renaming
 pass	α-equivalence handles nesting and distinguishes a bound variable from a same-numbered free variable
 todo	Set.of over runtime lists at two different element types declines pending the recursive-generic tie
-todo	TWO closures capturing one let-bound host call share ONE firing (in the exported def)
+pass	TWO closures capturing one let-bound host call share ONE firing (in the exported def)
 todo	Type is a first-class value
-todo	a 60-key trie captured ACROSS a host call reads intact after the response folds in
-todo	a @param accessor read inside a RECURSIVE walk consumes one response per iteration
-todo	a @param accessor splices into a quasiquote and the eval computes with the host value
-todo	a @param drives a recursive fold's iteration count
-todo	a @param of type (Qty Rational unit) desugars to num/den scalars + a guest Qty.of with the unit (#13 B2)
-todo	a @param of type Rational desugars to two scalar num/den accessors the guest recombines (#13)
-todo	a @param positions a slice window over a guest-built byte rope
-todo	a @param selects a match arm and a SECOND param feeds the selected body
-todo	a @param slice window at an interior cut reads the non-straddling bytes
-todo	a @param slice window whose length exceeds the remaining bytes yields None
-todo	a @param value SEEDS an in-program handler's state
-todo	a @param value crosses into a closure capture and applies
-todo	a @param value drives a CHAMP map lookup as the KEY
-todo	a @param value sizes a guest-built HEAP structure
+pass	a 60-key trie captured ACROSS a host call reads intact after the response folds in
+pass	a @param accessor read inside a RECURSIVE walk consumes one response per iteration
+pass	a @param accessor splices into a quasiquote and the eval computes with the host value
+pass	a @param drives a recursive fold's iteration count
+pass	a @param of type (Qty Rational unit) desugars to num/den scalars + a guest Qty.of with the unit (#13 B2)
+pass	a @param of type Rational desugars to two scalar num/den accessors the guest recombines (#13)
+pass	a @param positions a slice window over a guest-built byte rope
+pass	a @param selects a match arm and a SECOND param feeds the selected body
+pass	a @param slice window at an interior cut reads the non-straddling bytes
+pass	a @param slice window whose length exceeds the remaining bytes yields None
+pass	a @param value SEEDS an in-program handler's state
+pass	a @param value crosses into a closure capture and applies
+pass	a @param value drives a CHAMP map lookup as the KEY
+pass	a @param value sizes a guest-built HEAP structure
 todo	a BARE-param escaping closure capturing a handled value declines cleanly (annotated-param twin folds)
 todo	a BLOCK-wrapped branch perform in a MATCH-SCRUTINEE declines cleanly (adv-69 g3 sub-face)
 todo	a BLOCK-wrapped branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3 sub-face)
 todo	a BLOCK-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, not a silent miscompile)
 todo	a BLOCK-wrapped branch perform in a non-tail DO-STATEMENT declines cleanly (adv-69 c3 sub-face)
-todo	a Bool host arg BESIDE a scalar and a String composes in one mixed-arity op
-todo	a Bytes value SENT to the host is still readable after the call (the arg marshal borrows)
+pass	a Bool host arg BESIDE a scalar and a String composes in one mixed-arity op
+pass	a Bytes value SENT to the host is still readable after the call (the arg marshal borrows)
 todo	a DEPTH-2 block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor, nested wrappers)
 todo	a DEPTH-3 nested-op chain whose deepest resume performs the outer effect declines cleanly (no silent drop)
 todo	a DIRECT branch perform in a NESTED handler-arm resume-value declines cleanly (adv-69 a3-direct sub-face)
-todo	a Float64 closure captures a Float64 build-time host effect result
-todo	a Float64-inner Qty host result crosses as its float magnitude
+pass	a Float64 closure captures a Float64 build-time host effect result
+pass	a Float64-inner Qty host result crosses as its float magnitude
 todo	a HEAP-accumulator block-wrapped branch perform in a let-init declines cleanly (adv-69 safe floor)
 todo	a MODULE-exported closure that performs a delegated effect cannot cross the host boundary
-todo	a NOMINAL-Unit-typed host-call statement in a do-body is not spuriously dropped
-todo	a NON-TAIL host call consumes rows on the unwind, deepest frame first
-todo	a Quantity @param generates a Qty-result accessor the host supplies as a scalar magnitude
-todo	a ROPE Bytes arg (recursive concat, uncompacted) crosses the host boundary
-todo	a Rational-MAGNITUDE Quantity host value composes the num/den ops with the unit erasure (#13, B2)
-todo	a String host RESULT crosses the boundary and is read twice (byte-len + scalar-len of a multibyte response)
+pass	a NOMINAL-Unit-typed host-call statement in a do-body is not spuriously dropped
+pass	a NON-TAIL host call consumes rows on the unwind, deepest frame first
+pass	a Quantity @param generates a Qty-result accessor the host supplies as a scalar magnitude
+pass	a ROPE Bytes arg (recursive concat, uncompacted) crosses the host boundary
+pass	a Rational-MAGNITUDE Quantity host value composes the num/den ops with the unit erasure (#13, B2)
+pass	a String host RESULT crosses the boundary and is read twice (byte-len + scalar-len of a multibyte response)
 todo	a block-wrapped OUTER-effect perform in a do-statement TWO nested handlers deep declines cleanly (adv-69 nh7 depth-3)
 todo	a block-wrapped OUTER-effect perform in a let-init THREE handlers deep declines cleanly (adv-69 a4-depth3 sub-face)
 todo	a block-wrapped OUTER-effect perform in a match-SCRUTINEE inside a nested handler body declines cleanly (adv-69 g3-nested)
 todo	a block-wrapped OUTER-effect perform in a nested handle's INIT declines cleanly (adv-69 a4-init sub-face)
 todo	a block-wrapped OUTER-effect perform in a non-tail do-statement INSIDE a nested handler body declines cleanly (adv-69 c3-nested sub-face)
 todo	a block-wrapped branch perform of the OUTER effect in a let-init INSIDE a nested handler body declines cleanly (adv-69 a4 sub-face)
-todo	a build-time delegated effect whose result a returned closure captures does not escape
+pass	a build-time delegated effect whose result a returned closure captures does not escape
 todo	a closed literal closure forwarded through const-wrapper hops is not a false reject
-todo	a closure captures the result of a build-time host op called with an argument
-todo	a closure capturing a build-time host effect preserves the order of two host calls
-todo	a conditional performs only the taken branch's effect — else
-todo	a conditional performs only the taken branch's effect — then
+pass	a closure captures the result of a build-time host op called with an argument
+pass	a closure capturing a build-time host effect preserves the order of two host calls
+pass	a conditional performs only the taken branch's effect — else
+pass	a conditional performs only the taken branch's effect — then
 todo	a constant-try helper that fails feeds the None arm's fallback into resume
 todo	a cross-handler foreign-perform op-arg into a MATCH-shaped-resume arm declines cleanly (completeness gap)
-todo	a deep trie built BETWEEN two host calls reads correctly after the second
-todo	a delegated effect performed in a closure passed to a HOF is reached and fires
-todo	a delegated effect performed inside an intra-program handler
-todo	a delegated effect reached only through an if-branch is granted and fires when the branch is taken
-todo	a delegated host effect composes with the value-heap runtime
-todo	a discarded pure trapping item in a host do-body is elided beside a host call (dead-init ruling)
-todo	a host call's response is an ordinary value that feeds a LATER host call
-todo	a host effect with a non-kebab NAME crosses under a normalized interface extern name
-todo	a host effect with a non-kebab OPERATION name crosses under a normalized func extern name
-todo	a host op returning Bool crosses the boundary and drives a branch
-todo	a host op whose result is a QUANTITY crosses the boundary as its inner scalar (unit erased)
-todo	a host op with a Bytes arg AND a scalar arg crosses both parameters (list<u8> beside a scalar)
-todo	a host op with a String parameter composes with the value-heap runtime
-todo	a host response SIZES a guest-built collection which is then folded and keyed
-todo	a host result captured by closures in a NESTED tuple fires the host op once (adv-62 nested face)
-todo	a host result captured by two closures stored in a RECORD fires the host op once (adv-62b)
-todo	a host-block scrutinee folding to a multi-arm sum switch fires the host op once (adv-62 switch face)
-todo	a host-delegated result SEEDS an in-program handler's initial state
-todo	a host-op argument COMPUTED by guest arithmetic crosses the boundary evaluated
-todo	a let-bound host result captured by two escaping closures fires the host op once (adv-62)
+pass	a deep trie built BETWEEN two host calls reads correctly after the second
+pass	a delegated effect performed in a closure passed to a HOF is reached and fires
+pass	a delegated effect performed inside an intra-program handler
+pass	a delegated effect reached only through an if-branch is granted and fires when the branch is taken
+pass	a delegated host effect composes with the value-heap runtime
+pass	a discarded pure trapping item in a host do-body is elided beside a host call (dead-init ruling)
+pass	a host call's response is an ordinary value that feeds a LATER host call
+pass	a host effect with a non-kebab NAME crosses under a normalized interface extern name
+pass	a host effect with a non-kebab OPERATION name crosses under a normalized func extern name
+pass	a host op returning Bool crosses the boundary and drives a branch
+pass	a host op whose result is a QUANTITY crosses the boundary as its inner scalar (unit erased)
+pass	a host op with a Bytes arg AND a scalar arg crosses both parameters (list<u8> beside a scalar)
+pass	a host op with a String parameter composes with the value-heap runtime
+pass	a host response SIZES a guest-built collection which is then folded and keyed
+pass	a host result captured by closures in a NESTED tuple fires the host op once (adv-62 nested face)
+pass	a host result captured by two closures stored in a RECORD fires the host op once (adv-62b)
+pass	a host-block scrutinee folding to a multi-arm sum switch fires the host op once (adv-62 switch face)
+pass	a host-delegated result SEEDS an in-program handler's initial state
+pass	a host-op argument COMPUTED by guest arithmetic crosses the boundary evaluated
+pass	a let-bound host result captured by two escaping closures fires the host op once (adv-62)
 todo	a mutually-recursive group with a BRANCH-PERFORM sharing a strict expr with the mutual call declines cleanly (adv-69 rw4 sub-face)
-todo	a performing closure stored in a TUPLE and applied IN-GUEST fires normally
-todo	a program that makes a host call has that call in its observable behavior
-todo	a program uses a response-returning delegated host function's return value
-todo	a recursion-driven host-call sequence consumes one response row per iteration in order
+pass	a performing closure stored in a TUPLE and applied IN-GUEST fires normally
+pass	a program that makes a host call has that call in its observable behavior
+pass	a program uses a response-returning delegated host function's return value
+pass	a recursion-driven host-call sequence consumes one response row per iteration in order
 todo	a recursive NEWTYPE traversal recurses on its projected recursive field
 todo	a recursive NEWTYPE-wrapped linked list folds to a scalar
 todo	a recursive nested-op performer whose resume-VALUE reads the inner state around the outer perform declines cleanly
-todo	a run's result is a deterministic function of a host call's recorded response
-todo	a runtime Bool host arg crosses the boundary and drives two response bindings
-todo	a runtime Bytes host-arg BEFORE a scalar arg keeps distinct core slots (no width-clobber)
-todo	a runtime Bytes value crosses a host op boundary as list<u8> (H-bytes-arg)
+pass	a run's result is a deterministic function of a host call's recorded response
+pass	a runtime Bool host arg crosses the boundary and drives two response bindings
+pass	a runtime Bytes host-arg BEFORE a scalar arg keeps distinct core slots (no width-clobber)
+pass	a runtime Bytes value crosses a host op boundary as list<u8> (H-bytes-arg)
 todo	a runtime bin match decodes a FINAL constant-size utf8 segment
-todo	a runtime branch selects WHICH host op consumes the first response row
+pass	a runtime branch selects WHICH host op consumes the first response row
 todo	a runtime-DISC `?` inside a stored closure applies per-call once BRICK 3b lands
 todo	a runtime-operand try as a list element declines pending brick 3b
 todo	a two-site arm with a second op that REPLACES the state mid-chain declines cleanly
-todo	a unit-result host op consumes its response row so the next value op reads its own (adv-65)
-todo	a value-leaving host-call statement in a do-body runs and its result is dropped (dead-init sibling)
-todo	an @param of a Bool type generates a Bool-typed accessor
-todo	an @param of a Float64 type generates a Float64-typed accessor
-todo	an @param site generates a Param accessor a host delegation reads at run time
-todo	an @param with no widget config still generates its typed accessor
-todo	an EMPTY Bytes arg crosses the host boundary
-todo	an abortive handler ISSUES a host call sequenced BEFORE the abort in its discarded body
-todo	an abortive handler abandons a host call in the path it discards
+pass	a unit-result host op consumes its response row so the next value op reads its own (adv-65)
+pass	a value-leaving host-call statement in a do-body runs and its result is dropped (dead-init sibling)
+pass	an @param of a Bool type generates a Bool-typed accessor
+pass	an @param of a Float64 type generates a Float64-typed accessor
+pass	an @param site generates a Param accessor a host delegation reads at run time
+pass	an @param with no widget config still generates its typed accessor
+pass	an EMPTY Bytes arg crosses the host boundary
+pass	an abortive handler ISSUES a host call sequenced BEFORE the abort in its discarded body
+pass	an abortive handler abandons a host call in the path it discards
 todo	an abortive perform in a recursive callee with a PENDING continuation in the handle body abandons it
-todo	an effectful host arg flowing into a compound then a destructuring match is evaluated ONCE
-todo	an effectful host arg to a multi-use function parameter is evaluated ONCE, not re-performed per use
-todo	an entrypoint delegation lets a program reach its host function
-todo	an entrypoint delegation reaches an effect performed in a recursive callee
-todo	an exact RATIONAL host value crosses as two scalar num/den ops the guest recombines (#13)
-todo	an in-program two-site handler runs INSIDE a host block beside a host call
-todo	an inner handle of the SAME delegated effect discharges in-program inside the host block
-todo	an interposing handler TRANSFORMS the host response before resuming (offset adapter)
-todo	an intra-program handler interposes on a delegated effect, counts it, and forwards to the boundary
-todo	and performs the right operand's effect when the left is true
-todo	and short-circuit does not perform the right operand's effect
-todo	binary operator operands are evaluated left to right
+pass	an effectful host arg flowing into a compound then a destructuring match is evaluated ONCE
+pass	an effectful host arg to a multi-use function parameter is evaluated ONCE, not re-performed per use
+pass	an entrypoint delegation lets a program reach its host function
+pass	an entrypoint delegation reaches an effect performed in a recursive callee
+pass	an exact RATIONAL host value crosses as two scalar num/den ops the guest recombines (#13)
+pass	an in-program two-site handler runs INSIDE a host block beside a host call
+pass	an inner handle of the SAME delegated effect discharges in-program inside the host block
+pass	an interposing handler TRANSFORMS the host response before resuming (offset adapter)
+pass	an intra-program handler interposes on a delegated effect, counts it, and forwards to the boundary
+pass	and performs the right operand's effect when the left is true
+pass	and short-circuit does not perform the right operand's effect
+pass	binary operator operands are evaluated left to right
 todo	distinct-sig round-trip: a higher-order closure + a scalar closure of another sig — the higher-order one
 todo	distinct-sig round-trip: a higher-order closure-typed arg on one group + a scalar closure on another
 todo	expect on an overflowing checked add traps
 todo	expect traps on the absent case of a runtime optional
-todo	function arguments are evaluated left to right
-todo	host calls are observed in the order they were made
-todo	host calls issue only from the TAKEN arm of a fused match and in arm order
-todo	let bindings' initializers are evaluated in binding order
-todo	mixed-type @param sites share one Param effect and drive control flow
-todo	one @param accessor performed TWICE consumes two host responses in order
-todo	one @param read bound ONCE fans out to a map key, a set probe, and arithmetic
-todo	one host effect with TWO ops interleaves its calls in program order
-todo	or performs the right operand's effect when the left is false
-todo	or short-circuit does not perform the right operand's effect
+pass	function arguments are evaluated left to right
+pass	host calls are observed in the order they were made
+pass	host calls issue only from the TAKEN arm of a fused match and in arm order
+pass	let bindings' initializers are evaluated in binding order
+pass	mixed-type @param sites share one Param effect and drive control flow
+pass	one @param accessor performed TWICE consumes two host responses in order
+pass	one @param read bound ONCE fans out to a map key, a set probe, and arithmetic
+pass	one host effect with TWO ops interleaves its calls in program order
+pass	or performs the right operand's effect when the left is false
+pass	or short-circuit does not perform the right operand's effect
 todo	read of malformed text is a coded reject, not a wrong value
 todo	round-trip: a HIGHER-ORDER closure arg composed with a SUM result
 todo	round-trip: a HIGHER-ORDER closure — its argument is itself a closure built in-guest
@@ -5918,19 +5918,19 @@ todo	round-trip: a higher-order closure applied to TWO distinct inner closures
 todo	round-trip: a higher-order closure whose inner closure CAPTURES and is applied twice
 todo	round-trip: a higher-order closure whose inner closure takes an UNANNOTATED compound param
 todo	round-trip: an UNANNOTATED inner closure with a List param via the context arrow
-todo	the generated Param accessor carries the @param's declared type into arithmetic
-todo	the program manifest is the union of its entrypoints' delegations
-todo	the same program with a different response gives a different deterministic result
-todo	the unit-op response-cursor discriminator: a nonzero ping row is not misread by the later get (adv-65)
-todo	tuple elements are evaluated left to right
-todo	two @param accessors INTERLEAVED (a b a) consume per-op response queues in perform order
-todo	two @param sites generate two accessors under one Param effect
-todo	two @params seed two NESTED handlers independently
-todo	two @params seeding nested handlers in the WRONG order is caught by an asymmetric row
-todo	two DISTINCT let-bound host calls each captured by its own escaping closure fire once each in order (adv-62)
+pass	the generated Param accessor carries the @param's declared type into arithmetic
+pass	the program manifest is the union of its entrypoints' delegations
+pass	the same program with a different response gives a different deterministic result
+pass	the unit-op response-cursor discriminator: a nonzero ping row is not misread by the later get (adv-65)
+pass	tuple elements are evaluated left to right
+pass	two @param accessors INTERLEAVED (a b a) consume per-op response queues in perform order
+pass	two @param sites generate two accessors under one Param effect
+pass	two @params seed two NESTED handlers independently
+pass	two @params seeding nested handlers in the WRONG order is caught by an asymmetric row
+pass	two DISTINCT let-bound host calls each captured by its own escaping closure fire once each in order (adv-62)
 todo	two adapter records with different state types drive a take-while fold in one program
-todo	two host calls consume their responses in order
-todo	two host responses combine in call order through a non-commutative operator
-todo	two same-unit Qty host results combine guest-side as a same-dimension add
+pass	two host calls consume their responses in order
+pass	two host responses combine in call order through a non-commutative operator
+pass	two same-unit Qty host results combine guest-side as a same-dimension add
 pass	a closure looked up from a map by a perform result, applied to a perform result, threads through call_indirect
 pass	Bytes.slice of a map-looked-up Bytes with perform-threaded start and len threads without a scratch collision

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1050,15 +1050,15 @@ fn run_program(
         GateTarget::Wasm => {
             run_program_wasm(tools, store, program, modules, call, host_responses, None)
         }
-        // The ASYNC Rust backend has no host-boundary path yet — a host-delegating case declines (Todo). The
-        // SYNC Rust backend renders a no-arg integer-result host call (H1): the emitted `mod prog` calls
+        // Both Rust backends render a host call the SAME way: the emitted `mod prog` calls
         // `crate::__cdz_host_<key>()` and `run_program_rust` generates those shim fns from `host_responses`
-        // (a non-host case passes an empty slice → byte-identical to before). A UNIT-result effect op has no
-        // response but IS in host_calls (H8), so thread host_calls through too — an async host case still
-        // declines (it must have SOME host protocol), keyed on responses-or-calls being non-empty.
-        GateTarget::RustAsync if !host_responses.is_empty() || !host_calls.is_empty() => {
-            Ran::Declined { code: None }
-        }
+        // (a non-host case passes empty slices → byte-identical to before). A UNIT-result effect op has no
+        // response but IS in host_calls (H8), so thread host_calls through too. The host SHIMS are ordinary
+        // sync fns; an emitted async fn calls them synchronously (a host op charges no gas — only the
+        // enclosing async fn's entry `consume_boxed` does), so the async path needs NO async-shim variant —
+        // the SAME `host_responses`/`host_calls` protocol threads through with `async_mode=true`. (Option A's
+        // uniform-env emit already renders the async `Core::HostCall`; this just lets the harness DRIVE it,
+        // instead of the prior blanket async-host decline that todo'd the whole host/@param async frontier.)
         GateTarget::Rust => run_program_rust(
             tools,
             program,
@@ -1069,9 +1069,16 @@ fn run_program(
             host_responses,
             host_calls,
         ),
-        GateTarget::RustAsync => {
-            run_program_rust(tools, program, modules, call, true, None, &[], &[])
-        }
+        GateTarget::RustAsync => run_program_rust(
+            tools,
+            program,
+            modules,
+            call,
+            true,
+            None,
+            host_responses,
+            host_calls,
+        ),
         // The ML compiler has no package/host path today — a multi-file or host-delegating case is
         // simply not-yet-supported there, which is a decline (coverage-not-yet), never a disagreement.
         GateTarget::CadenzaMl
@@ -2437,10 +2444,12 @@ fn cdz_render_bytes_list(ty: &str) -> String {
 ///
 /// Nesting is balanced over `()`, `[]`, `{}` (block/struct-literal args), AND `<>` — EXCEPT a `>` that is
 /// the tail of a `->` return arrow (a closure-typed arg `Rc<dyn Fn(i64) -> i64>` contains a `->` whose `>`
-/// must NOT close a `<` group, or depth underflows and an inner comma leaks as top-level). Today the gate's
-/// `applied` args are corpus call VALUES (scalars, `(tuple …)`, bignum exprs) — no block/struct-literal/
-/// closure-sig arg reaches here — so the `{}`/`->` handling is DEFENSIVE (github-liaison #2391 c1): it keeps
-/// the splitter correct if the emit surface ever grows such an arg, rather than silently mis-tupling.
+/// must NOT close a `<` group, or the `<>` depth would decrement one step too EARLY — dropping back to 0
+/// before the type's real closing `>`, so a comma AFTER the arrow leaks as top-level and the arg mis-tuples;
+/// the depth uses `saturating_sub`, so it never underflows, it just closes the group prematurely). Today the
+/// gate's `applied` args are corpus call VALUES (scalars, `(tuple …)`, bignum exprs) — no block/struct-
+/// literal/closure-sig arg reaches here — so the `{}`/`->` handling is DEFENSIVE (github-liaison #2391 c1):
+/// it keeps the splitter correct if the emit surface ever grows such an arg, rather than silently mis-tupling.
 fn env_closure_call_arg(applied: &str) -> String {
     let applied = applied.trim();
     if applied.is_empty() {


### PR DESCRIPTION
Candidate PR for v-rust-backend's merge-request (ref 6cc77a261, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.