### PR TITLE
fix(cdz-agent-host): lifecycle spawn provenance from genesis-hash, not from_hex(id) — vanity-id supervisors spawn-capable (tick-#784 step 3/3)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/async_host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/async_host.rs
@@ -154,8 +154,14 @@ async fn apply_lifecycle_ops(
     while let Ok(op) = lifecycle_rx.try_recv() {
         match op {
             LifecycleOp::Terminate { target, by, reason } => {
-                let by_hash =
-                    Hash::from_hex(by.as_str()).unwrap_or_else(|| Hash::of(by.as_str().as_bytes()));
+                // `by` = the controller's genesis hash (recorded as who terminated). Resolve it by the
+                // controller session's genesis_hash() (content lookup — works for a vanity id), falling back
+                // to from_hex for a genesis-hex id no longer registered (§tick-#784: don't assume hex==id).
+                let by_hash = host
+                    .get(&by)
+                    .map(|s| s.genesis_hash())
+                    .or_else(|| Hash::from_hex(by.as_str()))
+                    .unwrap_or_else(|| Hash::of(by.as_str().as_bytes()));
                 match host.terminate(&target, by_hash, reason).await {
                     // Terminated, or a benign no-op (already-terminated FoldRefused / absent None) — nothing
                     // more to do; the durable marker (if fresh) + registry removal are done inside terminate.
@@ -194,11 +200,18 @@ async fn apply_lifecycle_ops(
                     );
                     continue;
                 };
-                // The parent genesis hash = the parent SessionId parsed back to a Hash (its id IS its
-                // genesis-hash-hex). A non-hex parent can't provide provenance → skip loud (the executor
-                // already rejects this, so it shouldn't reach here).
-                let Some(parent_genesis) = Hash::from_hex(parent.as_str()) else {
-                    tracing::warn!(parent = %parent.as_str(), "lifecycle/spawn: parent id not genesis-hash-hex — skipping");
+                // The parent genesis hash = the parent SESSION's genesis_hash() (content lookup via the
+                // registry — works for a VANITY-id parent, e.g. a "concierge" supervisor). This MUST match
+                // the child_id the executor pre-computed (both derive from the same parent genesis), so the
+                // loop registers the child under the id the parent's reducer already folded. Fall back to
+                // from_hex for a genesis-hex parent no longer registered; a truly-unresolvable parent skips
+                // loud (§tick-#784: resolve provenance by genesis-hash, never assume hex==id).
+                let Some(parent_genesis) = host
+                    .get(&parent)
+                    .map(|s| s.genesis_hash())
+                    .or_else(|| Hash::from_hex(parent.as_str()))
+                else {
+                    tracing::warn!(parent = %parent.as_str(), "lifecycle/spawn: parent genesis unresolvable (not registered + not genesis-hex) — skipping");
                     continue;
                 };
                 match factory
@@ -1250,6 +1263,7 @@ mod tests {
                 Box::new(crate::LifecycleExecutor::new(
                     async_host.lifecycle_channel(),
                     SessionId::new("controller"),
+                    Hash::of(b"controller"),
                 )),
             ),
         );
@@ -1332,6 +1346,7 @@ mod tests {
                 Box::new(crate::LifecycleExecutor::new(
                     async_host.lifecycle_channel(),
                     SessionId::new("controller"),
+                    Hash::of(b"controller"),
                 )),
             ),
         );
@@ -1405,6 +1420,11 @@ mod tests {
                 Box::new(crate::LifecycleExecutor::new(
                     async_host.lifecycle_channel(),
                     parent_id.clone(),
+                    cdz_kernel::kernel::Session::derive_genesis_hash(
+                        parent_reducer,
+                        parent_nonce,
+                        None,
+                    ),
                 )),
             ),
         );
@@ -1509,6 +1529,7 @@ mod tests {
                     Box::new(crate::LifecycleExecutor::new(
                         async_host.lifecycle_channel(),
                         SessionId::new("controller"),
+                        Hash::of(b"controller"),
                     )),
                 )
                 .with_effect(
@@ -1516,6 +1537,7 @@ mod tests {
                     Box::new(crate::LifecycleExecutor::new(
                         async_host.lifecycle_channel(),
                         SessionId::new("controller"),
+                        Hash::of(b"controller"),
                     )),
                 ),
         )
@@ -1757,6 +1779,7 @@ mod tests {
                 Box::new(crate::LifecycleExecutor::new(
                     async_host.lifecycle_channel(),
                     SessionId::new("controller-b"),
+                    Hash::of(b"controller-b"),
                 )),
             ),
         );
@@ -1870,6 +1893,7 @@ mod tests {
                 Box::new(crate::LifecycleExecutor::new(
                     async_host.lifecycle_channel(),
                     SessionId::new("killer"),
+                    Hash::of(b"killer"),
                 )),
             ),
         );

--- a/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/bin/cdz_agent_daemon.rs
@@ -389,9 +389,13 @@ async fn main() -> std::process::ExitCode {
 
         // Use the SAME lifecycle channel the session executors were wired with (not the internally-minted one)
         // so a session's lifecycle op reaches this loop.
-        let host =
-            AsyncAgentHost::with_factory_and_lifecycle(agent_host, factory, lifecycle_tx, lifecycle_rx)
-                .with_admin_authz(Box::new(AllowList::allow_all_for_local_admin()));
+        let host = AsyncAgentHost::with_factory_and_lifecycle(
+            agent_host,
+            factory,
+            lifecycle_tx,
+            lifecycle_rx,
+        )
+        .with_admin_authz(Box::new(AllowList::allow_all_for_local_admin()));
         // Drop our inbox sender so an idle inbox doesn't hold the loop open; the admin socket's AdminChannel
         // is what keeps the loop alive as a control plane.
         drop(host.inbox());

--- a/implementation/seed/crates/cdz-agent-host/src/factory.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/factory.rs
@@ -40,22 +40,25 @@ use std::sync::Arc;
 /// `LiveExecutorSet` (behind `live-net`), whose `build` `.await`s the live executor assembly (it loads AWS
 /// config for the Bedrock transport). A synchronous builder (a plain closure) satisfies it with no real
 /// await via the blanket impl.
-/// `build` takes the installed session's `id` (the SessionId it's registered under) so a per-session executor
-/// that needs the session's own identity — the [`LifecycleExecutor`](crate::LifecycleExecutor), whose `by`
-/// on every lifecycle op is this owner — can be built correctly. The lifecycle CHANNEL (the loop's) is held
-/// by the concrete builder (e.g. [`LiveExecutorSet`], set at construction), not passed per-build, since it's
-/// one-per-loop. A builder that serves no lifecycle effects simply ignores `id`.
+/// `build` takes the installed session's `id` (the registry label) AND its `owner_genesis` (the session's
+/// genesis hash) so a per-session executor that needs the session identity — the
+/// [`LifecycleExecutor`](crate::LifecycleExecutor), whose `by` is the id + whose spawn-provenance is the
+/// genesis hash — is built correctly. Both are threaded because the id is an opaque label (may be a vanity
+/// string) while the genesis hash is the stable provenance a spawn derives from (never re-parse the id as
+/// hex; §tick-#784). The lifecycle CHANNEL (the loop's) is held by the concrete builder (e.g.
+/// [`LiveExecutorSet`], set at construction), one-per-loop. A builder serving no lifecycle effects ignores both.
 #[async_trait::async_trait(?Send)]
 pub trait ExecutorSetBuilder {
-    async fn build(&self, id: &crate::host::SessionId) -> CompositeExecutor;
+    async fn build(&self, id: &crate::host::SessionId, owner_genesis: Hash) -> CompositeExecutor;
 }
 
 /// A synchronous `Fn() -> CompositeExecutor` (a test's hermetic set, or any non-async assembly) is an
-/// `ExecutorSetBuilder` for free — its `build` just calls the closure (no real await). It ignores `id` (a
-/// closure-built set serves no per-session-identity executor; a caller that needs one uses a real builder).
+/// `ExecutorSetBuilder` for free — its `build` just calls the closure (no real await). It ignores `id` +
+/// `owner_genesis` (a closure-built set serves no per-session-identity executor; a caller that needs one
+/// uses a real builder).
 #[async_trait::async_trait(?Send)]
 impl<F: Fn() -> CompositeExecutor> ExecutorSetBuilder for F {
-    async fn build(&self, _id: &crate::host::SessionId) -> CompositeExecutor {
+    async fn build(&self, _id: &crate::host::SessionId, _owner_genesis: Hash) -> CompositeExecutor {
         self()
     }
 }
@@ -198,7 +201,7 @@ impl LiveExecutorSet {
 #[cfg(feature = "live-net")]
 #[async_trait::async_trait(?Send)]
 impl ExecutorSetBuilder for LiveExecutorSet {
-    async fn build(&self, id: &crate::host::SessionId) -> CompositeExecutor {
+    async fn build(&self, id: &crate::host::SessionId, owner_genesis: Hash) -> CompositeExecutor {
         use cdz_kernel::effect::effect_ct;
         // Cheap per-install assembly: CLONE the shared transports (Arc bumps) into fresh executors, each
         // WRAPPED in a MeteredExecutor sharing the host-wide Arc<EffectMetrics> (an Arc-clone, also cheap) so
@@ -279,7 +282,11 @@ impl ExecutorSetBuilder for LiveExecutorSet {
                 c = c.with_effect(
                     fam,
                     Box::new(MeteredExecutor::new(
-                        Box::new(crate::LifecycleExecutor::new(lifecycle.clone(), id.clone())),
+                        Box::new(crate::LifecycleExecutor::new(
+                            lifecycle.clone(),
+                            id.clone(),
+                            owner_genesis,
+                        )),
                         m.clone(),
                     )),
                 );
@@ -520,12 +527,18 @@ where
                 spec.reducer_hash
             )
         })?;
-        // 3. Assemble the session with a fresh executor set + the session's authorizer. genesis records the
-        //    reducer hash as the session's genesis identity (so replay reconstructs it).
-        // Build the executor set for THIS session (its id owns any per-session executor, e.g. lifecycle).
-        let executors = self.executors.build(&spec.id).await;
-        let mut hosted = HostedSession::genesis(
+        // 3. Assemble the session. MINT THE NONCE FIRST so we can derive the session's genesis hash BEFORE
+        //    building the executor set — a lifecycle executor needs the owner's genesis hash (its spawn
+        //    provenance), which isn't the id string (a vanity install id). Then build the session with the
+        //    SAME nonce (`genesis_with_nonce`), so its genesis_hash matches what we derived + handed the
+        //    executors (a root install has no parent → derive with `None`).
+        let spawn_nonce = crate::host::mint_spawn_nonce();
+        let owner_genesis =
+            cdz_kernel::kernel::Session::derive_genesis_hash(spec.reducer_hash, spawn_nonce, None);
+        let executors = self.executors.build(&spec.id, owner_genesis).await;
+        let mut hosted = HostedSession::genesis_with_nonce(
             spec.reducer_hash,
+            spawn_nonce,
             Box::new(reducer),
             self.authz.build(),
             executors,
@@ -563,18 +576,16 @@ where
         let reducer = AsyncComponentReducer::from_component_bytes(&bytes).map_err(|e| {
             format!("child reducer component for {reducer_hash} did not lift: {e:?}")
         })?;
-        // The child's own SessionId = hex(its genesis hash), derived from (reducer, nonce, parent) — the same
-        // id the loop registers it under. Thread it as the executor-set owner so a spawned child's own
-        // lifecycle executor (if wired) is owned by the child, not a stale/absent id.
-        let child_id = crate::host::SessionId::new(
-            cdz_kernel::kernel::Session::derive_genesis_hash(
-                reducer_hash,
-                spawn_nonce,
-                Some(parent_genesis),
-            )
-            .to_hex(),
+        // The child's own genesis hash, derived from (reducer, nonce, parent) — its SessionId is that hash's
+        // hex (the id the loop registers it under) AND its genesis-provenance for the executor set (a spawned
+        // child that itself spawns uses this as its parent-genesis).
+        let child_genesis = cdz_kernel::kernel::Session::derive_genesis_hash(
+            reducer_hash,
+            spawn_nonce,
+            Some(parent_genesis),
         );
-        let executors = self.executors.build(&child_id).await;
+        let child_id = crate::host::SessionId::new(child_genesis.to_hex());
+        let executors = self.executors.build(&child_id, child_genesis).await;
         // DENY-ALL child authorizer (NOT self.authz.build() — a spawned child does not inherit the install
         // policy; it starts deny-by-default and earns caps via a later explicit grant).
         let hosted = HostedSession::genesis_spawned_with_nonce(

--- a/implementation/seed/crates/cdz-agent-host/src/lifecycle.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lifecycle.rs
@@ -81,14 +81,27 @@ pub type LifecycleChannel = mpsc::UnboundedSender<LifecycleOp>;
 pub struct LifecycleExecutor {
     channel: LifecycleChannel,
     owner: SessionId,
+    /// The owner session's GENESIS HASH — its provenance identity (`Session::genesis_hash()`), threaded at
+    /// wiring time. Used as the PARENT genesis when this owner spawns a child (`perform_spawn`), instead of
+    /// re-parsing the owner SessionId as hex. The id is a host registry LABEL (may be a vanity string like
+    /// "concierge" for a root/named supervisor); the genesis hash is the stable identity `derive_genesis_hash`
+    /// needs. Threading the Hash (not `Hash::from_hex(owner)`) keeps a vanity-id supervisor spawn-capable
+    /// (#2484 c1 / tick-#784 class: SessionId is opaque, resolve by genesis-hash content, never assume hex==id).
+    owner_genesis: Hash,
 }
 
 impl LifecycleExecutor {
     /// Build over the loop's [`LifecycleChannel`] for the session `owner` (the controller whose
     /// `CompositeExecutor` this registers in under the `lifecycle/*` families). `owner` is stamped as `by`
-    /// on every recorded op (who terminated/spawned).
-    pub fn new(channel: LifecycleChannel, owner: SessionId) -> Self {
-        LifecycleExecutor { channel, owner }
+    /// on every recorded op (who terminated/spawned); `owner_genesis` is that session's genesis hash
+    /// (`Session::genesis_hash()`), the parent-provenance for a spawn — threaded so it's never re-parsed from
+    /// the id string (which may be a vanity label, not genesis-hex).
+    pub fn new(channel: LifecycleChannel, owner: SessionId, owner_genesis: Hash) -> Self {
+        LifecycleExecutor {
+            channel,
+            owner,
+            owner_genesis,
+        }
     }
 
     /// Handle `lifecycle/spawn` (§lifecycle I3): the OWNER (parent) spawns a CHILD running `reducer_hash`.
@@ -120,15 +133,12 @@ impl LifecycleExecutor {
                 ));
             }
         };
-        // The parent genesis hash = the OWNER's SessionId parsed back to a Hash (the id IS the parent's
-        // genesis-hash-hex — the operator's SessionId ruling). A non-hex owner (a test/legacy string id, not a
-        // real genesis hash) can't be a spawn parent → PERMANENT (spawn needs a real provenance hash).
+        // The parent genesis hash = the owner's GENESIS HASH, threaded at wiring time (NOT re-parsed from the
+        // owner id string). This is what keeps a VANITY-id supervisor ("concierge") spawn-capable: the id is a
+        // registry label, but derive_genesis_hash needs the stable provenance identity (§tick-#784 / #2484 c1
+        // — SessionId is opaque, resolve provenance by genesis-hash, never assume hex==id).
         let parent = self.owner.clone();
-        let Some(parent_genesis) = Hash::from_hex(parent.as_str()) else {
-            return EffectOutcome::Err(crate::retry::permanent(
-                "LifecycleExecutor: lifecycle/spawn parent (owner) SessionId is not a genesis-hash-hex; cannot derive child provenance",
-            ));
-        };
+        let parent_genesis = self.owner_genesis;
         // Mint the nonce ONCE + pre-compute the child id from the SAME triple the loop will build with, so
         // the id returned here == the id the loop registers (byte-for-byte). This is the load-bearing bit.
         let spawn_nonce = crate::host::mint_spawn_nonce();
@@ -276,7 +286,7 @@ mod tests {
         let parent_id = SessionId::new(parent_hash.to_hex());
         let reducer_hash = Hash::of(b"child-reducer");
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut exec = LifecycleExecutor::new(tx, parent_id.clone());
+        let mut exec = LifecycleExecutor::new(tx, parent_id.clone(), parent_hash);
         let req = EffectRequest::new_with_family(
             effect_ct::LIFECYCLE_SPAWN,
             String::new(), // spawn has no peer target
@@ -327,7 +337,7 @@ mod tests {
     async fn spawn_without_a_reducer_hash_payload_is_permanent() {
         let parent_id = SessionId::new(Hash::of(b"p").to_hex());
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut exec = LifecycleExecutor::new(tx, parent_id);
+        let mut exec = LifecycleExecutor::new(tx, parent_id, Hash::of(b"p"));
         let req = EffectRequest::new_with_family(
             effect_ct::LIFECYCLE_SPAWN,
             String::new(),
@@ -342,30 +352,66 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn spawn_with_a_non_hex_owner_is_permanent() {
-        // A parent whose SessionId isn't a genesis-hash-hex (a test/legacy string id) can't be a spawn parent
-        // — the child's provenance needs a real parent genesis Hash.
-        let (tx, _rx) = mpsc::unbounded_channel();
-        let mut exec = LifecycleExecutor::new(tx, SessionId::new("not-a-hash"));
+    async fn spawn_with_a_vanity_id_owner_succeeds_using_the_threaded_genesis_hash() {
+        // §tick-#784 fix (regression pin): a parent whose SessionId is a VANITY string ("concierge") — NOT
+        // genesis-hash-hex — CAN spawn. The provenance comes from the owner's GENESIS HASH threaded at wiring
+        // time (not Hash::from_hex(id)), so a vanity-id supervisor is spawn-capable (the self-hosting use
+        // case). The child id is derived from that genesis, independent of the vanity id string.
+        let owner_genesis = Hash::of(b"concierge-genesis");
+        let reducer_hash = Hash::of(b"worker-reducer");
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut exec = LifecycleExecutor::new(tx, SessionId::new("concierge"), owner_genesis);
         let req = EffectRequest::new_with_family(
             effect_ct::LIFECYCLE_SPAWN,
             String::new(),
-            Some(Payload::Inline(
-                Hash::of(b"child").as_bytes().to_vec().into(),
-            )),
+            Some(Payload::Inline(reducer_hash.as_bytes().to_vec().into())),
             Timeliness::Interactive,
         );
-        assert!(
-            matches!(&exec.perform(&req, Hash::of(b"k")).await,
-                EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("genesis-hash-hex")),
-            "spawn with a non-hex owner is PERMANENT"
+        let out = exec.perform(&req, Hash::of(b"k")).await;
+        // Spawn ACCEPTED (Ok) despite the vanity id — and the returned child id == derive_genesis_hash from
+        // the THREADED genesis (not from the id string).
+        let EffectOutcome::Ok(Some(Payload::Inline(bytes))) = &out else {
+            panic!("expected Ok(child_id) for a vanity-id owner spawn, got {out:?}");
+        };
+        let expected_child = cdz_kernel::kernel::Session::derive_genesis_hash(
+            reducer_hash,
+            // the nonce the op recorded (read it off the channel below) — assert the id matches that op.
+            match rx.try_recv().expect("a Spawn op was recorded") {
+                LifecycleOp::Spawn {
+                    spawn_nonce,
+                    child_id,
+                    parent,
+                    ..
+                } => {
+                    assert_eq!(
+                        parent.as_str(),
+                        "concierge",
+                        "op records the vanity owner as parent"
+                    );
+                    // child_id in the op == the returned id == derive from (reducer, nonce, owner_genesis).
+                    assert_eq!(
+                        child_id.as_str().as_bytes(),
+                        &bytes[..],
+                        "returned child id == the op's child_id"
+                    );
+                    spawn_nonce
+                }
+                other => panic!("expected Spawn op, got {other:?}"),
+            },
+            Some(owner_genesis),
+        );
+        assert_eq!(
+            String::from_utf8_lossy(bytes),
+            expected_child.to_hex(),
+            "child id derives from the THREADED owner genesis, not the vanity id string"
         );
     }
 
     #[tokio::test]
     async fn terminate_records_a_lifecycle_op_for_the_loop() {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut exec = LifecycleExecutor::new(tx, SessionId::new("controller"));
+        let mut exec =
+            LifecycleExecutor::new(tx, SessionId::new("controller"), Hash::of(b"controller"));
         let out = exec
             .perform(
                 &terminate_req("victim", Some(b"operator kill")),
@@ -389,7 +435,7 @@ mod tests {
     #[tokio::test]
     async fn a_payloadless_terminate_records_an_empty_reason() {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"));
+        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"), Hash::of(b"ctl"));
         let out = exec
             .perform(&terminate_req("b", None), Hash::of(b"k"))
             .await;
@@ -403,7 +449,7 @@ mod tests {
     #[tokio::test]
     async fn suspend_and_resume_record_their_ops_and_handles_family_covers_all_three() {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"));
+        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"), Hash::of(b"ctl"));
         // handles_family covers terminate + suspend + resume, not an unrelated family.
         assert!(exec.handles_family(effect_ct::LIFECYCLE_TERMINATE));
         assert!(exec.handles_family(effect_ct::LIFECYCLE_SUSPEND));
@@ -448,7 +494,7 @@ mod tests {
         // payload (esp. a Blob ref) must be rejected PERMANENT, not silently dropped — mirroring terminate's
         // payload guard, the inconsistency the finding flagged.
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"));
+        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"), Hash::of(b"ctl"));
         for family in [effect_ct::LIFECYCLE_SUSPEND, effect_ct::LIFECYCLE_RESUME] {
             // Inline payload → PERMANENT.
             let inline = EffectRequest::new_with_family(
@@ -480,7 +526,7 @@ mod tests {
     #[tokio::test]
     async fn suspending_self_is_a_permanent_error() {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut exec = LifecycleExecutor::new(tx, SessionId::new("me"));
+        let mut exec = LifecycleExecutor::new(tx, SessionId::new("me"), Hash::of(b"me"));
         let req = EffectRequest::new_with_family(
             effect_ct::LIFECYCLE_SUSPEND,
             "me".to_string(),
@@ -499,7 +545,7 @@ mod tests {
         // A blob-ref reason can't be resolved here (no blob-store handle) — reject PERMANENT, mirroring
         // Http/Emit, rather than silently dropping a provided reason (#2425 review consistency).
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"));
+        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"), Hash::of(b"ctl"));
         let req = EffectRequest::new_with_family(
             effect_ct::LIFECYCLE_TERMINATE,
             "victim".to_string(),
@@ -516,7 +562,7 @@ mod tests {
     #[tokio::test]
     async fn terminating_self_is_a_permanent_error() {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut exec = LifecycleExecutor::new(tx, SessionId::new("me"));
+        let mut exec = LifecycleExecutor::new(tx, SessionId::new("me"), Hash::of(b"me"));
         let out = exec
             .perform(&terminate_req("me", None), Hash::of(b"k"))
             .await;
@@ -529,7 +575,7 @@ mod tests {
     #[tokio::test]
     async fn an_empty_target_is_a_permanent_error() {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"));
+        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"), Hash::of(b"ctl"));
         let out = exec.perform(&terminate_req("", None), Hash::of(b"k")).await;
         assert!(
             matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("non-empty target")),
@@ -541,7 +587,7 @@ mod tests {
     async fn a_closed_channel_is_a_retryable_error() {
         let (tx, rx) = mpsc::unbounded_channel();
         drop(rx);
-        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"));
+        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"), Hash::of(b"ctl"));
         let out = exec
             .perform(&terminate_req("b", None), Hash::of(b"k"))
             .await;
@@ -554,7 +600,7 @@ mod tests {
     #[tokio::test]
     async fn a_non_lifecycle_family_is_a_permanent_error() {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"));
+        let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"), Hash::of(b"ctl"));
         let req = EffectRequest::new_with_family(
             effect_ct::HTTP,
             "b".to_string(),


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref fa109c25b62903c836bd50ce114bff522b2cf961, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.