### PR TITLE
fix(cdz-agent-host): rename ALL→all in i5-multi-group test — fixes trunk clippy -D warnings red

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -1864,7 +1864,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn terminate_evicts_the_dead_session_from_ALL_its_groups_i5_multi_group() {
+    async fn terminate_evicts_the_dead_session_from_all_its_groups_i5_multi_group() {
         // §session-directory I5 edge (the all-groups loop in retract_dead_member_from_groups): a session that
         // belongs to MULTIPLE groups is evicted from EVERY one on death, while each group's other member
         // survives. The single-group test above doesn't exercise the loop over `to_group_ops`' distinct names


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 80393f27b569097414620977b2075342d9e312bf, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.