### PR TITLE
rcdzc(rust): fix Map.empty get-only miscompile — reconstruct the solved map type at Map.lookup (breaker ms9)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
@@ -1991,7 +1991,41 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
         // `Map.lookup` → the fallible keyed read → Rust's own `Option`: `BTreeMap::get` borrows, returns
         // `Option<&V>`; `.cloned()` gives an owned `Option<V>` (the harness renders a native Option).
         Core::MapLookup { map, key, .. } => {
-            let m = emit(db, map, env, ctx)?;
+            // An inlined empty `Map.empty` map operand (a `let`-bound `Map.empty` β-substituted to here) has
+            // its OWN `type_of` = `Map(Var, Var)` — fully OPEN, because inference fixes K/V only through this
+            // lookup's key + the DOWNSTREAM match arms, not at the construction node. Emitting it grounds to
+            // the DEFAULT `BTreeMap<i64,i64>`, but the use is `.get(&"k".to_string())` (String key) → a silent
+            // MISCOMPILE (rust E0308; wasm runs correct — breaker ms9). RECONSTRUCT the map's type at this
+            // lookup from the SOLVED evidence — the KEY's type (`key_ty`, here String) + this lookup's RESULT
+            // `Option<V>` payload (the map's value type) — then GROUND any still-open var (the value, fixed
+            // only by the match arms, grounds to the default like the plain empty-map path). Threading that
+            // as `expected_ty` makes `Core::MapNew` annotate `BTreeMap<String, i64>` — correct key, safely-
+            // grounded value (a wrong value ground still errors LOUDLY at rustc, never silently). Only when
+            // the map operand's own type is OPEN (a concrete map needs no hint) and the key type is concrete.
+            let key_ty = type_of(db, key);
+            let map_ty = type_of(db, map);
+            let reconstructed = if map_ty.has_free_var() && !key_ty.has_free_var() {
+                // The lookup result is `Option<V>`; pull V (the map's value type) from its sole type arg.
+                let val_ty = match type_of(db, id).strip_nominal() {
+                    Ty::Sum { name, args, .. } if name == "Option" && args.len() == 1 => {
+                        args[0].clone()
+                    }
+                    _ => Ty::Var(0), // no readable payload → leave open, grounds below
+                };
+                Some(types::ground_open_vars(&Ty::Map(
+                    Box::new(key_ty.clone()),
+                    Box::new(val_ty),
+                )))
+            } else {
+                None
+            };
+            let m = if let Some(exp) = reconstructed {
+                let mut c = ctx.clone();
+                c.expected_ty = Some(exp);
+                emit(db, map, env, &c)?
+            } else {
+                emit(db, map, env, ctx)?
+            };
             let k = emit(db, key, env, ctx)?;
             // Wrap a bare-float lookup key in `CdzF64::new` to match the map's `CdzF64` key type (and
             // NaN-canonicalize — a differently-produced NaN finds the stored entry, the corpus case).

--- a/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
@@ -1212,6 +1212,35 @@ fn an_empty_map_used_get_only_grounds_its_annotation_but_an_inserted_base_stays_
 }
 
 #[test]
+fn an_empty_map_get_only_with_a_solved_string_key_annotates_string_not_the_default() {
+    // REGRESSION (breaker ms9, 2026-08-06): a let-bound `Map.empty` used GET-ONLY, whose key type is fixed
+    // NOT at construction but by the lookup's KEY (`(Map.lookup m "k")` → String) — the map operand's own
+    // `type_of` at the lookup is `Map(Var, Var)` (fully open; K/V flow through the key + downstream match
+    // arms, invisible at the node), so it USED to ground to the DEFAULT `BTreeMap<i64, i64>` while the use
+    // emitted `.get(&"k".to_string())` → rust E0308 (a SILENT MISCOMPILE — wasm ran it correct, folding the
+    // String key). The fix RECONSTRUCTS the map type at `Core::MapLookup` from the SOLVED key type + the
+    // lookup-result `Option<V>` payload, grounds any still-open var (the value), and threads it as
+    // `expected_ty` — so `Core::MapNew` annotates `BTreeMap<String, i64>` (correct key, safely-grounded
+    // value). Distinct from the get-only test above (there the key IS the default i64; here it is String).
+    let m = compile_rust(
+        "(module m (def (main (: n Int64)) \
+           (let ((m Map.empty)) (match (Map.lookup m \"k\") ((Some x) x) ((None _u) n)))) (export main))",
+    );
+    assert!(
+        m.contains("BTreeMap<String, i64> = std::collections::BTreeMap::new()"),
+        "the get-only empty map annotates its SOLVED String key (not the default i64):\n{m}"
+    );
+    // e2e: compiles + runs to 5 (lookup misses the empty map → the None arm returns n=5), matching wasm.
+    let driver = "fn main() { println!(\"{}\", prog::main(5)); }";
+    if let Some(out) = rustc_run_driver(&m, driver) {
+        assert_eq!(
+            out, "5",
+            "empty-map lookup misses → None arm returns n=5:\n{m}"
+        );
+    }
+}
+
+#[test]
 fn a_bare_float_set_or_map_key_uses_the_cdz_f64_total_order_wrapper() {
     // A bare `Float` Set element / Map key is NOT `Ord` as a raw `f64` (NaN breaks totality), so it maps to
     // the `CdzF64` total-order wrapper (bit-canonical, NaN→one quiet NaN — the runtime's `box-float`). The


### PR DESCRIPTION
Candidate PR for v-rust-backend's merge-request (ref f1439b6be, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.