### PR TITLE
feat(cdz-agent-host): daemon wires the lifecycle channel into session executors (tick-#784 step 2/3)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/async_host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/async_host.rs
@@ -326,6 +326,36 @@ impl AsyncAgentHost {
         Self::build(host, Some(factory), Box::new(AllowList::deny_all()))
     }
 
+    /// A fresh, unconnected [`LifecycleChannel`] pair (sender, receiver) the DAEMON mints BEFORE building the
+    /// factory + host, so the SAME channel can be wired into both the session executors
+    /// ([`LiveExecutorSet::with_lifecycle_channel`](crate::factory::LiveExecutorSet)) and this loop (via
+    /// [`with_factory_and_lifecycle`](Self::with_factory_and_lifecycle)). Solves the construction chicken-egg:
+    /// the factory (which needs the sender) is built before the host, but `build` otherwise mints the channel
+    /// internally. Callers/tests that don't pre-wire lifecycle executors keep using [`with_factory`] (which
+    /// mints its own).
+    pub fn new_lifecycle_channel() -> (LifecycleChannel, mpsc::UnboundedReceiver<LifecycleOp>) {
+        mpsc::unbounded_channel()
+    }
+
+    /// Like [`with_factory`](Self::with_factory) but the loop uses a caller-supplied lifecycle channel
+    /// (from [`new_lifecycle_channel`](Self::new_lifecycle_channel)) — the SAME `tx` the daemon wired into the
+    /// session executors, so a session's `LifecycleExecutor` sends ops the loop actually drains. Use this
+    /// (not `with_factory`) whenever the executor set was built with a lifecycle channel.
+    pub fn with_factory_and_lifecycle(
+        host: AgentHost,
+        factory: Box<dyn SessionFactory>,
+        lifecycle_tx: LifecycleChannel,
+        lifecycle_rx: mpsc::UnboundedReceiver<LifecycleOp>,
+    ) -> Self {
+        Self::build_with_lifecycle(
+            host,
+            Some(factory),
+            Box::new(AllowList::deny_all()),
+            lifecycle_tx,
+            lifecycle_rx,
+        )
+    }
+
     /// Install the admin authorizer that gates every admin command (deny-by-default). Builder-style — the
     /// deployed daemon calls e.g. `AsyncAgentHost::with_factory(..).with_admin_authz(Box::new(AllowList::allow_all_for_local_admin()))`
     /// (the trusted-local-admin preset behind the `0o600` socket) or a Cedar-policy-component authorizer.
@@ -340,9 +370,23 @@ impl AsyncAgentHost {
         factory: Option<Box<dyn SessionFactory>>,
         admin_authz: Box<dyn AdminAuthorizer>,
     ) -> Self {
+        // Mint the lifecycle channel internally (the common path — callers that don't pre-wire lifecycle
+        // executors don't need to supply one).
+        let (lifecycle_tx, lifecycle_rx) = mpsc::unbounded_channel();
+        Self::build_with_lifecycle(host, factory, admin_authz, lifecycle_tx, lifecycle_rx)
+    }
+
+    /// The shared constructor: build with a CALLER-SUPPLIED lifecycle channel (so the daemon can wire the
+    /// SAME channel into the session executors). [`build`](Self::build) mints its own + delegates here.
+    fn build_with_lifecycle(
+        host: AgentHost,
+        factory: Option<Box<dyn SessionFactory>>,
+        admin_authz: Box<dyn AdminAuthorizer>,
+        lifecycle_tx: LifecycleChannel,
+        lifecycle_rx: mpsc::UnboundedReceiver<LifecycleOp>,
+    ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
         let (admin_tx, admin_rx) = mpsc::unbounded_channel();
-        let (lifecycle_tx, lifecycle_rx) = mpsc::unbounded_channel();
         AsyncAgentHost {
             host,
             rx,

--- a/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
@@ -177,8 +177,14 @@ async fn main() -> std::process::ExitCode {
         // happens — on the boot path, NOT per install). Each install then CLONES these into a fresh executor
         // set cheaply, so a slow IMDS probe can't stall the host loop mid-run (#1987 review). The per-effect
         // metrics register into the host's registry (shared).
+        // §lifecycle: mint the loop's lifecycle channel HERE, BEFORE the factory, so the SAME channel is wired
+        // into (a) each session's LifecycleExecutor (via LiveExecutorSet::with_lifecycle_channel below) and
+        // (b) the host loop (via with_factory_and_lifecycle) — a session's lifecycle op then lands on the loop
+        // the daemon runs. (The construction chicken-egg: the factory needs the sender, but the host — which
+        // otherwise mints the channel — is built last.)
+        let (lifecycle_tx, lifecycle_rx) = AsyncAgentHost::new_lifecycle_channel();
         let executors = match LiveExecutorSet::new(agent_host.registry()).await {
-            Ok(e) => e,
+            Ok(e) => e.with_lifecycle_channel(lifecycle_tx.clone()),
             Err(e) => {
                 eprintln!("cdz-agent-daemon: could not build the live executor transports: {e}");
                 return std::process::ExitCode::from(1);
@@ -381,8 +387,11 @@ async fn main() -> std::process::ExitCode {
             )
         };
 
-        let host = AsyncAgentHost::with_factory(agent_host, factory)
-            .with_admin_authz(Box::new(AllowList::allow_all_for_local_admin()));
+        // Use the SAME lifecycle channel the session executors were wired with (not the internally-minted one)
+        // so a session's lifecycle op reaches this loop.
+        let host =
+            AsyncAgentHost::with_factory_and_lifecycle(agent_host, factory, lifecycle_tx, lifecycle_rx)
+                .with_admin_authz(Box::new(AllowList::allow_all_for_local_admin()));
         // Drop our inbox sender so an idle inbox doesn't hold the loop open; the admin socket's AdminChannel
         // is what keeps the loop alive as a control plane.
         drop(host.inbox());


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref c54bea185b6b9d0fce0c40a7f121c710d72f41ed, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.