### PR TITLE
effects+infer: reject a perform in a match-arm guard (CDZ0407 EffectInGuard) — guards must be side-effect-free

### DIFF
--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -8620,6 +8620,41 @@ fn is_unit_param(db: &mut Db, param: StructId) -> bool {
     matches!(resolved_of(db, param), Resolved::Unit)
 }
 
+/// The first EFFECT-OP PERFORM reached inside a match-arm GUARD condition, if any — the detection side of
+/// the "guards must be side-effect-free" rule (operator directive, PR #2543; CDZ0407 EffectInGuard, emitted
+/// by `infer`'s guarded-arm check). Returns the offending PERFORM node (an `(E.op …)` application whose head
+/// resolves to an effect op) so the caller can anchor the diagnostic THERE, not at the whole guard. `None`
+/// when the guard cond is pure.
+///
+/// CONTEXT-FREE, unlike [`subtree_performs`]: a guard must be pure regardless of which handler encloses it
+/// (a performing guard is a re-evaluation hazard — the pattern engine may evaluate a guard speculatively or
+/// repeatedly, breaker finding #9 — so ANY effect op is forbidden, not only ops a specific handler
+/// discharges). So this keys on `eval::effect_op_of` (the op-IDENTITY channel) directly rather than a
+/// `HandlerCtx` discharged-op set. A `resume` is not reachable in a guard (guards are not handler arms), so
+/// only an effect-op application is detected. Does NOT descend into a LAMBDA body — a closure VALUE built in
+/// a guard performs nothing when constructed (its body's effects fire only when applied, an `Apply` node the
+/// walk sees on its own); this mirrors `subtree_performs`'s lambda-value treatment so a guard that merely
+/// builds a performing closure it never applies is not flagged. Structural walk over the resolved form; the
+/// FIRST perform found (pre-order) is returned.
+pub(crate) fn effect_op_in_guard_cond(db: &mut Db, cond: StructId) -> Option<StructId> {
+    if let Resolved::Apply { head, .. } = resolved_of(db, cond)
+        && crate::eval::effect_op_of(db, head).is_some()
+    {
+        return Some(cond);
+    }
+    // A lambda VALUE performs nothing when constructed — do not descend its body (same rule as
+    // `subtree_performs`); the application that fires its effects is a separate `Apply` node.
+    if matches!(resolved_of(db, cond), Resolved::Lambda { .. }) {
+        return None;
+    }
+    match db.ast.get(cond).clone() {
+        Struct::List(children) => children
+            .iter()
+            .find_map(|&c| effect_op_in_guard_cond(db, c)),
+        Struct::Atom(_) => None,
+    }
+}
+
 /// Whether the subtree at `node` performs an operation `ctx` discharges — a fast pre-check so a
 /// perform-free subtree is copied wholesale rather than threaded position-by-position. Structural walk.
 fn subtree_performs(db: &mut Db, node: StructId, ctx: &HandlerCtx) -> bool {

--- a/implementation/seed/crates/rcdzc/src/infer.rs
+++ b/implementation/seed/crates/rcdzc/src/infer.rs
@@ -13246,6 +13246,27 @@ fn collect_node(db: &mut Db, id: StructId, out: &mut Vec<Reject>) {
                 // descend into it so a fault INSIDE the guard (an unbound name, a type error) also surfaces.
                 if let Some(g) = db.ast.as_form(*pat, "guard").filter(|g| g.len() == 2) {
                     let cond = g[1];
+                    // GUARDS MUST BE SIDE-EFFECT-FREE (operator directive, PR #2543): a guard condition that
+                    // PERFORMS an effect is a compile error (CDZ0407). A guard is a boolean predicate the
+                    // pattern engine may evaluate speculatively or repeatedly, so an effect performed in it has
+                    // no well-defined evaluation count/order — the re-evaluation miscompile breaker finding #9
+                    // exposed (an inline performing scrutinee + performing guard on a miss re-drew the
+                    // scrutinee). Forbid ALL effects in guards (no non-mutating carve-out — operator's
+                    // consistency call), rejecting at the offending `(E.op …)` node (perform-detection owned by
+                    // v-effects, `effects::effect_op_in_guard_cond`). Checked BEFORE the Bool-type check so a
+                    // performing guard names the real fault (the effect) rather than a downstream type message.
+                    if let Some(op) = crate::effects::effect_op_in_guard_cond(db, cond) {
+                        trace!(target: "rcdzc::infer", node = op.0, "fault: effect performed in guard (CDZ0407)");
+                        out.push(
+                            Reject::coded(
+                                Code::EffectInGuard,
+                                "a guard must be side-effect-free — an effect is performed in this guard, \
+                                 which the pattern engine may evaluate speculatively or repeatedly; lift it \
+                                 to a `let` evaluated once before the `match` and guard on the bound value",
+                            )
+                            .at(op),
+                        );
+                    }
                     let cond_ty = type_of(db, cond);
                     if !cond_ty.agrees_with(&Ty::Bool) {
                         trace!(target: "rcdzc::infer", node = cond.0, cond_ty = %cond_ty.render_name(), "fault: guard condition not Bool (CDZ0203)");

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -64201,18 +64201,18 @@ mod stage1 {
     }
 
     #[test]
-    fn a_perform_in_a_match_guard_declines_honestly_not_no_enclosing_handler() {
-        // A perform inside a match-arm GUARD condition, under a `handle` that discharges it, is a position
-        // the effect-routing/distribution walks do NOT descend (they route the scrutinee + arm bodies, not
-        // the guard conds). It used to reach lowering as a bare perform → the FACTUALLY-WRONG
-        // `NO_HOME_STANDALONE_DECLINE` ("performed with no enclosing handler here") — even though the handle
-        // ENCLOSES it (the same guard-perform runs host-delegated → 100; scrutinee/arm-body/if-cond performs
-        // under the same handle all work). `reduce_handle` now DECLINES cleanly (an honest "not yet
-        // reducible" todo) when a guard cond performs a discharged op, rather than misleading. (Routing a
-        // guard perform through the handler — the ideal →100 fix — is a later increment: a guard runs before
-        // its arm, advancing handler state per arm-test, which the per-branch-sees-the-seed distribution
-        // does not model. The finding sanctions the honest decline as the minimum bar.)
-        let msg = |src: &str| {
+    fn a_perform_in_a_match_guard_is_cdz0407_guards_must_be_side_effect_free() {
+        // GUARDS MUST BE SIDE-EFFECT-FREE (operator directive, PR #2543): a perform in a match-arm GUARD
+        // condition is a COMPILE ERROR (CDZ0407 EffectInGuard). A guard is a boolean predicate the pattern
+        // engine may evaluate speculatively or repeatedly, so a performing guard has no well-defined
+        // evaluation count/order — the re-evaluation miscompile class (breaker finding #9: an inline
+        // performing scrutinee + performing guard re-drew the scrutinee on a miss). Forbidding ALL effects in
+        // guards (operator's consistency call, no non-mutating carve-out) eliminates that arm of the class at
+        // the source. `effects::effect_op_in_guard_cond` detects the perform; `infer`'s guarded-arm check
+        // emits CDZ0407 at the offending `(E.op …)` node. (History: this shape once honest-declined, then
+        // briefly folded via a guard-desugar; the operator directive supersedes both — a performing guard now
+        // cannot exist, so the fold + the finding-#9 interim reject are both moot.)
+        let codes = |src: &str| {
             let out = crate::compile::compile(
                 &[crate::abi::Artifact::new(
                     crate::abi::Artifact::KIND_AST,
@@ -64224,56 +64224,48 @@ mod stage1 {
             out.diagnostics
                 .iter()
                 .filter(|d| d.severity == crate::abi::Severity::Error)
-                .map(|d| d.message.clone())
+                .map(|d| d.code.clone().unwrap_or_default())
                 .collect::<Vec<_>>()
         };
-        // The IRREFUTABLE-guarded shape (a bare-name inner pattern guarded by a performing cond, plus an
-        // irrefutable catch-all) is now ROUTED: `reduce_handle` desugars it to an `if` on the guard, so it
-        // FOLDS (→100) rather than declines. (Updated from the interim honest-decline behavior: the corpus
-        // case "a perform in a match-arm guard is discharged by the enclosing handle" now grades pass →100,
-        // the target the interim decline anticipated.)
+        let is_empty = |src: &str| codes(src).is_empty();
+        // The IRREFUTABLE-guarded shape (a bare-name inner pattern guarded by a performing cond) → CDZ0407.
         let guard_src = "(do (effect Ask (op get (-> Int64))) \
                          (def (main) (handle Ask 5 ((get () s (resume s (- s 1)))) \
                            (match 9 ((guard n (> (Ask.get) 3)) 100) (n 200)))) (export main))";
         assert!(
-            msg(guard_src).is_empty(),
-            "an irrefutable-guarded performing arm under a handle now folds (desugars to an if): {:?}",
-            msg(guard_src)
+            codes(guard_src).iter().any(|c| c == "CDZ0407"),
+            "a performing guard (irrefutable pattern) is CDZ0407: {:?}",
+            codes(guard_src)
         );
-        // A REFUTABLE guarded inner pattern (the literal `9`, not a bare name) is now ALSO ROUTED: the
-        // desugar keeps the pattern match and hoists the performing guard into an `if` INSIDE the matched
-        // arm — `(match 9 ((guard 9 g) 100) (n 200))` ≡ `(match 9 (9 (if g 100 200)) (n 200))` — so it FOLDS
-        // (→100: scrutinee 9 matches, guard `(Ask.get)=5 > 3` holds). A scrutinee that FAILS the pattern
-        // yields the catch-all WITHOUT running the guard perform (verified separately: `(match 7 …)` → 200).
-        // (Updated from the interim refutable-decline behavior once the refutable-pattern face landed —
-        // breaker bg-family.)
+        // A REFUTABLE guarded inner pattern (the literal `9`) with a performing guard → CDZ0407 too (the
+        // reject is pattern-shape-agnostic; the perform in the cond is illegal regardless).
         let refutable_guard = "(do (effect Ask (op get (-> Int64))) \
                          (def (main) (handle Ask 5 ((get () s (resume s (- s 1)))) \
                            (match 9 ((guard 9 (> (Ask.get) 3)) 100) (n 200)))) (export main))";
         assert!(
-            msg(refutable_guard).is_empty(),
-            "a refutable-guarded performing arm under a handle now folds (desugars to a match with a \
-             guard-hoisted if): {:?}",
-            msg(refutable_guard)
+            codes(refutable_guard).iter().any(|c| c == "CDZ0407"),
+            "a performing guard (refutable pattern) is CDZ0407: {:?}",
+            codes(refutable_guard)
         );
-        // NO REGRESSION: a NON-performing guard under the same handle still COMPILES (my detection fires
-        // ONLY on a guard cond that performs a discharged op — a `(guard n (> n 3))` performs nothing).
+        // NO OVER-FIRE: a NON-performing guard under the same handle still COMPILES (detection fires ONLY on
+        // a guard cond that performs — `(guard n (> n 3))` performs nothing).
         let pure_guard = "(do (effect Ask (op get (-> Int64))) \
                           (def (main) (handle Ask 5 ((get () s (resume s (- s 1)))) \
                             (match 9 ((guard n (> n 3)) 100) (n 200)))) (export main))";
         assert!(
-            msg(pure_guard).is_empty(),
+            is_empty(pure_guard),
             "a non-performing guard under a handle must still compile clean: {:?}",
-            msg(pure_guard)
+            codes(pure_guard)
         );
-        // NO REGRESSION: a perform in the ARM BODY (not the guard) under the same handle still folds.
+        // NO OVER-FIRE: a perform in the ARM BODY (not the guard) under the same handle still folds — only the
+        // GUARD position is forbidden, not the arm body or scrutinee.
         let arm_body = "(do (effect Ask (op get (-> Int64))) \
                         (def (main) (handle Ask 5 ((get () s (resume s (- s 1)))) \
                           (match 9 (n (Ask.get))))) (export main))";
         assert!(
-            msg(arm_body).is_empty(),
+            is_empty(arm_body),
             "an arm-body perform under a handle must still fold: {:?}",
-            msg(arm_body)
+            codes(arm_body)
         );
     }
 

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -5954,7 +5954,7 @@ todo	a closed literal closure forwarded through const-wrapper hops is not a fals
 todo	a constant-try helper that fails feeds the None arm's fallback into resume
 todo	a cross-handler foreign-perform op-arg into a MATCH-shaped-resume arm declines cleanly (completeness gap)
 todo	a mutually-recursive group with a BRANCH-PERFORM sharing a strict expr with the mutual call declines cleanly (adv-69 rw4 sub-face)
-todo	a performing scrutinee matched by a performing guard with a NAMED fallback binder DECLINES (breaker finding #9)
+pass	a performing scrutinee matched by a PERFORMING GUARD is a COMPILE ERROR (breaker finding #9, now CDZ0407)
 todo	a recursive nested-op performer whose resume-VALUE reads the inner state around the outer perform declines cleanly
 todo	a recursive scalar-walk classifies characters across a multibyte String entry arg
 todo	a runtime bin match decodes a FINAL constant-size utf8 segment
@@ -6127,7 +6127,7 @@ pass	a USER-SUM-literal scrutinee with a performing payload — the ctor pattern
 pass	a STD-SUM (Option) literal scrutinee — single eval, payload binds by position
 pass	a LIST-literal scrutinee with performing elements — draws fire once, bind by position
 pass	a performing record nested in a TUPLE scrutinee — bound by position, record-matched after
-pass	a performing scrutinee + performing guard with a WILDCARD (unnamed) fallback folds — the finding #9 single-binder control
+pass	a performing guard with a WILDCARD fallback is ALSO a COMPILE ERROR (finding #9 sibling, CDZ0407)
 pass	za1 literal-arm dispatch on a draw — the MATCHED arm performs again, both calls exercised
 pass	za2 a COMPUTED scrutinee (difference of two draws) selects the performing arm at one input only
 pass	za3 NESTED literal-arm dispatch — each level matches a let-bound draw, the innermost arm reads a third
@@ -6147,7 +6147,7 @@ pass	hp3 the recursive call sits in the SEED — each frame's handler is seeded 
 pass	pa1 a SAME-effect perform as another op's ARGUMENT — the arg dispatch advances the state the outer dispatch reads
 pass	pa2 TWO same-effect draws as the TWO arguments of one op — left-to-right arg order, the arm reads the post-args state
 pass	pa3 THREE-deep nested same-effect arg-feed — scale(scale(next)) with a state-advancing scale arm
-pass	gp1 a PERFORMING guard on a wildcard pattern — hit and miss arms both read the guard-advanced state
+pass	gp1 a PERFORMING guard on a wildcard pattern is a COMPILE ERROR (guards-side-effect-free, CDZ0407)
 pass	gp2e TWO pure guards cascade over a draw, the fallback re-performs — guard misses leave dispatch serviceable
 pass	gp2 TWO guard arms where a guard PERFORMS — declines (multi-guard performing-condition fold gap)
 pass	hs1 an inner SAME-effect handle's result is the match SCRUTINEE — the selected arm and the trailing draw hit the OUTER state

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -5956,7 +5956,7 @@ todo	a closed literal closure forwarded through const-wrapper hops is not a fals
 todo	a constant-try helper that fails feeds the None arm's fallback into resume
 todo	a cross-handler foreign-perform op-arg into a MATCH-shaped-resume arm declines cleanly (completeness gap)
 todo	a mutually-recursive group with a BRANCH-PERFORM sharing a strict expr with the mutual call declines cleanly (adv-69 rw4 sub-face)
-todo	a performing scrutinee matched by a performing guard with a NAMED fallback binder DECLINES (breaker finding #9)
+pass	a performing scrutinee matched by a PERFORMING GUARD is a COMPILE ERROR (breaker finding #9, now CDZ0407)
 todo	a recursive NEWTYPE traversal recurses on its projected recursive field
 todo	a recursive NEWTYPE-wrapped linked list folds to a scalar
 todo	a recursive nested-op performer whose resume-VALUE reads the inner state around the outer perform declines cleanly
@@ -6127,7 +6127,7 @@ pass	a USER-SUM-literal scrutinee with a performing payload — the ctor pattern
 pass	a STD-SUM (Option) literal scrutinee — single eval, payload binds by position
 pass	a LIST-literal scrutinee with performing elements — draws fire once, bind by position
 pass	a performing record nested in a TUPLE scrutinee — bound by position, record-matched after
-pass	a performing scrutinee + performing guard with a WILDCARD (unnamed) fallback folds — the finding #9 single-binder control
+pass	a performing guard with a WILDCARD fallback is ALSO a COMPILE ERROR (finding #9 sibling, CDZ0407)
 pass	za1 literal-arm dispatch on a draw — the MATCHED arm performs again, both calls exercised
 pass	za2 a COMPUTED scrutinee (difference of two draws) selects the performing arm at one input only
 pass	za3 NESTED literal-arm dispatch — each level matches a let-bound draw, the innermost arm reads a third
@@ -6147,7 +6147,7 @@ pass	hp3 the recursive call sits in the SEED — each frame's handler is seeded 
 pass	pa1 a SAME-effect perform as another op's ARGUMENT — the arg dispatch advances the state the outer dispatch reads
 pass	pa2 TWO same-effect draws as the TWO arguments of one op — left-to-right arg order, the arm reads the post-args state
 pass	pa3 THREE-deep nested same-effect arg-feed — scale(scale(next)) with a state-advancing scale arm
-pass	gp1 a PERFORMING guard on a wildcard pattern — hit and miss arms both read the guard-advanced state
+pass	gp1 a PERFORMING guard on a wildcard pattern is a COMPILE ERROR (guards-side-effect-free, CDZ0407)
 pass	gp2e TWO pure guards cascade over a draw, the fallback re-performs — guard misses leave dispatch serviceable
 pass	gp2 TWO guard arms where a guard PERFORMS — declines (multi-guard performing-condition fold gap)
 pass	hs1 an inner SAME-effect handle's result is the match SCRUTINEE — the selected arm and the trailing draw hit the OUTER state

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -5895,7 +5895,7 @@ pass	a host-delegated result SEEDS an in-program handler's initial state
 pass	a host-op argument COMPUTED by guest arithmetic crosses the boundary evaluated
 pass	a let-bound host result captured by two escaping closures fires the host op once (adv-62)
 todo	a mutually-recursive group with a BRANCH-PERFORM sharing a strict expr with the mutual call declines cleanly (adv-69 rw4 sub-face)
-todo	a performing scrutinee matched by a performing guard with a NAMED fallback binder DECLINES (breaker finding #9)
+pass	a performing scrutinee matched by a PERFORMING GUARD is a COMPILE ERROR (breaker finding #9, now CDZ0407)
 pass	a performing closure stored in a TUPLE and applied IN-GUEST fires normally
 pass	a program that makes a host call has that call in its observable behavior
 pass	a program uses a response-returning delegated host function's return value
@@ -6127,7 +6127,7 @@ pass	a USER-SUM-literal scrutinee with a performing payload — the ctor pattern
 pass	a STD-SUM (Option) literal scrutinee — single eval, payload binds by position
 pass	a LIST-literal scrutinee with performing elements — draws fire once, bind by position
 pass	a performing record nested in a TUPLE scrutinee — bound by position, record-matched after
-pass	a performing scrutinee + performing guard with a WILDCARD (unnamed) fallback folds — the finding #9 single-binder control
+pass	a performing guard with a WILDCARD fallback is ALSO a COMPILE ERROR (finding #9 sibling, CDZ0407)
 pass	za1 literal-arm dispatch on a draw — the MATCHED arm performs again, both calls exercised
 pass	za2 a COMPUTED scrutinee (difference of two draws) selects the performing arm at one input only
 pass	za3 NESTED literal-arm dispatch — each level matches a let-bound draw, the innermost arm reads a third
@@ -6147,7 +6147,7 @@ pass	hp3 the recursive call sits in the SEED — each frame's handler is seeded 
 pass	pa1 a SAME-effect perform as another op's ARGUMENT — the arg dispatch advances the state the outer dispatch reads
 pass	pa2 TWO same-effect draws as the TWO arguments of one op — left-to-right arg order, the arm reads the post-args state
 pass	pa3 THREE-deep nested same-effect arg-feed — scale(scale(next)) with a state-advancing scale arm
-pass	gp1 a PERFORMING guard on a wildcard pattern — hit and miss arms both read the guard-advanced state
+pass	gp1 a PERFORMING guard on a wildcard pattern is a COMPILE ERROR (guards-side-effect-free, CDZ0407)
 pass	gp2e TWO pure guards cascade over a draw, the fallback re-performs — guard misses leave dispatch serviceable
 pass	gp2 TWO guard arms where a guard PERFORMS — declines (multi-guard performing-condition fold gap)
 pass	hs1 an inner SAME-effect handle's result is the match SCRUTINEE — the selected arm and the trailing draw hit the OUTER state

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -3777,7 +3777,9 @@
            guard-matches-then-false): a None scrutinee against `(guard (Some v) (> v (St.quota)))`
            must reach the catch-all with the guard's perform NEVER evaluated — witnessed by a
            post-match `St.quota` reading the UNADVANCED state: 100·99 + 5 = 9905. (The keep-the-match
-           hoist guarantees this; an if-only rewrite would have run the guard on the miss.)")
+           hoist guarantees this; an if-only rewrite would have run the guard on the miss.)
+           UPDATE (guards-side-effect-free, CDZ0407): `(St.quota)` in the guard cond is NOW a COMPILE ERROR —
+           the pattern-miss soundness this pinned is moot once a performing guard cannot exist.")
   (input  (do
             (effect St (op quota (-> Unit Int64)))
             (def (main (: n Int64))
@@ -3788,7 +3790,7 @@
                             (_other 99)))
                    (St.quota))))
             (export main)))
-  (call   main (: 5 Int64)) (output (: 9905 Int64)))
+  (error  CDZ0407))
 
 (case "a MULTI-argument op mixing a heap list and two scalars — the arm consumes all three"
   (doc    "Multi-argument op signatures are pinned scalar-only; here a `(List Int64)` crosses beside
@@ -5065,7 +5067,8 @@
   (doc    "The third position a perform can occupy in a guarded match: the GUARD CONDITION `(> (St.roll)
            4)` — scrutinee (`n`, pure) and arm bodies effect-free. roll → 5 (once; the guard evaluates
            only after its pattern matches), 5 > 4 holds → 5·100 = 500. Completes the position triple
-           with the scrutinee-perform and fallback-perform pins above.")
+           with the scrutinee-perform and fallback-perform pins above.
+           UPDATE (guards-side-effect-free, CDZ0407): `(St.roll)` in the guard cond is NOW a COMPILE ERROR.")
   (input  (do
             (effect St (op roll (-> Unit Int64)))
             (def (main (: n Int64))
@@ -5075,7 +5078,7 @@
                   ((guard v (> (St.roll) 4)) (* v 100))
                   (v v))))
             (export main)))
-  (call   main (: 5 Int64)) (output (: 500 Int64)))
+  (error  CDZ0407))
 
 (case "a MULTI-guard chain on a perform-result scrutinee with a performing fallback folds"
   (doc    "The chain face of the fixed class: TWO guarded arms cascade over the perform-result
@@ -10627,7 +10630,11 @@
            `5 > 3` holds, so the first arm fires → 100. (A REFUTABLE guarded pattern now ALSO folds — via a
            match that keeps the pattern and hoists the guard into an inner `if`, see the cases below. MULTIPLE
            guarded arms — which sequence handler state per arm-test — remain not-this-shape and decline
-           cleanly, an honest 'not yet reducible' todo, never the misleading 'no enclosing handler'.)")
+           cleanly, an honest 'not yet reducible' todo, never the misleading 'no enclosing handler'.)
+           UPDATE (guards-side-effect-free, operator directive PR #2543, CDZ0407): a perform in a guard is NOW
+           a COMPILE ERROR — the fold this once pinned is removed. `(Ask.get)` in the guard cond → CDZ0407.
+           The historical fold rationale above is retained for context; the workaround is to lift the perform
+           to a `let` before the match and guard on the bound value.")
   (input  (do
             (effect Ask (op get (-> Int64)))
             (def (main)
@@ -10636,14 +10643,15 @@
                   ((guard n (> (Ask.get) 3)) 100)
                   (n 200))))
             (export main)))
-  (output (: 100 Int64)))
+  (error  CDZ0407))
 
 (case "a performing match-arm guard folds with WILDCARD patterns (no binder to let-bind)"
   (doc    "The wildcard spelling of the guard-desugar above: both the guarded arm's inner pattern and the
            catch-all are `_` (bind nothing), so the desugar to `(if <guard> <arm-body> <catch-all-body>)`
            needs NO enclosing `let` — the bare `if` suffices (the `binders.is_empty()` path). `Ask` seeded 5,
            `(> (Ask.get) 3)` reads 5 → true, so the first arm fires → 100. Pins that the guard-routing
-           desugar handles a wildcard-patterned guarded arm (no scrutinee binder) as well as a named one.")
+           desugar handles a wildcard-patterned guarded arm (no scrutinee binder) as well as a named one.
+           UPDATE (guards-side-effect-free, CDZ0407): `(Ask.get)` in the guard cond is NOW a COMPILE ERROR.")
   (input  (do
             (effect Ask (op get (-> Int64)))
             (def (main)
@@ -10652,7 +10660,7 @@
                   ((guard _ (> (Ask.get) 3)) 100)
                   (_ 200))))
             (export main)))
-  (output (: 100 Int64)))
+  (error  CDZ0407))
 
 (case "a performing match-arm guard on a REFUTABLE pattern folds (keeps the match, hoists the guard)"
   (doc    "The refutable-pattern face of the performing guard-desugar (breaker bg-family). When the guarded
@@ -10664,7 +10672,8 @@
            two-byte scrutinee (tag=7, val=42), the guard `(> val (St.quota))` reads the seed (n) and holds
            for n<42, so the arm yields `(+ (* 100 tag) val)` = 742; for n≥42 the guard fails and the arm's
            inner `if` falls to the catch-all -1. A scrutinee that FAILS the pattern reaches the catch-all
-           WITHOUT running the guard perform (the match, not the guard, gates it). Seeded n=5 → 742.")
+           WITHOUT running the guard perform (the match, not the guard, gates it). Seeded n=5 → 742.
+           UPDATE (guards-side-effect-free, CDZ0407): `(St.quota)` in the guard cond is NOW a COMPILE ERROR.")
   (input  (do
             (effect St (op quota (-> Unit Int64)))
             (def (main (: n Int64))
@@ -10675,14 +10684,15 @@
                     (+ (* 100 tag) val))
                   (_other -1))))
             (export main)))
-  (call   main (: 5 Int64)) (output (: 742 Int64)))
+  (error  CDZ0407))
 
 (case "a performing guard on a refutable pattern whose guard FAILS falls to the catch-all"
   (doc    "The guard-fails path of the refutable performing-guard fold: same shape as above but seeded so the
            guard is false — `(> val (St.quota))` with `val`=42 and the seed n=50, so `42 > 50` is FALSE. The
            pattern still matches (tag=7, val=42), the hoisted inner `if` evaluates the guard (which reads the
            seed 50) and takes the else branch → the catch-all -1. Pins that a matched pattern with a failing
-           performing guard folds to the fall-through, not the guarded body.")
+           performing guard folds to the fall-through, not the guarded body.
+           UPDATE (guards-side-effect-free, CDZ0407): `(St.quota)` in the guard cond is NOW a COMPILE ERROR.")
   (input  (do
             (effect St (op quota (-> Unit Int64)))
             (def (main (: n Int64))
@@ -10693,14 +10703,15 @@
                     (+ (* 100 tag) val))
                   (_other -1))))
             (export main)))
-  (call   main (: 50 Int64)) (output (: -1 Int64)))
+  (error  CDZ0407))
 
 (case "a performing guard on a TUPLE-destructuring pattern folds"
   (doc    "The tuple-pattern spelling of the refutable performing-guard fold: `(guard (tuple tag val) (> val
            (St.quota)))` destructures a tuple scrutinee, and the performing guard hoists into the matched
            arm's inner `if` exactly as for the bit-pattern. `(tuple 7 42)` matches (tag=7, val=42), guard
            `42 > 5` holds → `(+ 700 42)` = 742. Confirms the refutable-pattern guard-desugar is
-           pattern-shape-agnostic (bit patterns, tuples, and by extension ctor patterns all route).")
+           pattern-shape-agnostic (bit patterns, tuples, and by extension ctor patterns all route).
+           UPDATE (guards-side-effect-free, CDZ0407): `(St.quota)` in the guard cond is NOW a COMPILE ERROR.")
   (input  (do
             (effect St (op quota (-> Unit Int64)))
             (def (main (: n Int64))
@@ -10711,7 +10722,7 @@
                     (+ (* 100 tag) val))
                   (_other -1))))
             (export main)))
-  (call   main (: 5 Int64)) (output (: 742 Int64)))
+  (error  CDZ0407))
 
 (case "an effectful condition of a same-constructor if is performed exactly once"
   (doc    "The evaluate-ONCE pin for the common-constructor if-arm hoist, observable through handler
@@ -14291,7 +14302,11 @@
 ;; is an honest not-yet-reducible decline (the multi-guard arm-copy cascade lands the performing
 ;; condition non-tail); flip values banked (main 6=248, 30=111, 1=-8) for when that fold lands.
 
-(case "gp1 a PERFORMING guard on a wildcard pattern — hit and miss arms both read the guard-advanced state"
+(case "gp1 a PERFORMING guard on a wildcard pattern is a COMPILE ERROR (guards-side-effect-free, CDZ0407)"
+  (doc    "Was a fold pin (breaker gp1); guards-side-effect-free (operator directive PR #2543) makes a perform
+           in a guard cond a COMPILE ERROR. `(St.next)` in `(> (St.next) 6)` → CDZ0407. breaker re-adds the
+           dispatch-semantics coverage as a let-lifted pure-guard equivalent in a follow-up batch (bind the
+           guard's draw to a `let` before the match, guard on the bound value).")
   (input  (do
             (effect St (op next (-> Int64)))
             (def (main (: n Int64))
@@ -14302,8 +14317,7 @@
                     ((guard _x (> (St.next) 6)) (+ 100 (St.next)))
                     (_o (* 10 (St.next)))))))
             (export main)))
-  (call   main (: 6 Int64)) (output (: 108 Int64))
-  (call   main (: 2 Int64)) (output (: 40 Int64)))
+  (error  CDZ0407))
 
 (case "gp2e TWO pure guards cascade over a draw, the fallback re-performs — guard misses leave dispatch serviceable"
   (input  (do
@@ -14335,23 +14349,15 @@
             (export main)))
   (declines))
 
-(case "a performing scrutinee matched by a performing guard with a NAMED fallback binder DECLINES (breaker finding #9)"
-  (doc    "REJECT-DON'T-MISCOMPILE (v-effects finding #9, breaker f1, 3-backend-agree-wrong). The performing-
-           guard-match desugar (`desugar_performing_guard_match`) rewrites `(match S ((guard x cond) b) (_o
-           b2))` into `(let ((x S') (_o S'')) (if cond b b2))`, binding the scrutinee to EACH named arm binder
-           via a fresh `copy_pure(S)`. When the scrutinee S itself PERFORMS and there are >=2 named binders
-           (arm-0's guard binder `x` AND a NAMED fallback binder `_o`), each copy RE-EVALUATES the performing
-           scrutinee: on a guard MISS the fallback `_o` reads a RE-DRAWN value — this shape silently returned 6
-           not 3 (f1), with a third hidden draw (f2 dispatch-witness). Correctness is INPUT-DEPENDENT (the SAME
-           program is correct when the guard HITS, wrong when it MISSES), so the whole shape declines rather
-           than miscompile. The correct fix (bind the performing scrutinee ONCE to a temp, alias both binders
-           to it) is the fresh-context bind-once/let-threading arc (shared root with findings #8/lb/sh). The
-           workaround — `let`-bind the scrutinee first, then match the bound value — folds correctly (breaker
-           c3). A SINGLE named binder is sound (one copy = one eval — the control below). The desugar now
-           DECLINES this shape (returns None → the honest 'not yet reducible' todo) rather than emit the
-           copy-per-binder re-eval, so this is a TODO decline-witness pinned with its post-fix value: n=3 draws
-           scrutinee 3 (s->6), guard performs 6 (s->12), 3 > 6 false → the `_o` fallback yields the correctly-
-           bound 3. Flips todo->3 when the bind-once arc binds the scrutinee once and aliases both binders.")
+(case "a performing scrutinee matched by a PERFORMING GUARD is a COMPILE ERROR (breaker finding #9, now CDZ0407)"
+  (doc    "HISTORY: v-effects finding #9 was a silent 3-backend re-eval MISCOMPILE — `(match (St.next) ((guard x
+           (> x (St.next))) …) (_o _o))` where the performing guard's desugar copied the performing scrutinee
+           per named binder, so a guard MISS re-drew (f1: 6 not 3). Interim fix reject-don't-miscompiled it (a
+           todo decline). SUPERSEDED by guards-side-effect-free (operator directive PR #2543): a perform in a
+           guard cond is now a COMPILE ERROR (CDZ0407) — `(> x (St.next))` has a perform, so the whole
+           finding-#9 shape errors at the guard BEFORE the fold ever sees it. The re-eval class is eliminated
+           at the source for the guard arm. Workaround: lift the guard's draw to a `let` before the match and
+           guard on the bound value (breaker re-adds pure-guard dispatch coverage in a follow-up).")
   (input  (do
             (effect St (op next (-> Int64)))
             (def (main (: n Int64))
@@ -14361,16 +14367,14 @@
                   ((guard x (> x (St.next))) (* 100 x))
                   (_o _o))))
             (export main)))
-  (call   main (: 3 Int64)) (output (: 3 Int64)))
+  (error  CDZ0407))
 
-(case "a performing scrutinee + performing guard with a WILDCARD (unnamed) fallback folds — the finding #9 single-binder control"
-  (doc    "The scoping control for finding #9's decline above: the SAME performing-scrutinee + performing-guard
-           shape but with a WILDCARD `_` fallback (NOT a named binder), so only ONE named binder (`x`) exists.
-           The desugar then does a SINGLE `copy_pure(scrutinee)` (one eval, not two), so it folds soundly — the
-           `>=2 named binders over a performing scrutinee` gate does NOT fire. `next` returns s then doubles it
-           (n=3: draw 3 s->6, guard draws 6 s->12; 3 > 6 is false → the `_` fallback = 99). Pins that the
-           finding-#9 reject is SCOPED to the >=2-named-binder re-copy shape and does not over-decline the
-           sound single-binder performing guard.")
+(case "a performing guard with a WILDCARD fallback is ALSO a COMPILE ERROR (finding #9 sibling, CDZ0407)"
+  (doc    "The wildcard-fallback sibling of the finding-#9 shape above: same performing scrutinee + performing
+           guard `(> x (St.next))` but a `_` fallback. Under the interim fold-decline this folded (single named
+           binder = one copy); under guards-side-effect-free it is a COMPILE ERROR like every performing guard —
+           the perform in the guard cond is CDZ0407 regardless of the fallback shape. Pins that the guard-reject
+           is fallback-shape-agnostic (named or wildcard): a performing guard is illegal, period.")
   (input  (do
             (effect St (op next (-> Int64)))
             (def (main (: n Int64))
@@ -14380,7 +14384,7 @@
                   ((guard x (> x (St.next))) (* 100 x))
                   (_ 99))))
             (export main)))
-  (call   main (: 3 Int64)) (output (: 99 Int64)))
+  (error  CDZ0407))
 
 ;; ── an inner handle's RESULT feeds outer control flow (breaker hs) ───────────────────────────────
 ;; The inner same-effect handle runs to completion and its VALUE drives the enclosing region's


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref 5d4e975968519c54120ac880ef2ebaa962dc6b75, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.