### PR TITLE
cdz-agent-host: rustfmt-1.95.0 cleanup — clear the trunk fmt debt blocking the cdz-agent-host nix check (v-nix cache-warm)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -1330,7 +1330,11 @@ mod tests {
         match out {
             Some(Ok(marker)) => {
                 // A real event hash was returned (not the zero/default) — the marker was appended.
-                assert_ne!(marker, Hash::of(b""), "terminate returns the marker event hash");
+                assert_ne!(
+                    marker,
+                    Hash::of(b""),
+                    "terminate returns the marker event hash"
+                );
             }
             other => panic!("expected Some(Ok(marker)) on a fresh terminate, got {other:?}"),
         }
@@ -1349,7 +1353,10 @@ mod tests {
         let out = host
             .terminate(&SessionId::new("ghost"), Hash::of(b"ctl"), "x".into())
             .await;
-        assert!(out.is_none(), "terminating an absent session is a None no-op");
+        assert!(
+            out.is_none(),
+            "terminating an absent session is a None no-op"
+        );
     }
 
     #[tokio::test]

--- a/implementation/seed/crates/cdz-agent-host/tests/agent_runs_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/agent_runs_e2e.rs
@@ -86,7 +86,10 @@ async fn agent_loop_runs_end_to_end_through_the_real_clock_executor() {
     // will be alongside it.
     let mut exec =
         CompositeExecutor::new().with_effect(effect_ct::NOW, Box::new(ClockExecutor::new()));
-    let mut session = Session::genesis(Hash::of(b"clock-agent-v1"), Hash::of(b"clock-agent-v1-nonce"));
+    let mut session = Session::genesis(
+        Hash::of(b"clock-agent-v1"),
+        Hash::of(b"clock-agent-v1-nonce"),
+    );
 
     session
         .deliver(inbound_go(), None, &reducer, &authz, &mut exec)
@@ -124,7 +127,10 @@ async fn the_recorded_instant_makes_the_run_replayable() {
     let reducer = ClockAgent;
     let mut exec =
         CompositeExecutor::new().with_effect(effect_ct::NOW, Box::new(ClockExecutor::new()));
-    let mut session = Session::genesis(Hash::of(b"clock-agent-v1"), Hash::of(b"clock-agent-v1-nonce"));
+    let mut session = Session::genesis(
+        Hash::of(b"clock-agent-v1"),
+        Hash::of(b"clock-agent-v1-nonce"),
+    );
     session
         .deliver(inbound_go(), None, &ClockAgent, &now_cap(), &mut exec)
         .await
@@ -154,7 +160,10 @@ async fn a_now_effect_outside_the_grant_is_denied_never_reaching_the_clock() {
     let deny = Authorizer::deny_all();
     let mut exec =
         CompositeExecutor::new().with_effect(effect_ct::NOW, Box::new(ClockExecutor::new()));
-    let mut session = Session::genesis(Hash::of(b"clock-agent-v1"), Hash::of(b"clock-agent-v1-nonce"));
+    let mut session = Session::genesis(
+        Hash::of(b"clock-agent-v1"),
+        Hash::of(b"clock-agent-v1-nonce"),
+    );
     session
         .deliver(inbound_go(), None, &reducer, &deny, &mut exec)
         .await

--- a/implementation/seed/crates/cdz-agent-host/tests/cedar_authz_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/cedar_authz_e2e.rs
@@ -110,7 +110,10 @@ async fn a_real_agent_is_gated_by_a_real_cedar_decision() {
         let reducer = PolicyProbe;
         let mut exec = CompositeExecutor::new()
             .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(StubModel)));
-        let mut session = Session::genesis(Hash::of(b"cedar-permit-v1"), Hash::of(b"cedar-permit-v1-nonce"));
+        let mut session = Session::genesis(
+            Hash::of(b"cedar-permit-v1"),
+            Hash::of(b"cedar-permit-v1-nonce"),
+        );
         session
             .deliver(inbound("model-ok"), None, &reducer, &authz, &mut exec)
             .await
@@ -136,7 +139,8 @@ async fn a_real_agent_is_gated_by_a_real_cedar_decision() {
         // Http executor isn't even needed to prove the deny (the gate stops it first).
         let mut exec = CompositeExecutor::new()
             .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(StubModel)));
-        let mut session = Session::genesis(Hash::of(b"cedar-deny-v1"), Hash::of(b"cedar-deny-v1-nonce"));
+        let mut session =
+            Session::genesis(Hash::of(b"cedar-deny-v1"), Hash::of(b"cedar-deny-v1-nonce"));
         session
             .deliver(inbound("http-imds"), None, &reducer, &authz, &mut exec)
             .await

--- a/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
@@ -98,7 +98,10 @@ async fn agent_loop_runs_end_to_end_through_the_http_executor() {
     let reducer = FetchAgent;
     let mut exec = CompositeExecutor::new()
         .with_effect(effect_ct::HTTP, Box::new(HttpExecutor::new(StubHttp)));
-    let mut session = Session::genesis(Hash::of(b"fetch-agent-v1"), Hash::of(b"fetch-agent-v1-nonce"));
+    let mut session = Session::genesis(
+        Hash::of(b"fetch-agent-v1"),
+        Hash::of(b"fetch-agent-v1-nonce"),
+    );
 
     session
         .deliver(inbound_go(), None, &FetchAgent, &host_cap(), &mut exec)
@@ -159,7 +162,10 @@ async fn a_fetch_to_an_unpermitted_host_is_denied_before_the_client() {
     }
     let mut exec = CompositeExecutor::new()
         .with_effect(effect_ct::HTTP, Box::new(HttpExecutor::new(MustNotCall)));
-    let mut session = Session::genesis(Hash::of(b"exfil-agent-v1"), Hash::of(b"exfil-agent-v1-nonce"));
+    let mut session = Session::genesis(
+        Hash::of(b"exfil-agent-v1"),
+        Hash::of(b"exfil-agent-v1-nonce"),
+    );
     session
         .deliver(inbound_go(), None, &ExfilAgent, &host_cap(), &mut exec)
         .await

--- a/implementation/seed/crates/cdz-agent-host/tests/model_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/model_agent_e2e.rs
@@ -96,7 +96,10 @@ async fn agent_loop_runs_end_to_end_through_the_model_executor() {
     let reducer = ModelAgent;
     let mut exec = CompositeExecutor::new()
         .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(StubModel)));
-    let mut session = Session::genesis(Hash::of(b"model-agent-v1"), Hash::of(b"model-agent-v1-nonce"));
+    let mut session = Session::genesis(
+        Hash::of(b"model-agent-v1"),
+        Hash::of(b"model-agent-v1-nonce"),
+    );
 
     session
         .deliver(inbound_go(), None, &ModelAgent, &model_cap(), &mut exec)
@@ -186,7 +189,10 @@ async fn one_composite_routes_both_now_and_model_for_one_agent() {
     let mut exec = CompositeExecutor::new()
         .with_effect(effect_ct::NOW, Box::new(ClockExecutor::new()))
         .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(StubModel)));
-    let mut session = Session::genesis(Hash::of(b"clock-then-model-v1"), Hash::of(b"clock-then-model-v1-nonce"));
+    let mut session = Session::genesis(
+        Hash::of(b"clock-then-model-v1"),
+        Hash::of(b"clock-then-model-v1-nonce"),
+    );
 
     session
         .deliver(inbound_go(), None, &ClockThenModel, &authz, &mut exec)
@@ -234,7 +240,10 @@ async fn a_model_call_to_an_unpermitted_id_is_denied_before_the_transport() {
     }
     let mut exec = CompositeExecutor::new()
         .with_effect(effect_ct::MODEL, Box::new(ModelExecutor::new(MustNotCall)));
-    let mut session = Session::genesis(Hash::of(b"wrong-model-v1"), Hash::of(b"wrong-model-v1-nonce"));
+    let mut session = Session::genesis(
+        Hash::of(b"wrong-model-v1"),
+        Hash::of(b"wrong-model-v1-nonce"),
+    );
     session
         .deliver(
             inbound_go(),


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref f81ffd06d, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.