### PR TITLE
refactor(cdz-agent-host): migrate callers to typed EffectOutcome::Err{message,retryability} (Q2 pair-half)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/clock.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/clock.rs
@@ -18,7 +18,6 @@
 //! `u64::from_le_bytes(bytes.try_into()?)`. (`Now`'s target is empty; a capability gates it by kind, e.g.
 //! `Capability { kind: Now, predicate: Any }`.)
 
-use crate::retry;
 use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::executor::Executor;
@@ -57,11 +56,11 @@ impl Executor for ClockExecutor {
         if !req.content_type.matches_family(effect_ct::NOW) {
             // A wrong-family request is structural — PERMANENT, a supervisor must not retry it (§17: an
             // observable Err, never a panic).
-            return EffectOutcome::Err(retry::permanent(format!(
+            return EffectOutcome::err(format!(
                 "ClockExecutor only handles the {} family, got {}",
                 effect_ct::NOW,
                 req.content_type.family
-            )));
+            ));
         }
         // Nanoseconds since the Unix epoch as a u64 LITTLE-ENDIAN 8-byte integer (operator binary-ns
         // directive + the kernel monotonic-clamp payload spec): the kernel's clamp reads exactly this
@@ -76,9 +75,7 @@ impl Executor for ClockExecutor {
                 let ns = dur.as_nanos() as u64;
                 EffectOutcome::Ok(Some(Payload::Inline(ns.to_le_bytes().to_vec().into())))
             }
-            Err(e) => EffectOutcome::Err(retry::permanent(format!(
-                "system clock is before the Unix epoch: {e}"
-            ))),
+            Err(e) => EffectOutcome::err(format!("system clock is before the Unix epoch: {e}")),
         }
     }
 
@@ -94,6 +91,7 @@ impl Executor for ClockExecutor {
 mod tests {
     use super::*;
     use cdz_kernel::effect::{EffectKind, Timeliness};
+    use cdz_kernel::event::Retryability;
 
     fn req(kind: EffectKind, target: &str) -> EffectRequest {
         EffectRequest::new(kind, target.to_string(), None, Timeliness::Interactive)
@@ -181,16 +179,15 @@ mod tests {
             .perform(&req(EffectKind::Http, "https://x/"), Hash::of(b"k"))
             .await
         {
-            EffectOutcome::Err(msg) => {
+            EffectOutcome::Err {
+                message,
+                retryability,
+            } => {
                 assert!(
-                    msg.contains(effect_ct::NOW),
-                    "err names the handled family: {msg}"
+                    message.contains(effect_ct::NOW),
+                    "err names the handled family: {message}"
                 );
-                assert_eq!(
-                    retry::classify(&msg),
-                    retry::Retryability::Permanent,
-                    "{msg}"
-                );
+                assert_eq!(retryability, Retryability::Permanent, "{message}");
             }
             other => panic!("expected Err for a non-Now kind, got {other:?}"),
         }

--- a/implementation/seed/crates/cdz-agent-host/src/config.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/config.rs
@@ -245,7 +245,7 @@ pub enum BlobConfig {
 }
 
 /// Effect-retry policy: a bounded exponential backoff the daemon's supervisor applies to a RETRYABLE
-/// effect outcome (a transient Bedrock/HTTP failure classified `RETRYABLE:` by [`crate::retry`]). A
+/// effect outcome (a transient Bedrock/HTTP failure the host classified `Retryability::Retryable`). A
 /// PERMANENT failure is never retried. This is the POLICY; the retry MECHANISM (re-emit via Timer on a
 /// RETRYABLE `EffectResult`) is a userspace/kernel-supervisor concern that reads it. The policy math —
 /// [`should_retry`](Self::should_retry) (attempt within `max_attempts`?) + [`backoff_ms`](Self::backoff_ms)

--- a/implementation/seed/crates/cdz-agent-host/src/emit.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/emit.rs
@@ -71,19 +71,19 @@ impl Executor for EmitExecutor {
         // Family-keyed (seq-39), matching the router + authz decision. A non-Emit family is structural →
         // PERMANENT (§17: observable Err, never a panic).
         if !req.content_type.matches_family(effect_ct::EMIT) {
-            return EffectOutcome::Err(crate::retry::permanent(format!(
+            return EffectOutcome::err(format!(
                 "EmitExecutor only handles the {} family, got {}",
                 effect_ct::EMIT,
                 req.content_type.family
-            )));
+            ));
         }
 
         // `target` is the peer session id (raw SessionId string, opaque routing hint). An empty target has
         // no peer to route to — structural PERMANENT.
         if req.target.is_empty() {
-            return EffectOutcome::Err(crate::retry::permanent(
+            return EffectOutcome::err(
                 "EmitExecutor: an Emit effect requires a non-empty target (the peer session id to route to)",
-            ));
+            );
         }
         // Clone the `Arc<str>` (O(1) refcount bump) rather than round-tripping `as_ref()` → a fresh alloc
         // (#2351 review c3): `SessionId` IS an `Arc<str>` and `req.target` already is one.
@@ -96,9 +96,9 @@ impl Executor for EmitExecutor {
             Some(Payload::Inline(bytes)) => Payload::Inline(bytes.clone()),
             None => Payload::Inline(Vec::new().into()),
             Some(Payload::Blob(_)) => {
-                return EffectOutcome::Err(crate::retry::permanent(
+                return EffectOutcome::err(
                     "EmitExecutor: a blob-ref Emit payload is unsupported — this executor has no blob-store access; inline the message",
-                ));
+                );
             }
         };
 
@@ -127,9 +127,9 @@ impl Executor for EmitExecutor {
             // The loop's receiver is gone (host shutting down / dropped). The signal couldn't be routed;
             // classify RETRYABLE — a supervisor may re-drive after the loop is back (transient, not a
             // malformed request).
-            Err(_) => EffectOutcome::Err(crate::retry::retryable(
+            Err(_) => EffectOutcome::err_retryable(
                 "EmitExecutor: the host loop inbox is closed — cannot route the Emit (host shutting down?)",
-            )),
+            ),
         }
     }
 
@@ -144,6 +144,7 @@ impl Executor for EmitExecutor {
 mod tests {
     use super::*;
     use cdz_kernel::effect::Timeliness;
+    use cdz_kernel::event::Retryability;
     use tokio::sync::mpsc;
 
     /// Build an Emit effect request to `target` with an inline `payload` (or none).
@@ -227,12 +228,16 @@ mod tests {
             .perform(&emit_req("", Some(b"x")), Hash::of(b"k"))
             .await;
         match out {
-            EffectOutcome::Err(reason) => {
-                assert!(
-                    reason.starts_with("PERMANENT:"),
-                    "empty target is structural: {reason}"
+            EffectOutcome::Err {
+                message,
+                retryability,
+            } => {
+                assert_eq!(
+                    retryability,
+                    Retryability::Permanent,
+                    "empty target is structural: {message}"
                 );
-                assert!(reason.contains("non-empty target"));
+                assert!(message.contains("non-empty target"));
             }
             other => panic!("expected a PERMANENT Err, got {other:?}"),
         }
@@ -250,7 +255,7 @@ mod tests {
         );
         let out = exec.perform(&req, Hash::of(b"k")).await;
         assert!(
-            matches!(out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("only handles")),
+            matches!(out, EffectOutcome::Err { message, retryability } if retryability == Retryability::Permanent && message.contains("only handles")),
             "a non-Emit family is rejected PERMANENT"
         );
         assert!(exec.handles_family(effect_ct::EMIT) && !exec.handles_family(effect_ct::HTTP));
@@ -272,7 +277,7 @@ mod tests {
         );
         let out = exec.perform(&req, Hash::of(b"k")).await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("blob-ref")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("blob-ref")),
             "a blob-ref Emit payload is rejected PERMANENT (no blob-store access to forward it), got {out:?}"
         );
     }
@@ -288,7 +293,7 @@ mod tests {
             .perform(&emit_req("b", Some(b"x")), Hash::of(b"k"))
             .await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("RETRYABLE:") && r.contains("inbox is closed")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Retryable && message.contains("inbox is closed")),
             "a closed inbox is a transient RETRYABLE, got {out:?}"
         );
     }

--- a/implementation/seed/crates/cdz-agent-host/src/factory.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/factory.rs
@@ -105,17 +105,18 @@ impl Executor for MeteredExecutor {
                 self.metrics.record_ok();
                 tracing::debug!(target: "cdz_agent_host::effect", family, "effect ok");
             }
-            EffectOutcome::Err(reason) => {
-                // Classify ONCE + reuse for both the metric and the trace, so the event carries the derived
-                // Retryability as a structured field (filterable without parsing the reason string) — #2069
-                // review.
-                let retryability = crate::retry::classify(reason);
-                self.metrics.record_err(retryability);
+            EffectOutcome::Err {
+                message,
+                retryability,
+            } => {
+                // Read the TYPED retryability straight off the outcome (no string parsing) for both the
+                // metric and the trace, so the event carries it as a structured field — #2069 review.
+                self.metrics.record_err(*retryability);
                 tracing::warn!(
                     target: "cdz_agent_host::effect",
                     family,
                     retryability = ?retryability,
-                    reason,
+                    reason = message,
                     "effect errored"
                 );
             }
@@ -838,18 +839,17 @@ mod tests {
 
     #[tokio::test]
     async fn metered_executor_tallies_outcomes_and_passes_them_through() {
-        use crate::retry::{permanent, retryable};
         use cdz_kernel::effect::{EffectKind, Payload, Timeliness};
 
-        // Script Ok, a retryable Err, a permanent Err, an UNPREFIXED Err (fail-closed → permanent), and a
+        // Script Ok, a retryable Err, a permanent Err, an err() default (fail-closed → permanent), and a
         // TimedOut (its own counter, not an Err).
         let scripted = ScriptedExecutor {
             outcomes: std::cell::RefCell::new(
                 vec![
                     EffectOutcome::Ok(Some(Payload::Inline(b"ok".to_vec().into()))),
-                    EffectOutcome::Err(retryable("bedrock throttled (429)")),
-                    EffectOutcome::Err(permanent("bad request (400)")),
-                    EffectOutcome::Err("no token here".to_string()),
+                    EffectOutcome::err_retryable("bedrock throttled (429)"),
+                    EffectOutcome::err("bad request (400)"),
+                    EffectOutcome::err("no token here"),
                     EffectOutcome::TimedOut,
                 ]
                 .into(),
@@ -878,7 +878,7 @@ mod tests {
         ));
         assert!(matches!(
             metered.perform(&req, Hash::of(b"k")).await,
-            EffectOutcome::Err(_)
+            EffectOutcome::Err { .. }
         ));
         metered.perform(&req, Hash::of(b"k")).await;
         metered.perform(&req, Hash::of(b"k")).await;

--- a/implementation/seed/crates/cdz-agent-host/src/fs_exec.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/fs_exec.rs
@@ -21,7 +21,6 @@
 //! classified `EffectOutcome::Err`, never a panic. Most fs errors are PERMANENT for a given path+op (a
 //! missing file won't appear on a blind retry); the reducer decides what to do.
 
-use crate::retry;
 use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::executor::Executor;
@@ -56,7 +55,7 @@ impl Executor for FsExecutor {
         if req.content_type.matches_family(effect_ct::FS_READ) {
             match std::fs::read(path) {
                 Ok(bytes) => EffectOutcome::Ok(Some(Payload::Inline(bytes.into()))),
-                Err(e) => EffectOutcome::Err(retry::permanent(format!("fs/read {path}: {e}"))),
+                Err(e) => EffectOutcome::err(format!("fs/read {path}: {e}")),
             }
         } else if req.content_type.matches_family(effect_ct::FS_WRITE) {
             // The payload IS the file content. A blob-ref payload can't be resolved here (no blob-store
@@ -64,29 +63,29 @@ impl Executor for FsExecutor {
             let content: &[u8] = match &req.payload {
                 Some(Payload::Inline(bytes)) => bytes,
                 Some(Payload::Blob(_)) => {
-                    return EffectOutcome::Err(retry::permanent(
+                    return EffectOutcome::err(
                         "fs/write: blob-ref payload unsupported — this executor has no blob-store access; inline the bytes",
-                    ));
+                    );
                 }
                 None => {
-                    return EffectOutcome::Err(retry::permanent(
+                    return EffectOutcome::err(
                         "fs/write: a write requires a payload (the file bytes)",
-                    ));
+                    );
                 }
             };
             match std::fs::write(path, content) {
                 // A write returns no data — an empty inline payload is the unit ack the reducer folds.
                 Ok(()) => EffectOutcome::Ok(Some(Payload::Inline(Vec::new().into()))),
-                Err(e) => EffectOutcome::Err(retry::permanent(format!("fs/write {path}: {e}"))),
+                Err(e) => EffectOutcome::err(format!("fs/write {path}: {e}")),
             }
         } else if req.content_type.matches_family(effect_ct::FS_GLOB) {
             glob_paths(path)
         } else {
             // A non-fs family is structural (this executor serves only fs/*) → PERMANENT.
-            EffectOutcome::Err(retry::permanent(format!(
+            EffectOutcome::err(format!(
                 "FsExecutor only handles the fs/* families, got {}",
                 req.content_type.family
-            )))
+            ))
         }
     }
 
@@ -115,9 +114,7 @@ fn glob_paths(pattern: &str) -> EffectOutcome {
                 v.sort();
                 v
             }
-            Err(e) => {
-                return EffectOutcome::Err(retry::permanent(format!("fs/glob {pattern}: {e}")))
-            }
+            Err(e) => return EffectOutcome::err(format!("fs/glob {pattern}: {e}")),
         }
     } else if std::path::Path::new(pattern).exists() {
         vec![pattern.to_string()]
@@ -133,6 +130,7 @@ fn glob_paths(pattern: &str) -> EffectOutcome {
 mod tests {
     use super::*;
     use cdz_kernel::effect::{EffectKind, Timeliness};
+    use cdz_kernel::event::Retryability;
 
     fn fs_req(family: &'static str, path: &str, payload: Option<&[u8]>) -> EffectRequest {
         EffectRequest::new_with_family(
@@ -187,7 +185,7 @@ mod tests {
             )
             .await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("fs/read")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("fs/read")),
             "a missing path read is PERMANENT, got {out:?}"
         );
     }
@@ -201,7 +199,7 @@ mod tests {
             .perform(&fs_req(effect_ct::FS_WRITE, &ps, None), Hash::of(b"k"))
             .await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.contains("requires a payload")),
+            matches!(&out, EffectOutcome::Err { message, .. } if message.contains("requires a payload")),
             "a payload-less write is PERMANENT, got {out:?}"
         );
     }
@@ -242,7 +240,7 @@ mod tests {
         );
         let out = exec.perform(&req, Hash::of(b"k")).await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("only handles")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("only handles")),
             "a non-fs family is PERMANENT, got {out:?}"
         );
         assert!(exec.handles_family(effect_ct::FS_READ) && !exec.handles_family(effect_ct::SHELL));

--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -3064,7 +3064,7 @@ mod tests {
             _h: &[(String, String)],
             _b: Option<&[u8]>,
             _k: Hash,
-        ) -> Result<crate::HttpResponse, String> {
+        ) -> Result<crate::HttpResponse, cdz_kernel::event::EffectOutcome> {
             unreachable!("mechanism-surface test never performs the request")
         }
     }

--- a/implementation/seed/crates/cdz-agent-host/src/http.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/http.rs
@@ -21,7 +21,6 @@
 //! a deep copy. **Trust boundary:** the kernel already gated the resolved URL's host (SEC-F1) before
 //! dispatch; this executor does not re-authorize.
 
-use crate::retry;
 use bytes::Bytes;
 use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
@@ -93,13 +92,15 @@ impl HttpMethod {
 /// 500) and read response headers (content-type, …). The `idempotency_key` lets a side-effecting transport
 /// dedup a crash-re-driven request (§16c-S1/D) — relevant for a non-idempotent method.
 ///
-/// **Error classification (supervision, [`crate::retry`]).** `Err` is strictly a TRANSPORT-LEVEL failure
-/// (the request never completed) — NOT an HTTP status: a completed request with a 4xx/5xx STATUS comes back
-/// as `Ok(HttpResponse)` carrying that status, and the reducer decides what a 404/500 means, not the
-/// transport. An `Err(reason)` MUST lead with a retryability token classifying that transport failure — a
-/// transient one (timeout, connection reset/refused) as [`crate::retry::retryable`], a permanent one (DNS
-/// failure, malformed URL, TLS error) as [`crate::retry::permanent`]. Unprefixed reasons are treated
-/// PERMANENT (fail-closed). The retryability guidance applies to `Err` only, never to app-level statuses.
+/// **Error classification (supervision).** `Err` is strictly a TRANSPORT-LEVEL failure (the request never
+/// completed) — NOT an HTTP status: a completed request with a 4xx/5xx STATUS comes back as
+/// `Ok(HttpResponse)` carrying that status, and the reducer decides what a 404/500 means, not the transport.
+/// The `Err` half is a classified [`EffectOutcome`](cdz_kernel::event::EffectOutcome) carrying a typed
+/// [`Retryability`](cdz_kernel::event::Retryability) — a transient failure (timeout, connection
+/// reset/refused) via [`EffectOutcome::err_retryable`](cdz_kernel::event::EffectOutcome::err_retryable), a
+/// permanent one (DNS failure, malformed URL, TLS error) via
+/// [`EffectOutcome::err`](cdz_kernel::event::EffectOutcome::err) (`Permanent` is the fail-closed default).
+/// The retryability applies to `Err` only, never to app-level statuses.
 /// `#[async_trait(?Send)]` — a real HTTP request awaits the socket; not `Send` (single-threaded host).
 #[async_trait::async_trait(?Send)]
 pub trait HttpTransport {
@@ -110,7 +111,7 @@ pub trait HttpTransport {
         headers: &[(String, String)],
         body: Option<&[u8]>,
         idempotency_key: Hash,
-    ) -> Result<HttpResponse, String>;
+    ) -> Result<HttpResponse, EffectOutcome>;
 }
 
 /// A completed HTTP response — the STATUS code, response HEADERS (ordered name/value pairs), and BODY. The
@@ -143,11 +144,11 @@ impl<T: HttpTransport> Executor for HttpExecutor<T> {
         // Family-keyed (seq-39), not the EffectKind enum — the same decision the router + authz make.
         if !req.content_type.matches_family(effect_ct::HTTP) {
             // Structural — PERMANENT, a supervisor must not retry it (§17: observable Err, never a panic).
-            return EffectOutcome::Err(retry::permanent(format!(
+            return EffectOutcome::err(format!(
                 "HttpExecutor only handles the {} family, got {}",
                 effect_ct::HTTP,
                 req.content_type.family
-            )));
+            ));
         }
         // The payload is a `(http-request (method <name>) (headers ((k v)…)) (body <opt>))` binary-sexpr —
         // decode the caller-specified method + headers + body (NO body-presence heuristic). A blob-ref
@@ -160,20 +161,20 @@ impl<T: HttpTransport> Executor for HttpExecutor<T> {
                         (HttpMethod::from_name(&method_name), headers, body)
                     }
                     Err(e) => {
-                        return EffectOutcome::Err(retry::permanent(format!(
+                        return EffectOutcome::err(format!(
                             "HttpExecutor: malformed http-request payload: {e:?}"
-                        )));
+                        ));
                     }
                 },
                 Some(Payload::Blob(_)) => {
-                    return EffectOutcome::Err(retry::permanent(
+                    return EffectOutcome::err(
                         "HttpExecutor: blob-ref request payload unsupported — this executor has no blob-store access; inline the http-request",
-                    ));
+                    );
                 }
                 None => {
-                    return EffectOutcome::Err(retry::permanent(
+                    return EffectOutcome::err(
                         "HttpExecutor: an Http effect requires an http-request payload (method + optional body)",
-                    ));
+                    );
                 }
             };
         match self
@@ -194,7 +195,7 @@ impl<T: HttpTransport> Executor for HttpExecutor<T> {
                 let payload = encode_http_response(resp.status, &resp.headers, &resp.body);
                 EffectOutcome::Ok(Some(Payload::Inline(payload.into())))
             }
-            Err(reason) => EffectOutcome::Err(reason),
+            Err(outcome) => outcome,
         }
     }
 
@@ -213,8 +214,8 @@ impl<T: HttpTransport> Executor for HttpExecutor<T> {
 /// The kernel already gated the resolved URL's host (SEC-F1 SSRF/exfil guard) BEFORE dispatch, so this
 /// does NOT re-authorize — it just performs the request. It maps a completed request (any status) to
 /// `Ok(HttpResponse)` and a TRANSPORT failure to a retryability-classified `Err` (§9d/§17): a timeout or
-/// connect error is [`retry::retryable`], a builder/decode/redirect-policy failure is
-/// [`retry::permanent`]. Credentials come from the ambient environment where relevant (none needed here).
+/// connect error is `err_retryable`, a builder/decode/redirect-policy failure is `err` (Permanent).
+/// Credentials come from the ambient environment where relevant (none needed here).
 ///
 /// **Redirects are NOT followed** (SEC-F1). The kernel authorizes the host of the ORIGINAL URL; a 3xx to a
 /// different host would let an authorized fetch be silently redirected to a DISALLOWED host after the
@@ -242,7 +243,7 @@ impl ReqwestHttpTransport {
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .map(|client| ReqwestHttpTransport { client })
-            .map_err(|e| retry::permanent(format!("failed to build the HTTP client: {e}")))
+            .map_err(|e| format!("failed to build the HTTP client: {e}"))
     }
 }
 
@@ -256,12 +257,12 @@ impl HttpTransport for ReqwestHttpTransport {
         headers: &[(String, String)],
         body: Option<&[u8]>,
         _idempotency_key: Hash,
-    ) -> Result<HttpResponse, String> {
+    ) -> Result<HttpResponse, EffectOutcome> {
         // Method + URL. reqwest parses the method string; an unparseable custom method (control chars,
         // spaces) is a structural PERMANENT error (the request line can't be formed).
         let reqwest_method =
             reqwest::Method::from_bytes(method.as_str().as_bytes()).map_err(|e| {
-                retry::permanent(format!("invalid HTTP method {:?}: {e}", method.as_str()))
+                EffectOutcome::err(format!("invalid HTTP method {:?}: {e}", method.as_str()))
             })?;
         let mut builder = self.client.request(reqwest_method, url);
         for (k, v) in headers {
@@ -273,13 +274,13 @@ impl HttpTransport for ReqwestHttpTransport {
 
         // A transport-level failure (the request never completed) → classified Err. A COMPLETED request
         // with any status (incl. 4xx/5xx) is Ok — the reducer decides what a status means, not us.
-        let resp =
-            self.client
-                .execute(builder.build().map_err(|e| {
-                    retry::permanent(format!("failed to build the HTTP request: {e}"))
-                })?)
-                .await
-                .map_err(classify_reqwest_error)?;
+        let resp = self
+            .client
+            .execute(builder.build().map_err(|e| {
+                EffectOutcome::err(format!("failed to build the HTTP request: {e}"))
+            })?)
+            .await
+            .map_err(classify_reqwest_error)?;
 
         let status = resp.status().as_u16();
         let resp_headers: Vec<(String, String)> = resp
@@ -310,11 +311,11 @@ impl HttpTransport for ReqwestHttpTransport {
 /// failure is transient (the endpoint may recover) → retryable; anything else (a redirect-policy or
 /// decode failure, a malformed URL that slipped the builder) is permanent by default (fail-closed).
 #[cfg(feature = "live-net")]
-fn classify_reqwest_error(e: reqwest::Error) -> String {
+fn classify_reqwest_error(e: reqwest::Error) -> EffectOutcome {
     if e.is_timeout() || e.is_connect() {
-        retry::retryable(format!("HTTP transport failure: {e}"))
+        EffectOutcome::err_retryable(format!("HTTP transport failure: {e}"))
     } else {
-        retry::permanent(format!("HTTP transport failure: {e}"))
+        EffectOutcome::err(format!("HTTP transport failure: {e}"))
     }
 }
 
@@ -322,6 +323,7 @@ fn classify_reqwest_error(e: reqwest::Error) -> String {
 mod tests {
     use super::*;
     use cdz_kernel::effect::Timeliness;
+    use cdz_kernel::event::Retryability;
     use cdz_kernel::event_ast::{
         decode_http_response, encode_http_request, encode_http_request_with_headers,
     };
@@ -343,7 +345,7 @@ mod tests {
             headers: &[(String, String)],
             body: Option<&[u8]>,
             _key: Hash,
-        ) -> Result<HttpResponse, String> {
+        ) -> Result<HttpResponse, EffectOutcome> {
             assert_eq!(url, "https://ok.host/x");
             assert_eq!(
                 method, self.expect_method,
@@ -530,7 +532,7 @@ mod tests {
                 _h: &[(String, String)],
                 _b: Option<&[u8]>,
                 _k: Hash,
-            ) -> Result<HttpResponse, String> {
+            ) -> Result<HttpResponse, EffectOutcome> {
                 panic!("transport must not be called for a blob-ref payload");
             }
         }
@@ -542,13 +544,12 @@ mod tests {
             Timeliness::Interactive,
         );
         match exec.perform(&req, Hash::of(b"k")).await {
-            EffectOutcome::Err(msg) => {
-                assert!(msg.contains("no blob-store access"), "{msg}");
-                assert_eq!(
-                    retry::classify(&msg),
-                    retry::Retryability::Permanent,
-                    "{msg}"
-                );
+            EffectOutcome::Err {
+                message,
+                retryability,
+            } => {
+                assert!(message.contains("no blob-store access"), "{message}");
+                assert_eq!(retryability, Retryability::Permanent, "{message}");
             }
             other => panic!("expected Err for a blob-ref payload, got {other:?}"),
         }
@@ -566,7 +567,7 @@ mod tests {
                 _h: &[(String, String)],
                 _b: Option<&[u8]>,
                 _k: Hash,
-            ) -> Result<HttpResponse, String> {
+            ) -> Result<HttpResponse, EffectOutcome> {
                 panic!("transport must not be called for a malformed request");
             }
         }
@@ -578,13 +579,12 @@ mod tests {
             Timeliness::Interactive,
         );
         match exec.perform(&no_payload, Hash::of(b"k")).await {
-            EffectOutcome::Err(msg) => {
-                assert!(msg.contains("http-request payload"), "{msg}");
-                assert_eq!(
-                    retry::classify(&msg),
-                    retry::Retryability::Permanent,
-                    "{msg}"
-                );
+            EffectOutcome::Err {
+                message,
+                retryability,
+            } => {
+                assert!(message.contains("http-request payload"), "{message}");
+                assert_eq!(retryability, Retryability::Permanent, "{message}");
             }
             other => panic!("expected Err for a missing payload, got {other:?}"),
         }
@@ -596,13 +596,12 @@ mod tests {
             Timeliness::Interactive,
         );
         match exec.perform(&garbage, Hash::of(b"k")).await {
-            EffectOutcome::Err(msg) => {
-                assert!(msg.contains("malformed"), "{msg}");
-                assert_eq!(
-                    retry::classify(&msg),
-                    retry::Retryability::Permanent,
-                    "{msg}"
-                );
+            EffectOutcome::Err {
+                message,
+                retryability,
+            } => {
+                assert!(message.contains("malformed"), "{message}");
+                assert_eq!(retryability, Retryability::Permanent, "{message}");
             }
             other => panic!("expected Err for a garbage payload, got {other:?}"),
         }
@@ -620,19 +619,18 @@ mod tests {
                 _h: &[(String, String)],
                 _b: Option<&[u8]>,
                 _k: Hash,
-            ) -> Result<HttpResponse, String> {
-                Err(retry::retryable("connection refused"))
+            ) -> Result<HttpResponse, EffectOutcome> {
+                Err(EffectOutcome::err_retryable("connection refused"))
             }
         }
         let mut exec = HttpExecutor::new(FlakyHttp);
         match exec.perform(&http_req("get", None), Hash::of(b"k")).await {
-            EffectOutcome::Err(msg) => {
-                assert!(msg.contains("connection refused"), "{msg}");
-                assert_eq!(
-                    retry::classify(&msg),
-                    retry::Retryability::Retryable,
-                    "{msg}"
-                );
+            EffectOutcome::Err {
+                message,
+                retryability,
+            } => {
+                assert!(message.contains("connection refused"), "{message}");
+                assert_eq!(retryability, Retryability::Retryable, "{message}");
             }
             other => panic!("expected the transport error to fold as Err, got {other:?}"),
         }
@@ -650,7 +648,7 @@ mod tests {
                 _h: &[(String, String)],
                 _b: Option<&[u8]>,
                 _k: Hash,
-            ) -> Result<HttpResponse, String> {
+            ) -> Result<HttpResponse, EffectOutcome> {
                 panic!("transport must not be called for a non-http-family effect");
             }
         }
@@ -662,16 +660,15 @@ mod tests {
             Timeliness::Interactive,
         );
         match exec.perform(&req, Hash::of(b"k")).await {
-            EffectOutcome::Err(msg) => {
+            EffectOutcome::Err {
+                message,
+                retryability,
+            } => {
                 assert!(
-                    msg.contains(effect_ct::HTTP) && msg.contains(effect_ct::MODEL),
-                    "err names the handled (http) + rejected (model) families: {msg}"
+                    message.contains(effect_ct::HTTP) && message.contains(effect_ct::MODEL),
+                    "err names the handled (http) + rejected (model) families: {message}"
                 );
-                assert_eq!(
-                    retry::classify(&msg),
-                    retry::Retryability::Permanent,
-                    "{msg}"
-                );
+                assert_eq!(retryability, Retryability::Permanent, "{message}");
             }
             other => panic!("expected Err for a non-http-family effect, got {other:?}"),
         }

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -48,8 +48,9 @@
 //! authorization of each command is the following slice.
 //!
 //! All executor errors are RECOVERABLE + classified for the kernel's supervision tree (see [`retry`]):
-//! an `EffectOutcome::Err` reason leads with a `RETRYABLE:`/`PERMANENT:` token so a supervisor decides
-//! backoff-retry vs give-up — never a panic, never a silent drop (the operator's error-resilience floor).
+//! an `EffectOutcome::Err` carries a typed [`Retryability`](cdz_kernel::event::Retryability) field so a
+//! supervisor decides backoff-retry vs give-up — never a panic, never a silent drop (the operator's
+//! error-resilience floor).
 //!
 //! The shared surface with `cdz-kernel` is ONLY the trait signatures; this crate never edits kernel src.
 
@@ -124,7 +125,7 @@ pub use metrics::{EffectMetrics, HostMetrics};
 #[cfg(feature = "live-net")]
 pub use model::BedrockModelTransport;
 pub use model::{ModelExecutor, ModelTransport};
-pub use retry::{classify, permanent, retryable, Retryability};
+pub use retry::Retryability;
 #[cfg(feature = "live-aws-storage")]
 pub use s3_blob::S3BlobStore;
 #[cfg(feature = "live-exec")]

--- a/implementation/seed/crates/cdz-agent-host/src/lifecycle.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lifecycle.rs
@@ -128,9 +128,9 @@ impl LifecycleExecutor {
                 Hash::from_bytes(arr)
             }
             _ => {
-                return EffectOutcome::Err(crate::retry::permanent(
+                return EffectOutcome::err(
                     "LifecycleExecutor: lifecycle/spawn requires the child reducer_hash as a 32-byte inline payload",
-                ));
+                );
             }
         };
         // The parent genesis hash = the owner's GENESIS HASH, threaded at wiring time (NOT re-parsed from the
@@ -160,9 +160,9 @@ impl LifecycleExecutor {
             Ok(()) => EffectOutcome::Ok(Some(cdz_kernel::effect::Payload::Inline(
                 child_id.as_str().as_bytes().to_vec().into(),
             ))),
-            Err(_) => EffectOutcome::Err(crate::retry::retryable(
+            Err(_) => EffectOutcome::err_retryable(
                 "LifecycleExecutor: the host loop lifecycle channel is closed — cannot record the spawn op (host shutting down?)",
-            )),
+            ),
         }
     }
 }
@@ -187,24 +187,24 @@ impl Executor for LifecycleExecutor {
             .matches_family(effect_ct::LIFECYCLE_SUSPEND);
         let is_resume = req.content_type.matches_family(effect_ct::LIFECYCLE_RESUME);
         if !(is_terminate || is_suspend || is_resume) {
-            return EffectOutcome::Err(crate::retry::permanent(format!(
+            return EffectOutcome::err(format!(
                 "LifecycleExecutor handles only lifecycle/spawn|terminate|suspend|resume, got {family}"
-            )));
+            ));
         }
         // `target` is the peer session id (raw SessionId string). Empty = structural PERMANENT.
         if req.target.is_empty() {
-            return EffectOutcome::Err(crate::retry::permanent(format!(
+            return EffectOutcome::err(format!(
                 "LifecycleExecutor: {family} requires a non-empty target (the peer session id)"
-            )));
+            ));
         }
         let target = SessionId::new(req.target.clone());
         // A session controlling ITSELF via lifecycle/* is rejected — self-lifecycle is the `close`/own-loop
         // path, not the controller-controls-a-peer path this family is for (and it avoids the loop mutating
         // the very session it's mid-deliver on).
         if target == self.owner {
-            return EffectOutcome::Err(crate::retry::permanent(format!(
+            return EffectOutcome::err(format!(
                 "LifecycleExecutor: a session cannot {family} itself; target == controller"
-            )));
+            ));
         }
         let by = self.owner.clone();
         // RECORD the op for the loop to apply after deliver (defer-to-loop). Ok(None) = accepted + enqueued
@@ -220,9 +220,9 @@ impl Executor for LifecycleExecutor {
                 }
                 None => String::new(),
                 Some(cdz_kernel::effect::Payload::Blob(_)) => {
-                    return EffectOutcome::Err(crate::retry::permanent(
+                    return EffectOutcome::err(
                         "LifecycleExecutor: a blob-ref reason is unsupported — this executor has no blob-store access; inline the reason (or omit it)",
-                    ));
+                    );
                 }
             };
             LifecycleOp::Terminate { target, by, reason }
@@ -233,9 +233,9 @@ impl Executor for LifecycleExecutor {
             // building their op WITHOUT reading req.payload, so a payload, esp. a Blob ref, vanished silently
             // — the exact inconsistency terminate's exhaustive match guards against).
             if req.payload.is_some() {
-                return EffectOutcome::Err(crate::retry::permanent(format!(
+                return EffectOutcome::err(format!(
                     "LifecycleExecutor: {family} takes no payload (it flips a scheduler bit); drop the payload"
-                )));
+                ));
             }
             if is_suspend {
                 LifecycleOp::Suspend { target, by }
@@ -245,9 +245,9 @@ impl Executor for LifecycleExecutor {
         };
         match self.channel.send(op) {
             Ok(()) => EffectOutcome::Ok(None),
-            Err(_) => EffectOutcome::Err(crate::retry::retryable(
+            Err(_) => EffectOutcome::err_retryable(
                 "LifecycleExecutor: the host loop lifecycle channel is closed — cannot record the op (host shutting down?)",
-            )),
+            ),
         }
     }
 
@@ -267,6 +267,7 @@ impl Executor for LifecycleExecutor {
 mod tests {
     use super::*;
     use cdz_kernel::effect::{Payload, Timeliness};
+    use cdz_kernel::event::Retryability;
 
     fn terminate_req(target: &str, reason: Option<&[u8]>) -> EffectRequest {
         EffectRequest::new_with_family(
@@ -346,7 +347,7 @@ mod tests {
         );
         assert!(
             matches!(&exec.perform(&req, Hash::of(b"k")).await,
-                EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("reducer_hash")),
+                EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("reducer_hash")),
             "spawn with no reducer_hash payload is PERMANENT"
         );
     }
@@ -505,7 +506,7 @@ mod tests {
             );
             assert!(
                 matches!(&exec.perform(&inline, Hash::of(b"k")).await,
-                    EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("takes no payload")),
+                    EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("takes no payload")),
                 "{family} with an inline payload is PERMANENT"
             );
             // Blob-ref payload → PERMANENT (the specific silent-drop the finding called out).
@@ -517,7 +518,7 @@ mod tests {
             );
             assert!(
                 matches!(&exec.perform(&blob, Hash::of(b"k")).await,
-                    EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("takes no payload")),
+                    EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("takes no payload")),
                 "{family} with a blob-ref payload is PERMANENT (no silent drop)"
             );
         }
@@ -535,7 +536,7 @@ mod tests {
         );
         assert!(
             matches!(&exec.perform(&req, Hash::of(b"k")).await,
-                EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("cannot lifecycle/suspend itself")),
+                EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("cannot lifecycle/suspend itself")),
             "self-suspend is PERMANENT"
         );
     }
@@ -554,7 +555,7 @@ mod tests {
         );
         let out = exec.perform(&req, Hash::of(b"k")).await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("blob-ref reason is unsupported")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("blob-ref reason is unsupported")),
             "a blob-ref reason is rejected PERMANENT, got {out:?}"
         );
     }
@@ -567,7 +568,7 @@ mod tests {
             .perform(&terminate_req("me", None), Hash::of(b"k"))
             .await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("cannot lifecycle/terminate itself")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("cannot lifecycle/terminate itself")),
             "self-terminate is PERMANENT, got {out:?}"
         );
     }
@@ -578,7 +579,7 @@ mod tests {
         let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"), Hash::of(b"ctl"));
         let out = exec.perform(&terminate_req("", None), Hash::of(b"k")).await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("non-empty target")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("non-empty target")),
             "empty target is PERMANENT, got {out:?}"
         );
     }
@@ -592,7 +593,7 @@ mod tests {
             .perform(&terminate_req("b", None), Hash::of(b"k"))
             .await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("RETRYABLE:") && r.contains("channel is closed")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Retryable && message.contains("channel is closed")),
             "a closed lifecycle channel is RETRYABLE, got {out:?}"
         );
     }
@@ -608,7 +609,9 @@ mod tests {
             Timeliness::Interactive,
         );
         let out = exec.perform(&req, Hash::of(b"k")).await;
-        assert!(matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:")));
+        assert!(
+            matches!(&out, EffectOutcome::Err { retryability, .. } if *retryability == Retryability::Permanent)
+        );
         assert!(
             exec.handles_family(effect_ct::LIFECYCLE_TERMINATE)
                 && !exec.handles_family(effect_ct::HTTP)

--- a/implementation/seed/crates/cdz-agent-host/src/metric_exec.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/metric_exec.rs
@@ -103,25 +103,25 @@ impl Executor for MetricExecutor {
         // Family-keyed, matching the router + authz decision. A non-metric/publish family is structural →
         // PERMANENT (§17: observable Err, never a panic).
         if !req.content_type.matches_family(effect_ct::METRIC_PUBLISH) {
-            return EffectOutcome::Err(crate::retry::permanent(format!(
+            return EffectOutcome::err(format!(
                 "MetricExecutor only handles the {} family, got {}",
                 effect_ct::METRIC_PUBLISH,
                 req.content_type.family
-            )));
+            ));
         }
         // The payload IS the encoded MetricSample. A blob-ref / missing payload can't be a metric sample →
         // structural PERMANENT.
         let bytes: &[u8] = match &req.payload {
             Some(Payload::Inline(bytes)) => bytes,
             Some(Payload::Blob(_)) => {
-                return EffectOutcome::Err(crate::retry::permanent(
+                return EffectOutcome::err(
                     "MetricExecutor: a blob-ref metric/publish payload is unsupported — inline the metric sample",
-                ));
+                );
             }
             None => {
-                return EffectOutcome::Err(crate::retry::permanent(
+                return EffectOutcome::err(
                     "MetricExecutor: a metric/publish effect requires a payload (the encoded metric sample)",
-                ));
+                );
             }
         };
         // Decode the kernel-side MetricSample. A malformed frame is a clean PERMANENT (the reducer built a bad
@@ -129,9 +129,9 @@ impl Executor for MetricExecutor {
         let sample = match decode_metric_publish(bytes) {
             Ok(s) => s,
             Err(e) => {
-                return EffectOutcome::Err(crate::retry::permanent(format!(
+                return EffectOutcome::err(format!(
                     "MetricExecutor: metric/publish payload did not decode: {e:?}"
-                )));
+                ));
             }
         };
 
@@ -139,15 +139,15 @@ impl Executor for MetricExecutor {
         // charset + length). Reject the whole publish PERMANENT otherwise — never record or log an unsafe
         // guest string into the telemetry pipeline.
         if !Self::is_safe_str(&sample.name) {
-            return EffectOutcome::Err(crate::retry::permanent(
+            return EffectOutcome::err(
                 "MetricExecutor: metric name is empty/too-long/has unsafe chars (rejected before off-box export)",
-            ));
+            );
         }
         for (k, v) in &sample.labels {
             if !Self::is_safe_str(k) || !Self::is_safe_str(v) {
-                return EffectOutcome::Err(crate::retry::permanent(
+                return EffectOutcome::err(
                     "MetricExecutor: a metric label key/value is empty/too-long/has unsafe chars (rejected before off-box export)",
-                ));
+                );
             }
         }
 
@@ -155,9 +155,9 @@ impl Executor for MetricExecutor {
         // records. This bounds the guest's contribution to registry/backend cardinality.
         if !self.admitted.contains(&sample.name) {
             if self.admitted.len() >= MAX_DISTINCT_NAMES {
-                return EffectOutcome::Err(crate::retry::permanent(format!(
+                return EffectOutcome::err(format!(
                     "MetricExecutor: session exceeded its distinct-metric-name cap ({MAX_DISTINCT_NAMES}) — new metric names rejected (cardinality bound)"
-                )));
+                ));
             }
             self.admitted.insert(sample.name.clone());
         }
@@ -206,9 +206,9 @@ impl Executor for MetricExecutor {
                     .record_f64(sample.value);
             }
             other => {
-                return EffectOutcome::Err(crate::retry::permanent(format!(
+                return EffectOutcome::err(format!(
                     "MetricExecutor: unknown metric kind {other:?} (expected counter/gauge/timing)"
-                )));
+                ));
             }
         }
         // Recorded — fire-and-forget: Ok(None) acks the publish (no result payload for the reducer to fold).
@@ -225,6 +225,7 @@ impl Executor for MetricExecutor {
 mod tests {
     use super::*;
     use cdz_kernel::effect::Timeliness;
+    use cdz_kernel::event::Retryability;
     use cdz_kernel::event_ast::encode_metric_publish;
 
     fn publish_req(sample: &MetricSample) -> EffectRequest {
@@ -304,7 +305,7 @@ mod tests {
             )
             .await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("unknown metric kind")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("unknown metric kind")),
             "an unmapped kind is PERMANENT, got {out:?}"
         );
     }
@@ -321,7 +322,7 @@ mod tests {
             )
             .await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("unsafe chars")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("unsafe chars")),
             "an unsafe metric name is rejected before off-box export, got {out:?}"
         );
         // A control char likewise.
@@ -331,7 +332,9 @@ mod tests {
                 Hash::of(b"k"),
             )
             .await;
-        assert!(matches!(&out, EffectOutcome::Err(r) if r.contains("unsafe chars")));
+        assert!(
+            matches!(&out, EffectOutcome::Err { message, .. } if message.contains("unsafe chars"))
+        );
     }
 
     #[tokio::test]
@@ -356,7 +359,7 @@ mod tests {
             )
             .await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("cardinality")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("cardinality")),
             "a new name beyond the cap is rejected, got {out:?}"
         );
         // But an ALREADY-ADMITTED name still records fine (the cap bounds distinct names, not volume).
@@ -381,7 +384,7 @@ mod tests {
             Timeliness::Interactive,
         );
         assert!(
-            matches!(exec.perform(&wrong, Hash::of(b"k")).await, EffectOutcome::Err(r) if r.contains("only handles"))
+            matches!(exec.perform(&wrong, Hash::of(b"k")).await, EffectOutcome::Err { message, .. } if message.contains("only handles"))
         );
         assert!(
             exec.handles_family(effect_ct::METRIC_PUBLISH) && !exec.handles_family(effect_ct::EMIT)
@@ -394,7 +397,7 @@ mod tests {
             Timeliness::Interactive,
         );
         assert!(
-            matches!(exec.perform(&no_payload, Hash::of(b"k")).await, EffectOutcome::Err(r) if r.contains("requires a payload"))
+            matches!(exec.perform(&no_payload, Hash::of(b"k")).await, EffectOutcome::Err { message, .. } if message.contains("requires a payload"))
         );
         // Undecodable payload.
         let garbage = EffectRequest::new_with_family(
@@ -404,7 +407,7 @@ mod tests {
             Timeliness::Interactive,
         );
         assert!(
-            matches!(exec.perform(&garbage, Hash::of(b"k")).await, EffectOutcome::Err(r) if r.contains("did not decode"))
+            matches!(exec.perform(&garbage, Hash::of(b"k")).await, EffectOutcome::Err { message, .. } if message.contains("did not decode"))
         );
     }
 }

--- a/implementation/seed/crates/cdz-agent-host/src/metrics.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/metrics.rs
@@ -15,7 +15,8 @@
 //!   [`Summary`].
 //! - [`EffectMetrics`] — PER-EFFECT dispatch outcomes captured by the
 //!   [`MeteredExecutor`](crate::factory::MeteredExecutor) decorator: ok / retryable-err / permanent-err /
-//!   timed-out (classified via [`crate::retry::classify`]), + an effect-latency [`Summary`]. `Arc`-shared so
+//!   timed-out (read off the outcome's typed [`Retryability`](crate::retry::Retryability)), + an
+//!   effect-latency [`Summary`]. `Arc`-shared so
 //!   all of a session's per-family decorators tally into one set.
 
 use s2n_quic_dc_metrics::{Counter, Summary, Unit};
@@ -149,8 +150,9 @@ impl EffectMetrics {
         self.effects_ok.increment(1);
     }
 
-    /// Record one FAILED effect dispatch, split by its [`retry`](crate::retry) classification (the metering
-    /// decorator passes the [`classify`](crate::retry::classify)d result; fail-closed unprefixed → Permanent).
+    /// Record one FAILED effect dispatch, split by its typed [`Retryability`](crate::retry::Retryability)
+    /// (the metering decorator reads it straight off `EffectOutcome::Err { retryability, .. }`; the
+    /// fail-closed default an un-annotated error carries is `Permanent`).
     pub(crate) fn record_err(&self, retryability: crate::retry::Retryability) {
         match retryability {
             crate::retry::Retryability::Retryable => self.effects_retryable_err.increment(1),

--- a/implementation/seed/crates/cdz-agent-host/src/model.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/model.rs
@@ -17,7 +17,6 @@
 //! kernel's `idempotency_key` and passes it to the transport, so a real Bedrock transport can dedup a
 //! re-driven dispatch after a crash (or at least be aware the same key means "the same logical call").
 
-use crate::retry;
 use bytes::Bytes;
 use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
@@ -34,11 +33,13 @@ use cdz_kernel::hash::Hash;
 /// deep copy (operator perf directive). A transport holding a `Vec<u8>` freezes it with `.into()` (a
 /// move, no copy).
 ///
-/// **Error classification (supervision, [`crate::retry`]):** an `Err(reason)` MUST lead with a
-/// retryability token so the kernel supervisor can decide backoff-retry vs give-up — a transient failure
-/// (Bedrock 429/5xx/timeout, throttle, connection reset) as [`crate::retry::retryable`], a permanent one
-/// (400/auth/malformed) as [`crate::retry::permanent`]. An unprefixed reason is treated PERMANENT
-/// (fail-closed), so forgetting the prefix means "not retried," never "retried forever."
+/// **Error classification (supervision):** the `Err` half is a classified
+/// [`EffectOutcome`](cdz_kernel::event::EffectOutcome) carrying a typed
+/// [`Retryability`](cdz_kernel::event::Retryability), so the kernel supervisor decides backoff-retry vs
+/// give-up structurally — a transient failure (Bedrock 429/5xx/timeout, throttle, connection reset) via
+/// [`EffectOutcome::err_retryable`](cdz_kernel::event::EffectOutcome::err_retryable), a permanent one
+/// (400/auth/malformed) via [`EffectOutcome::err`](cdz_kernel::event::EffectOutcome::err) (`Permanent` is the
+/// fail-closed default). The executor folds the returned outcome through unchanged.
 /// `#[async_trait(?Send)]` — the invoke is async (a real Bedrock call awaits the socket) and not `Send`
 /// (single-threaded host, no cross-thread futures; §15b), matching the kernel's `Executor`/`Reducer`.
 #[async_trait::async_trait(?Send)]
@@ -51,7 +52,7 @@ pub trait ModelTransport {
         model_id: &str,
         body: &[u8],
         idempotency_key: Hash,
-    ) -> Result<Bytes, String>;
+    ) -> Result<Bytes, EffectOutcome>;
 }
 
 /// Performs `Model` effects by delegating the network call to a [`ModelTransport`]. Single-KIND: a
@@ -76,11 +77,11 @@ impl<T: ModelTransport> Executor for ModelExecutor<T> {
         // enum — the same decision the router and authz make. Decouples this executor from the enum ahead
         // of its retirement; matches_family is the one-source-of-truth family compare.
         if !req.content_type.matches_family(effect_ct::MODEL) {
-            return EffectOutcome::Err(retry::permanent(format!(
+            return EffectOutcome::err(format!(
                 "ModelExecutor only handles the {} family, got {}",
                 effect_ct::MODEL,
                 req.content_type.family
-            )));
+            ));
         }
         // A model call needs a request body. An inline payload IS the request; a blob-ref payload is
         // rejected because this executor has no blob-store handle to resolve it, and a payload-free Model
@@ -88,14 +89,14 @@ impl<T: ModelTransport> Executor for ModelExecutor<T> {
         let body: &[u8] = match &req.payload {
             Some(Payload::Inline(bytes)) => bytes,
             Some(Payload::Blob(_)) => {
-                return EffectOutcome::Err(retry::permanent(
+                return EffectOutcome::err(
                     "ModelExecutor: blob-ref payload unsupported — this executor has no blob-store access; inline the request body",
-                ));
+                );
             }
             None => {
-                return EffectOutcome::Err(retry::permanent(
+                return EffectOutcome::err(
                     "ModelExecutor: a Model effect requires a request payload",
-                ));
+                );
             }
         };
         match self
@@ -104,10 +105,10 @@ impl<T: ModelTransport> Executor for ModelExecutor<T> {
             .await
         {
             // The transport's `Bytes` completion moves straight into `Payload::Inline` (ref-counted
-            // `Bytes`) — no copy. The transport's Err reason already carries its own retryability token
-            // (RETRYABLE:/PERMANENT:, per the trait contract), so pass it through unchanged.
+            // `Bytes`) — no copy. The transport's Err is already a classified `EffectOutcome::Err` carrying
+            // its typed retryability (per the trait contract), so pass it through unchanged.
             Ok(response) => EffectOutcome::Ok(Some(Payload::Inline(response))),
-            Err(reason) => EffectOutcome::Err(reason),
+            Err(outcome) => outcome,
         }
     }
 
@@ -139,8 +140,8 @@ impl<T: ModelTransport> Executor for ModelExecutor<T> {
 /// the standard regional Bedrock endpoint for the resolved model id.
 ///
 /// **Error classification (§17):** a throttle / server / timeout / dispatch failure is
-/// [`retry::retryable`]; a request-construction or other service error is [`retry::permanent`]
-/// (fail-closed — an unprefixed reason is treated permanent, so a misclassification never retries forever).
+/// `err_retryable`; a request-construction or other service error is `err` (Permanent, the fail-closed
+/// default — a misclassification never retries forever).
 // `Clone` is cheap: an `aws_sdk_bedrockruntime::Client` is an `Arc`-backed handle over a shared
 // `SdkConfig` (connection pool + credential cache), so cloning is a refcount bump, NOT a re-resolution of
 // AWS config / IMDS. This lets the daemon build ONE Bedrock client at startup and clone it into a fresh
@@ -182,7 +183,7 @@ impl ModelTransport for BedrockModelTransport {
         model_id: &str,
         body: &[u8],
         _idempotency_key: Hash,
-    ) -> Result<Bytes, String> {
+    ) -> Result<Bytes, EffectOutcome> {
         use aws_sdk_bedrockruntime::primitives::Blob;
 
         // GAP-1 tool-calling (ADDITIVE): if `body` decodes as an M1 `model-request` (the kernel's
@@ -201,7 +202,7 @@ impl ModelTransport for BedrockModelTransport {
             .body(Blob::new(body.to_vec()))
             .send()
             .await
-            .map_err(classify_bedrock_error)?;
+            .map_err(classify_bedrock_error)?; // -> EffectOutcome
 
         // The response body is the model's native completion JSON — folded back verbatim as Bytes.
         Ok(Bytes::from(resp.body.into_inner()))
@@ -220,7 +221,7 @@ impl BedrockModelTransport {
     async fn converse_tool_calling(
         &self,
         req: &cdz_kernel::event_ast::ModelRequest,
-    ) -> Result<Bytes, String> {
+    ) -> Result<Bytes, EffectOutcome> {
         use crate::converse::{
             from_model_request, to_model_response, ConverseResponse, ConverseRole,
         };
@@ -235,7 +236,7 @@ impl BedrockModelTransport {
 
         // Decode + interpret M1 → transport-agnostic ConverseRequest (system-hoist, role-normalize). A
         // malformed request (unknown role) is a PERMANENT structural error the reducer built.
-        let cr = from_model_request(req).map_err(|e| retry::permanent(e.to_string()))?;
+        let cr = from_model_request(req).map_err(|e| EffectOutcome::err(e.to_string()))?;
 
         // ── Build the Converse call ──────────────────────────────────────────────────────────────────
         let mut call = self.client.converse().model_id(&cr.model_id);
@@ -256,25 +257,28 @@ impl BedrockModelTransport {
                 let bd = match block {
                     KContentBlock::Text(t) => BdContentBlock::Text(t.clone()),
                     KContentBlock::ToolCall { id, name, input } => {
-                        let input_doc = json_bytes_to_document(input).map_err(retry::permanent)?;
+                        let input_doc =
+                            json_bytes_to_document(input).map_err(EffectOutcome::err)?;
                         BdContentBlock::ToolUse(
                             ToolUseBlock::builder()
                                 .tool_use_id(id)
                                 .name(name)
                                 .input(input_doc)
                                 .build()
-                                .map_err(|e| retry::permanent(format!("tool-use block: {e}")))?,
+                                .map_err(|e| EffectOutcome::err(format!("tool-use block: {e}")))?,
                         )
                     }
                     KContentBlock::ToolResult { id, result } => {
                         let result_doc =
-                            json_bytes_to_document(result).map_err(retry::permanent)?;
+                            json_bytes_to_document(result).map_err(EffectOutcome::err)?;
                         BdContentBlock::ToolResult(
                             ToolResultBlock::builder()
                                 .tool_use_id(id)
                                 .content(ToolResultContentBlock::Json(result_doc))
                                 .build()
-                                .map_err(|e| retry::permanent(format!("tool-result block: {e}")))?,
+                                .map_err(|e| {
+                                    EffectOutcome::err(format!("tool-result block: {e}"))
+                                })?,
                         )
                     }
                 };
@@ -282,7 +286,7 @@ impl BedrockModelTransport {
             }
             let msg = msg
                 .build()
-                .map_err(|e| retry::permanent(format!("message: {e}")))?;
+                .map_err(|e| EffectOutcome::err(format!("message: {e}")))?;
             call = call.messages(msg);
         }
 
@@ -290,17 +294,17 @@ impl BedrockModelTransport {
         if !cr.tools.is_empty() {
             let mut tc = ToolConfiguration::builder();
             for t in &cr.tools {
-                let schema_doc = json_bytes_to_document(&t.schema).map_err(retry::permanent)?;
+                let schema_doc = json_bytes_to_document(&t.schema).map_err(EffectOutcome::err)?;
                 let spec = ToolSpecification::builder()
                     .name(&t.name)
                     .input_schema(ToolInputSchema::Json(schema_doc))
                     .build()
-                    .map_err(|e| retry::permanent(format!("tool spec: {e}")))?;
+                    .map_err(|e| EffectOutcome::err(format!("tool spec: {e}")))?;
                 tc = tc.tools(Tool::ToolSpec(spec));
             }
             let tc = tc
                 .build()
-                .map_err(|e| retry::permanent(format!("tool config: {e}")))?;
+                .map_err(|e| EffectOutcome::err(format!("tool config: {e}")))?;
             call = call.tool_config(tc);
         }
 
@@ -364,7 +368,7 @@ fn classify_bedrock_error(
     e: aws_sdk_bedrockruntime::error::SdkError<
         aws_sdk_bedrockruntime::operation::invoke_model::InvokeModelError,
     >,
-) -> String {
+) -> EffectOutcome {
     use aws_sdk_bedrockruntime::error::SdkError;
     // Transport-level failures that never reached, or didn't cleanly complete at, the service → transient:
     // a timeout, a dispatch (connect/IO) failure, or a ResponseError (a reply arrived but was unparseable /
@@ -375,19 +379,19 @@ fn classify_bedrock_error(
         SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) | SdkError::ResponseError(_)
     );
     if transient_transport {
-        return retry::retryable(format!("Bedrock transport failure: {e}"));
+        return EffectOutcome::err_retryable(format!("Bedrock transport failure: {e}"));
     }
     // A completed service error: throttling / 5xx are transient; other 4xx are permanent.
     if let SdkError::ServiceError(ref svc) = e {
         let err = svc.err();
         if err.is_throttling_exception() || err.is_model_timeout_exception() {
-            return retry::retryable(format!("Bedrock throttled/timed out: {e}"));
+            return EffectOutcome::err_retryable(format!("Bedrock throttled/timed out: {e}"));
         }
         if err.is_internal_server_exception() || err.is_service_unavailable_exception() {
-            return retry::retryable(format!("Bedrock server error: {e}"));
+            return EffectOutcome::err_retryable(format!("Bedrock server error: {e}"));
         }
     }
-    retry::permanent(format!("Bedrock invoke failed: {e}"))
+    EffectOutcome::err(format!("Bedrock invoke failed: {e}"))
 }
 
 /// Classify a Bedrock `Converse` error (§17), same policy as [`classify_bedrock_error`] but over the Converse
@@ -399,31 +403,34 @@ fn classify_converse_error(
     e: aws_sdk_bedrockruntime::error::SdkError<
         aws_sdk_bedrockruntime::operation::converse::ConverseError,
     >,
-) -> String {
+) -> EffectOutcome {
     use aws_sdk_bedrockruntime::error::SdkError;
     let transient_transport = matches!(
         e,
         SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) | SdkError::ResponseError(_)
     );
     if transient_transport {
-        return retry::retryable(format!("Bedrock Converse transport failure: {e}"));
+        return EffectOutcome::err_retryable(format!("Bedrock Converse transport failure: {e}"));
     }
     if let SdkError::ServiceError(ref svc) = e {
         let err = svc.err();
         if err.is_throttling_exception() || err.is_model_timeout_exception() {
-            return retry::retryable(format!("Bedrock Converse throttled/timed out: {e}"));
+            return EffectOutcome::err_retryable(format!(
+                "Bedrock Converse throttled/timed out: {e}"
+            ));
         }
         if err.is_internal_server_exception() || err.is_service_unavailable_exception() {
-            return retry::retryable(format!("Bedrock Converse server error: {e}"));
+            return EffectOutcome::err_retryable(format!("Bedrock Converse server error: {e}"));
         }
     }
-    retry::permanent(format!("Bedrock Converse failed: {e}"))
+    EffectOutcome::err(format!("Bedrock Converse failed: {e}"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use cdz_kernel::effect::Timeliness;
+    use cdz_kernel::event::Retryability;
 
     /// A transport that echoes a canned completion, recording what it was asked to invoke so a test can
     /// assert the executor extracted the model id + body correctly.
@@ -432,7 +439,12 @@ mod tests {
     }
     #[async_trait::async_trait(?Send)]
     impl ModelTransport for StubTransport {
-        async fn invoke(&self, model_id: &str, body: &[u8], _key: Hash) -> Result<Bytes, String> {
+        async fn invoke(
+            &self,
+            model_id: &str,
+            body: &[u8],
+            _key: Hash,
+        ) -> Result<Bytes, EffectOutcome> {
             // Prove the executor passed the model id (target) + the request body (payload) through.
             assert_eq!(model_id, "test-model");
             assert_eq!(body, b"prompt");
@@ -474,14 +486,13 @@ mod tests {
             response: Bytes::new(),
         });
         match exec.perform(&model_req(None), Hash::of(b"k")).await {
-            EffectOutcome::Err(msg) => {
-                assert!(msg.contains("requires a request payload"), "{msg}");
+            EffectOutcome::Err {
+                message,
+                retryability,
+            } => {
+                assert!(message.contains("requires a request payload"), "{message}");
                 // A structural request error is PERMANENT — a supervisor must not retry it.
-                assert_eq!(
-                    retry::classify(&msg),
-                    retry::Retryability::Permanent,
-                    "{msg}"
-                );
+                assert_eq!(retryability, Retryability::Permanent, "{message}");
             }
             other => panic!("expected Err for a payload-free Model effect, got {other:?}"),
         }
@@ -499,14 +510,13 @@ mod tests {
             )
             .await
         {
-            EffectOutcome::Err(msg) => {
+            EffectOutcome::Err {
+                message,
+                retryability,
+            } => {
                 // Rejected because this executor has no blob-store access (an invariant, not a "yet").
-                assert!(msg.contains("no blob-store access"), "{msg}");
-                assert_eq!(
-                    retry::classify(&msg),
-                    retry::Retryability::Permanent,
-                    "{msg}"
-                );
+                assert!(message.contains("no blob-store access"), "{message}");
+                assert_eq!(retryability, Retryability::Permanent, "{message}");
             }
             other => panic!("expected Err for a blob-ref payload, got {other:?}"),
         }
@@ -519,8 +529,8 @@ mod tests {
         struct ThrottledTransport;
         #[async_trait::async_trait(?Send)]
         impl ModelTransport for ThrottledTransport {
-            async fn invoke(&self, _m: &str, _b: &[u8], _k: Hash) -> Result<Bytes, String> {
-                Err(retry::retryable("bedrock throttled (429)"))
+            async fn invoke(&self, _m: &str, _b: &[u8], _k: Hash) -> Result<Bytes, EffectOutcome> {
+                Err(EffectOutcome::err_retryable("bedrock throttled (429)"))
             }
         }
         let mut exec = ModelExecutor::new(ThrottledTransport);
@@ -531,13 +541,12 @@ mod tests {
             )
             .await
         {
-            EffectOutcome::Err(msg) => {
-                assert!(msg.contains("throttled"), "{msg}");
-                assert_eq!(
-                    retry::classify(&msg),
-                    retry::Retryability::Retryable,
-                    "{msg}"
-                );
+            EffectOutcome::Err {
+                message,
+                retryability,
+            } => {
+                assert!(message.contains("throttled"), "{message}");
+                assert_eq!(retryability, Retryability::Retryable, "{message}");
             }
             other => panic!("expected the transport error to fold as Err, got {other:?}"),
         }
@@ -548,7 +557,7 @@ mod tests {
         struct NeverCalled;
         #[async_trait::async_trait(?Send)]
         impl ModelTransport for NeverCalled {
-            async fn invoke(&self, _m: &str, _b: &[u8], _k: Hash) -> Result<Bytes, String> {
+            async fn invoke(&self, _m: &str, _b: &[u8], _k: Hash) -> Result<Bytes, EffectOutcome> {
                 panic!("transport must not be called for a non-model-family effect");
             }
         }
@@ -562,16 +571,15 @@ mod tests {
             Timeliness::Interactive,
         );
         match exec.perform(&req, Hash::of(b"k")).await {
-            EffectOutcome::Err(msg) => {
+            EffectOutcome::Err {
+                message,
+                retryability,
+            } => {
                 assert!(
-                    msg.contains(effect_ct::MODEL) && msg.contains(effect_ct::HTTP),
-                    "err names the handled family (model) + the rejected one (http): {msg}"
+                    message.contains(effect_ct::MODEL) && message.contains(effect_ct::HTTP),
+                    "err names the handled family (model) + the rejected one (http): {message}"
                 );
-                assert_eq!(
-                    retry::classify(&msg),
-                    retry::Retryability::Permanent,
-                    "{msg}"
-                );
+                assert_eq!(retryability, Retryability::Permanent, "{message}");
             }
             other => panic!("expected Err for a non-model-family effect, got {other:?}"),
         }

--- a/implementation/seed/crates/cdz-agent-host/src/retry.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/retry.rs
@@ -1,96 +1,18 @@
-//! Retryability classification for executor errors — the near-term convention (ruling (1), 2026-08-02)
-//! the kernel supervisor branches on until a first-class `EffectOutcome::Err` retryable field lands.
+//! Retryability classification for executor errors.
 //!
-//! The operator's supervision-tree direction: an executor error must be a structured, RECOVERABLE
-//! outcome the supervisor can act on — retry a transient failure (with backoff), give up on a permanent
-//! one. Until `EffectOutcome::Err` carries a typed retryable flag (a kernel shared-surface change
-//! v-agent-harness folds into the supervisor slice), we encode retryability in the `Err(reason)` STRING
-//! with a leading token, agreed with v-agent-harness:
+//! Retryability is now a FIRST-CLASS typed field on [`cdz_kernel::event::EffectOutcome::Err`] (operator Q2),
+//! so a reducer's fold matches STRUCTURALLY on the retryability rather than parsing a `RETRYABLE:`/
+//! `PERMANENT:` token out of the message string (the old host convention this replaces). The host only
+//! CLASSIFIES an error (a Bedrock throttle → [`Retryability::Retryable`], a malformed request →
+//! [`Retryability::Permanent`]); the RETRY POLICY (backoff + re-emit) lives in the reducer.
 //!
-//! - [`RETRYABLE`]` : <detail>` — a transient failure worth a backoff-retry (Bedrock 429/5xx/timeout,
-//!   connection reset, throttle). The supervisor re-emits the effect (same `idempotency_key`, so a paid
-//!   invoke dedups — §16c-S1/D).
-//! - [`PERMANENT`]` : <detail>` — do NOT retry (a 400/auth/malformed request, an unroutable kind, a bad
-//!   payload). Retrying can't help; the supervisor escalates or fails the branch.
-//!
-//! **Fail-closed default:** a supervisor treats an UNPREFIXED reason as PERMANENT — never auto-retry an
-//! unclassified error (safer than retrying a truly-permanent one forever). So a transport that forgets
-//! the prefix degrades to "not retried," not "retried forever."
-//!
-//! The reason STARTS with exactly one token then `": "`, so a supervisor matches with
-//! `reason.starts_with("RETRYABLE:")` — cheap and unambiguous (no fragile substring-in-the-middle match).
-//! [`classify`] reads a reason back into a [`Retryability`] for callers/tests.
+//! Construct a permanent failure via [`cdz_kernel::event::EffectOutcome::err`] and a retryable one via
+//! [`cdz_kernel::event::EffectOutcome::err_retryable`]. The classifiers in [`crate::model`] /
+//! [`crate::http`] return an [`EffectOutcome`](cdz_kernel::event::EffectOutcome) already carrying the typed
+//! retryability. [`Retryability::Permanent`] is the fail-closed default (never auto-retry an unclassified
+//! error forever).
 
-/// The leading token marking a transient, retry-worthy failure.
-pub const RETRYABLE: &str = "RETRYABLE";
-/// The leading token marking a permanent, do-not-retry failure.
-pub const PERMANENT: &str = "PERMANENT";
-
-/// How a supervisor should treat an executor error. Read from a reason string by [`classify`].
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum Retryability {
-    /// Transient — a backoff-retry may succeed.
-    Retryable,
-    /// Permanent — retrying cannot help; escalate/fail.
-    Permanent,
-}
-
-/// Build a `RETRYABLE: <detail>` reason for a transient failure.
-pub fn retryable(detail: impl AsRef<str>) -> String {
-    format!("{RETRYABLE}: {}", detail.as_ref())
-}
-
-/// Build a `PERMANENT: <detail>` reason for a non-retryable failure.
-pub fn permanent(detail: impl AsRef<str>) -> String {
-    format!("{PERMANENT}: {}", detail.as_ref())
-}
-
-/// Classify a reason string. A leading `RETRYABLE:` → [`Retryability::Retryable`]; anything else
-/// (including an unprefixed reason) → [`Retryability::Permanent`] — the fail-closed default a supervisor
-/// uses so an unclassified error is never auto-retried forever.
-pub fn classify(reason: &str) -> Retryability {
-    if reason.starts_with(&format!("{RETRYABLE}:")) {
-        Retryability::Retryable
-    } else {
-        Retryability::Permanent
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn builders_produce_the_agreed_prefixes() {
-        assert_eq!(
-            retryable("bedrock throttled (429)"),
-            "RETRYABLE: bedrock throttled (429)"
-        );
-        assert_eq!(
-            permanent("bad request (400)"),
-            "PERMANENT: bad request (400)"
-        );
-    }
-
-    #[test]
-    fn classify_reads_the_prefix() {
-        assert_eq!(classify(&retryable("timeout")), Retryability::Retryable);
-        assert_eq!(classify(&permanent("400")), Retryability::Permanent);
-    }
-
-    #[test]
-    fn unprefixed_reason_is_permanent_fail_closed() {
-        // The safety default: an unclassified error is treated as permanent, so a forgotten prefix means
-        // "not retried" rather than "retried forever."
-        assert_eq!(
-            classify("some raw error with no token"),
-            Retryability::Permanent
-        );
-        // A token that isn't exactly the RETRYABLE prefix must not be mistaken for retryable.
-        assert_eq!(classify("RETRYABLE_ISH: nope"), Retryability::Permanent);
-        assert_eq!(
-            classify("this mentions RETRYABLE: in the middle"),
-            Retryability::Permanent
-        );
-    }
-}
+/// Re-export the kernel's typed retryability — the single source of truth. The old crate-local enum + the
+/// `RETRYABLE:`/`PERMANENT:` string-token convention (consts, `retryable()`/`permanent()`/`classify()`) are
+/// gone: retryability now rides structurally on `EffectOutcome::Err { retryability, .. }`.
+pub use cdz_kernel::event::Retryability;

--- a/implementation/seed/crates/cdz-agent-host/src/shell.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/shell.rs
@@ -26,7 +26,6 @@
 //! dedup handle a re-driven dispatch (post-crash) can key on. v0 runs the command each perform (documented);
 //! a dedup cache is a later refinement.
 
-use crate::retry;
 use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::executor::Executor;
@@ -58,18 +57,18 @@ impl Executor for ShellExecutor {
         // Family guard (seq-39 family-string source of truth, same as Clock/Http/Model). A wrong family is
         // structural → PERMANENT (§17: an observable Err, never a panic; a supervisor must not retry it).
         if !req.content_type.matches_family(effect_ct::SHELL) {
-            return EffectOutcome::Err(retry::permanent(format!(
+            return EffectOutcome::err(format!(
                 "ShellExecutor only handles the {} family, got {}",
                 effect_ct::SHELL,
                 req.content_type.family
-            )));
+            ));
         }
         // Split the target into program + args on whitespace and exec DIRECTLY — no shell, so metacharacters
         // are literal args, not interpreted (CWE-78 / kernel PR#992 parity). This is the irreducible spawn
         // mechanism; the command itself was already authorized by the Cedar policy (SEC-F1) before dispatch.
         let mut parts = req.target.split_whitespace();
         let Some(program) = parts.next() else {
-            return EffectOutcome::Err(retry::permanent("empty command"));
+            return EffectOutcome::err("empty command");
         };
         let args: Vec<&str> = parts.collect();
         match std::process::Command::new(program).args(&args).output() {
@@ -79,14 +78,14 @@ impl Executor for ShellExecutor {
             // A non-zero exit is a REAL command outcome the reducer folds (a failed build/test), not a
             // transient host fault → PERMANENT (retrying the identical command re-fails the same way; the
             // reducer decides what to do with the failure). Carries the exit code + stderr for the fold.
-            Ok(out) => EffectOutcome::Err(retry::permanent(format!(
+            Ok(out) => EffectOutcome::err(format!(
                 "exit {}: {}",
                 out.status.code().unwrap_or(-1),
                 String::from_utf8_lossy(&out.stderr).trim()
-            ))),
+            )),
             // A spawn failure (program missing on PATH, fork error) is a host/environment fault → PERMANENT
             // (a missing program won't appear on a retry); the message carries the OS error.
-            Err(e) => EffectOutcome::Err(retry::permanent(format!("spawn failed: {e}"))),
+            Err(e) => EffectOutcome::err(format!("spawn failed: {e}")),
         }
     }
 
@@ -101,6 +100,7 @@ impl Executor for ShellExecutor {
 mod tests {
     use super::*;
     use cdz_kernel::effect::{EffectKind, Timeliness};
+    use cdz_kernel::event::Retryability;
 
     fn shell_req(target: &str) -> EffectRequest {
         EffectRequest::new(
@@ -154,7 +154,7 @@ mod tests {
         let mut exec = ShellExecutor::new();
         let out = exec.perform(&shell_req("false"), Hash::of(b"k")).await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("exit ")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("exit ")),
             "a non-zero exit is a PERMANENT command-failure, got {out:?}"
         );
     }
@@ -169,7 +169,7 @@ mod tests {
             )
             .await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("spawn failed")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("spawn failed")),
             "a missing program is a PERMANENT spawn failure, got {out:?}"
         );
     }
@@ -185,7 +185,7 @@ mod tests {
         );
         let out = exec.perform(&req, Hash::of(b"k")).await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.starts_with("PERMANENT:") && r.contains("only handles")),
+            matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("only handles")),
             "a non-Shell family is rejected PERMANENT, got {out:?}"
         );
         assert!(exec.handles_family(effect_ct::SHELL) && !exec.handles_family(effect_ct::HTTP));
@@ -196,7 +196,7 @@ mod tests {
         let mut exec = ShellExecutor::new();
         let out = exec.perform(&shell_req("   "), Hash::of(b"k")).await;
         assert!(
-            matches!(&out, EffectOutcome::Err(r) if r.contains("empty command")),
+            matches!(&out, EffectOutcome::Err { message, .. } if message.contains("empty command")),
             "an empty/whitespace target is PERMANENT, got {out:?}"
         );
     }

--- a/implementation/seed/crates/cdz-agent-host/tests/agent_tool_call_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/agent_tool_call_e2e.rs
@@ -51,7 +51,7 @@ impl ModelTransport for ScriptedConverse {
         _model_id: &str,
         _body: &[u8],
         _key: Hash,
-    ) -> Result<bytes::Bytes, String> {
+    ) -> Result<bytes::Bytes, EffectOutcome> {
         let n = self.calls.get();
         self.calls.set(n + 1);
         let resp = if n == 0 {

--- a/implementation/seed/crates/cdz-agent-host/tests/capability_manifest_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/capability_manifest_e2e.rs
@@ -45,7 +45,7 @@ impl HttpTransport for UnusedHttp {
         _headers: &[(String, String)],
         _body: Option<&[u8]>,
         _key: Hash,
-    ) -> Result<HttpResponse, String> {
+    ) -> Result<HttpResponse, cdz_kernel::event::EffectOutcome> {
         unreachable!("manifest projection probes policy; it never performs an effect")
     }
 }
@@ -53,7 +53,12 @@ impl HttpTransport for UnusedHttp {
 struct UnusedModel;
 #[async_trait::async_trait(?Send)]
 impl ModelTransport for UnusedModel {
-    async fn invoke(&self, _model_id: &str, _body: &[u8], _key: Hash) -> Result<Bytes, String> {
+    async fn invoke(
+        &self,
+        _model_id: &str,
+        _body: &[u8],
+        _key: Hash,
+    ) -> Result<Bytes, cdz_kernel::event::EffectOutcome> {
         unreachable!("manifest projection probes policy; it never performs an effect")
     }
 }

--- a/implementation/seed/crates/cdz-agent-host/tests/cedar_authz_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/cedar_authz_e2e.rs
@@ -35,7 +35,7 @@ impl ModelTransport for StubModel {
         _model_id: &str,
         _body: &[u8],
         _key: Hash,
-    ) -> Result<bytes::Bytes, String> {
+    ) -> Result<bytes::Bytes, EffectOutcome> {
         Ok(bytes::Bytes::from_static(b"a completion"))
     }
 }

--- a/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/http_agent_e2e.rs
@@ -30,7 +30,7 @@ impl HttpTransport for StubHttp {
         _headers: &[(String, String)],
         _body: Option<&[u8]>,
         _key: Hash,
-    ) -> Result<HttpResponse, String> {
+    ) -> Result<HttpResponse, EffectOutcome> {
         assert_eq!(method, HttpMethod::Get, "the reducer emitted a GET");
         Ok(HttpResponse {
             status: 200,
@@ -140,7 +140,7 @@ async fn a_fetch_to_an_unpermitted_host_is_denied_before_the_client() {
             _h: &[(String, String)],
             _b: Option<&[u8]>,
             _k: Hash,
-        ) -> Result<HttpResponse, String> {
+        ) -> Result<HttpResponse, EffectOutcome> {
             panic!("a denied Http effect must never reach the client");
         }
     }

--- a/implementation/seed/crates/cdz-agent-host/tests/live_transport_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/live_transport_e2e.rs
@@ -150,7 +150,7 @@ async fn a_real_bedrock_invoke_returns_a_completion() {
             );
         }
         Err(reason) => panic!(
-            "live Bedrock invoke failed (creds/region/model-id/schema?): {reason}\n\
+            "live Bedrock invoke failed (creds/region/model-id/schema?): {reason:?}\n\
              (this test only runs when CDZ_LIVE_BEDROCK_MODEL_ID is set — check the env is complete)"
         ),
     }

--- a/implementation/seed/crates/cdz-agent-host/tests/model_agent_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/model_agent_e2e.rs
@@ -33,7 +33,7 @@ impl ModelTransport for StubModel {
         model_id: &str,
         body: &[u8],
         _key: Hash,
-    ) -> Result<bytes::Bytes, String> {
+    ) -> Result<bytes::Bytes, EffectOutcome> {
         // Echo enough that the test can prove the executor threaded the model id + prompt through.
         Ok(
             format!("{model_id} says: {}", String::from_utf8_lossy(body))
@@ -218,7 +218,12 @@ async fn a_model_call_to_an_unpermitted_id_is_denied_before_the_transport() {
     struct MustNotCall;
     #[async_trait::async_trait(?Send)]
     impl ModelTransport for MustNotCall {
-        async fn invoke(&self, _m: &str, _b: &[u8], _k: Hash) -> Result<bytes::Bytes, String> {
+        async fn invoke(
+            &self,
+            _m: &str,
+            _b: &[u8],
+            _k: Hash,
+        ) -> Result<bytes::Bytes, EffectOutcome> {
             panic!("a denied Model effect must never reach the transport");
         }
     }

--- a/implementation/seed/crates/cdz-agent-host/tests/name_store_e2e.rs
+++ b/implementation/seed/crates/cdz-agent-host/tests/name_store_e2e.rs
@@ -194,7 +194,7 @@ async fn a_store_effect_with_no_name_store_attached_folds_an_error_not_a_panic()
         session.session().log().iter().any(|e| matches!(
             &e.body,
             EventBody::EffectResult {
-                result: EffectOutcome::Err(_),
+                result: EffectOutcome::Err { .. },
                 ..
             }
         )),

--- a/implementation/seed/crates/cdz-kernel/src/event.rs
+++ b/implementation/seed/crates/cdz-kernel/src/event.rs
@@ -276,15 +276,59 @@ pub enum CloseOutcome {
     Failure(String),
 }
 
+/// Whether a failed effect is worth RETRYING — a FIRST-CLASS typed field on [`EffectOutcome::Err`] (operator
+/// Q2), so a reducer's fold matches STRUCTURALLY on the retryability rather than parsing a `RETRYABLE:`/
+/// `PERMANENT:` prefix out of the message string (the old host convention this replaces). RETRY POLICY lives
+/// in the reducer (re-emit + timer backoff = evolvable-on-log), not the host — the kernel/host only CLASSIFY
+/// (e.g. a Bedrock throttle → `Retryable`, a malformed request → `Permanent`); the standing-order split.
+/// An enum (not a bool) for additive room (a future `Unknown`/`RetryAfter` arm appends without a wire break).
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum Retryability {
+    /// The failure is permanent — retrying can't help (malformed input, an auth denial, a logic error). The
+    /// SAFE DEFAULT: an un-annotated / legacy error is `Permanent` (fail-closed — never auto-retry blindly).
+    #[default]
+    Permanent,
+    /// The failure is transient — a retry (the reducer's policy: backoff + re-emit) may succeed (a throttle,
+    /// a timeout, a 5xx). The host CLASSIFIES the error as this; the reducer DECIDES whether/how to retry.
+    Retryable,
+}
+
 /// The outcome of an executed effect: success payload, a failure, or a timeout (the §9d anti-stuck
 /// path — a hung effect becomes a normal event, not a wedge).
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum EffectOutcome {
     Ok(Option<Payload>),
-    Err(String),
+    /// A failure: a human/diagnostic `message` + a typed [`Retryability`] (operator Q2 — the reducer folds
+    /// on the retryability, not a string token). Construct a permanent error ergonomically via
+    /// [`EffectOutcome::err`]; a retryable one via [`EffectOutcome::err_retryable`].
+    Err {
+        message: String,
+        retryability: Retryability,
+    },
     /// The effect's deadline elapsed with no result. Per the v0 decision (§16c-S4), a timeout CANCELS
     /// the dispatch — the kernel guarantees no late `Ok`/`Err` for this id will ever be folded.
     TimedOut,
+}
+
+impl EffectOutcome {
+    /// A PERMANENT failure (the common case — a malformed effect, a no-store, an internal error): retrying
+    /// can't help. The ergonomic constructor the ~all kernel-internal error sites use (they were `Err(msg)`
+    /// before Q2 added the typed field; `err(msg)` preserves their intent = `Permanent`).
+    pub fn err(message: impl Into<String>) -> Self {
+        EffectOutcome::Err {
+            message: message.into(),
+            retryability: Retryability::Permanent,
+        }
+    }
+
+    /// A RETRYABLE failure (the host sets this when it classifies a transient error — a throttle/timeout/5xx);
+    /// the reducer's fold decides whether/how to retry (backoff + re-emit).
+    pub fn err_retryable(message: impl Into<String>) -> Self {
+        EffectOutcome::Err {
+            message: message.into(),
+            retryability: Retryability::Retryable,
+        }
+    }
 }
 
 /// An event plus its envelope. The envelope fields are the day-one commitments from the review/§10:
@@ -598,7 +642,23 @@ fn decode_outcome(c: &mut Cursor) -> Result<EffectOutcome, DecodeError> {
                 })
             }
         }),
-        1 => EffectOutcome::Err(c.string()?),
+        1 => {
+            let message = c.string()?;
+            let retryability = match c.u8()? {
+                0 => Retryability::Permanent,
+                1 => Retryability::Retryable,
+                t => {
+                    return Err(DecodeError::BadTag {
+                        field: "retryability",
+                        tag: t,
+                    })
+                }
+            };
+            EffectOutcome::Err {
+                message,
+                retryability,
+            }
+        }
         2 => EffectOutcome::TimedOut,
         t => {
             return Err(DecodeError::BadTag {
@@ -779,9 +839,18 @@ fn encode_outcome(o: &EffectOutcome, out: &mut Vec<u8>) {
                 None => out.push(0),
             }
         }
-        EffectOutcome::Err(msg) => {
+        EffectOutcome::Err {
+            message,
+            retryability,
+        } => {
             out.push(1);
-            encode_str(msg, out);
+            encode_str(message, out);
+            // Retryability rides as a fixed byte AFTER the message (this bespoke binary codec is NOT the
+            // durable log — that's event_ast; here always-write is safe + keeps decode positional).
+            out.push(match retryability {
+                Retryability::Permanent => 0,
+                Retryability::Retryable => 1,
+            });
         }
         EffectOutcome::TimedOut => out.push(2),
     }
@@ -1107,7 +1176,7 @@ mod tests {
                 cause: None,
                 body: EventBody::EffectResult {
                     id: EffectId(9),
-                    result: EffectOutcome::Err("boom".into()),
+                    result: EffectOutcome::err("boom"),
                     token: None,
                 },
             },

--- a/implementation/seed/crates/cdz-kernel/src/event_ast.rs
+++ b/implementation/seed/crates/cdz-kernel/src/event_ast.rs
@@ -1289,10 +1289,25 @@ fn outcome_form(b: &mut Builder, o: &EffectOutcome) -> StructId {
             let pf = opt_payload_form(b, p);
             b.list(vec![head, pf])
         }
-        EffectOutcome::Err(msg) => {
+        EffectOutcome::Err {
+            message,
+            retryability,
+        } => {
             let head = b.name("err");
-            let m = str_leaf(b, msg);
-            b.list(vec![head, m])
+            let m = str_leaf(b, message);
+            // BACKWARD-COMPATIBLE (operator Q2): a Permanent error encodes as the BARE `(err <str>)` —
+            // BYTE-IDENTICAL to a legacy pre-Q2 Err, so no durable-wire break for the common case. A
+            // Retryable error appends `(retryability retryable)`; read_outcome is arity-tolerant (2 = legacy
+            // Permanent, 3 = read the retryability form). A future arm just adds a retryability token.
+            match retryability {
+                crate::event::Retryability::Permanent => b.list(vec![head, m]),
+                crate::event::Retryability::Retryable => {
+                    let rh = b.name("retryability");
+                    let rv = str_leaf(b, "retryable");
+                    let rf = b.list(vec![rh, rv]);
+                    b.list(vec![head, m, rf])
+                }
+            }
         }
         EffectOutcome::TimedOut => {
             let head = b.name("timed-out");
@@ -1573,6 +1588,25 @@ fn read_kind(a: &Arenas, id: StructId) -> Result<EffectKind, EventAstError> {
     EffectKind::from_family(family).ok_or(shape("unknown effect kind"))
 }
 
+/// Decode a `(retryability <permanent|retryable>)` form → [`crate::event::Retryability`] (operator Q2).
+/// An unknown token is a `Shape` error (fail-closed — don't guess retryable). Total.
+fn read_retryability(
+    a: &Arenas,
+    id: StructId,
+) -> Result<crate::event::Retryability, EventAstError> {
+    let [v] = a
+        .as_form(id, "retryability")
+        .ok_or(shape("retryability form"))?
+    else {
+        return Err(shape("retryability arity"));
+    };
+    match a.as_str(*v) {
+        Some("permanent") => Ok(crate::event::Retryability::Permanent),
+        Some("retryable") => Ok(crate::event::Retryability::Retryable),
+        _ => Err(shape("unknown retryability token")),
+    }
+}
+
 fn read_outcome(a: &Arenas, id: StructId) -> Result<EffectOutcome, EventAstError> {
     match head_of(a, id)? {
         "ok" => {
@@ -1582,10 +1616,23 @@ fn read_outcome(a: &Arenas, id: StructId) -> Result<EffectOutcome, EventAstError
             Ok(EffectOutcome::Ok(read_opt_payload(a, *p)?))
         }
         "err" => {
-            let [m] = form(a, id, "err")? else {
-                return Err(shape("err arity"));
+            // Arity-tolerant (operator Q2): `(err <str>)` = legacy/Permanent (2-form incl the head);
+            // `(err <str> (retryability retryable))` = the typed retryable case. A missing retryability form
+            // ⇒ Permanent (the safe default — an un-annotated error must not auto-retry, fail-closed).
+            let kids = form(a, id, "err")?;
+            let (m, retryability) = match kids {
+                [m] => (m, crate::event::Retryability::Permanent),
+                [m, rf] => (m, read_retryability(a, *rf)?),
+                _ => {
+                    return Err(shape(
+                        "err arity (want (err <str>) or (err <str> <retryability>))",
+                    ))
+                }
             };
-            Ok(EffectOutcome::Err(read_str(a, *m)?))
+            Ok(EffectOutcome::Err {
+                message: read_str(a, *m)?,
+                retryability,
+            })
         }
         "timed-out" => Ok(EffectOutcome::TimedOut),
         _ => Err(shape("unknown outcome tag")),
@@ -1909,7 +1956,7 @@ mod tests {
                 cause: None,
                 body: EventBody::EffectResult {
                     id: EffectId(9),
-                    result: EffectOutcome::Err("boom".into()),
+                    result: EffectOutcome::err("boom"),
                     token: None,
                 },
             },
@@ -2711,6 +2758,83 @@ mod tests {
             },
             "a #1938-window (closed (success …)) decodes as Success (all 3 shapes accepted)"
         );
+    }
+
+    #[test]
+    fn effect_result_err_round_trips_retryability_and_is_legacy_backward_compatible() {
+        // operator Q2: a typed EffectOutcome::Err retryability survives the durable shared codec both arms,
+        // AND a legacy `(err <str>)` (pre-Q2, no retryability form) decodes as Permanent (fail-closed default).
+        use crate::effect::EffectId;
+        use crate::event::Retryability;
+        let permanent = Event {
+            seq: 1,
+            cause: None,
+            body: EventBody::EffectResult {
+                id: EffectId(7),
+                result: EffectOutcome::err("malformed request"),
+                token: None,
+            },
+        };
+        let retryable = Event {
+            seq: 2,
+            cause: None,
+            body: EventBody::EffectResult {
+                id: EffectId(8),
+                result: EffectOutcome::err_retryable("bedrock throttled"),
+                token: None,
+            },
+        };
+        assert_eq!(decode(&encode(&permanent)).unwrap(), permanent);
+        assert_eq!(decode(&encode(&retryable)).unwrap(), retryable);
+        // The two retryabilities are DISTINGUISHABLE after a round-trip (a reducer folds on them structurally).
+        assert_ne!(encode(&permanent), encode(&retryable));
+        // Permanent encodes BYTE-IDENTICALLY to a legacy `(err <str>)` — no durable-wire break (the point of
+        // the additive optional retryability form): build the legacy bare-`(err <str>)` body by hand + prove
+        // it decodes as Err{Permanent}.
+        let legacy_bytes = {
+            let mut b = Builder::new();
+            let head = b.name("event");
+            let seq = u64_leaf(&mut b, 3);
+            let cause = {
+                let n = b.name("none");
+                b.list(vec![n])
+            };
+            let er_head = b.name("effect-result");
+            let idv = u64_leaf(&mut b, 9);
+            let outcome = {
+                let eh = b.name("err");
+                let m = str_leaf(&mut b, "legacy permanent");
+                b.list(vec![eh, m]) // BARE (err <str>) — the pre-Q2 shape
+            };
+            let tok = {
+                let n = b.name("none");
+                b.list(vec![n])
+            };
+            let body = b.list(vec![er_head, idv, outcome, tok]);
+            let root = b.list(vec![head, seq, cause, body]);
+            codec::encode(&b.finish(root))
+        };
+        match decode(&legacy_bytes)
+            .expect("legacy (err <str>) still decodes")
+            .body
+        {
+            EventBody::EffectResult {
+                result:
+                    EffectOutcome::Err {
+                        message,
+                        retryability,
+                    },
+                ..
+            } => {
+                assert_eq!(message, "legacy permanent");
+                assert_eq!(
+                    retryability,
+                    Retryability::Permanent,
+                    "a legacy un-annotated (err <str>) decodes as Permanent (safe default)"
+                );
+            }
+            other => panic!("expected EffectResult Err, got {other:?}"),
+        }
     }
 
     #[test]

--- a/implementation/seed/crates/cdz-kernel/src/executor.rs
+++ b/implementation/seed/crates/cdz-kernel/src/executor.rs
@@ -102,7 +102,7 @@ impl Executor for CompositeExecutor {
         // executor is an OBSERVABLE Err (§9d anti-stuck), never a panic/drop.
         match self.by_family.get_mut(req.content_type.family.as_ref()) {
             Some(inner) => inner.perform(req, idempotency_key).await,
-            None => EffectOutcome::Err(format!(
+            None => EffectOutcome::err(format!(
                 "no executor registered for effect family {:?} (target {:?})",
                 req.content_type.family, req.target
             )),
@@ -184,7 +184,7 @@ impl Executor for ShellExecutor {
     async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash) -> EffectOutcome {
         use crate::effect::EffectKind;
         if req.kind != EffectKind::Shell {
-            return EffectOutcome::Err(format!(
+            return EffectOutcome::err(format!(
                 "ShellExecutor only handles Shell effects, got {:?}",
                 req.kind
             ));
@@ -193,7 +193,7 @@ impl Executor for ShellExecutor {
         // metacharacters are literal arguments, not interpreted (PR#992 CWE-78 fix).
         let mut parts = req.target.split_whitespace();
         let Some(program) = parts.next() else {
-            return EffectOutcome::Err("empty command".to_string());
+            return EffectOutcome::err("empty command".to_string());
         };
         let args: Vec<&str> = parts.collect();
         let output = std::process::Command::new(program).args(&args).output();
@@ -201,12 +201,12 @@ impl Executor for ShellExecutor {
             Ok(out) if out.status.success() => {
                 EffectOutcome::Ok(Some(Payload::Inline(out.stdout.into())))
             }
-            Ok(out) => EffectOutcome::Err(format!(
+            Ok(out) => EffectOutcome::err(format!(
                 "exit {}: {}",
                 out.status.code().unwrap_or(-1),
                 String::from_utf8_lossy(&out.stderr).trim()
             )),
-            Err(e) => EffectOutcome::Err(format!("spawn failed: {e}")),
+            Err(e) => EffectOutcome::err(format!("spawn failed: {e}")),
         }
     }
 }
@@ -281,7 +281,7 @@ mod tests {
             .perform(&req(EffectKind::Model, "gpt"), Hash::of(b"k"))
             .await
         {
-            EffectOutcome::Err(msg) => {
+            EffectOutcome::Err { message: msg, .. } => {
                 // The message names the unroutable FAMILY (seq-39: routing keys on the family string).
                 assert!(
                     msg.contains(EffectKind::Model.family()),
@@ -407,7 +407,7 @@ mod tests {
         let mut ext = req(EffectKind::Http, "x");
         ext.content_type.family = "embedding".into();
         match exec.perform(&ext, Hash::of(b"k")).await {
-            EffectOutcome::Err(msg) => assert!(
+            EffectOutcome::Err { message: msg, .. } => assert!(
                 msg.contains("embedding"),
                 "unroutable extension family named in the err: {msg}"
             ),

--- a/implementation/seed/crates/cdz-kernel/src/kernel.rs
+++ b/implementation/seed/crates/cdz-kernel/src/kernel.rs
@@ -914,7 +914,7 @@ impl Session {
                     // S1 latch: an un-durable dispatch folds an Err, never a phantom answer (same tier-B
                     // rule the routed path applies before executing).
                     let outcome = if self.persist_error.is_some() {
-                        EffectOutcome::Err(
+                        EffectOutcome::err(
                             "dispatch not durably logged (persist failure) — capabilities NOT answered (S1)"
                                 .to_string(),
                         )
@@ -1008,7 +1008,7 @@ impl Session {
                 let outcome = if self.persist_error.is_some() {
                     // S1 latch: an un-durable dispatch never mutates the store (same tier-B rule the routed
                     // path applies before executing) — the set/resolve is NOT applied.
-                    EffectOutcome::Err(
+                    EffectOutcome::err(
                         "dispatch not durably logged (persist failure) — store effect NOT applied (S1)"
                             .to_string(),
                     )
@@ -1102,7 +1102,7 @@ impl Session {
 
             // S1 latch-check BEFORE routing (tier B): an un-durable dispatch is NOT routed.
             if self.persist_error.is_some() {
-                let outcome = EffectOutcome::Err(
+                let outcome = EffectOutcome::err(
                     "dispatch not durably logged (persist failure) — effect NOT routed (S1)"
                         .to_string(),
                 );
@@ -1297,7 +1297,7 @@ impl Session {
                         // resolve-with-payload as MalformedStoreEffect below, so don't apply the set-specific
                         // name-mismatch error to a non-set family.
                         if is_set && payload_name != name {
-                            return EffectOutcome::Err(format!(
+                            return EffectOutcome::err(format!(
                                 "store/set payload name {payload_name:?} != authorized target {name:?} \
                                  — refusing (the target is what authz gated)"
                             ));
@@ -1305,21 +1305,21 @@ impl Session {
                         Some(h)
                     }
                     Err(e) => {
-                        return EffectOutcome::Err(format!(
+                        return EffectOutcome::err(format!(
                             "store effect: malformed name-set payload: {e:?}"
                         ));
                     }
                 }
             }
             Some(crate::effect::Payload::Blob(_)) => {
-                return EffectOutcome::Err(
+                return EffectOutcome::err(
                     "store effect: blob-ref payload unsupported — inline the name-set".to_string(),
                 );
             }
             None => None,
         };
         let Some(store) = self.name_store.as_mut() else {
-            return EffectOutcome::Err(
+            return EffectOutcome::err(
                 "store effect: no name store attached to this session (attach_name_store)"
                     .to_string(),
             );
@@ -1342,11 +1342,11 @@ impl Session {
             Ok(
                 crate::name_store::StoreOutcome::GroupOpApplied
                 | crate::name_store::StoreOutcome::Members(_),
-            ) => EffectOutcome::Err(format!(
+            ) => EffectOutcome::err(format!(
                 "store effect on {name:?}: a group OR-set outcome from the pointer path \
                  (misroute — group verbs use apply_group_effect)"
             )),
-            Err(e) => EffectOutcome::Err(format!("store effect on {name:?}: {e:?}")),
+            Err(e) => EffectOutcome::err(format!("store effect on {name:?}: {e:?}")),
         }
     }
 
@@ -1376,7 +1376,7 @@ impl Session {
                 match crate::event_ast::decode_member_op(bytes) {
                     Ok((payload_name, add, member, tag)) => {
                         if payload_name != name {
-                            return EffectOutcome::Err(format!(
+                            return EffectOutcome::err(format!(
                                 "group store effect payload name {payload_name:?} != authorized target \
                                  {name:?} — refusing (the target is what authz gated)"
                             ));
@@ -1384,14 +1384,14 @@ impl Session {
                         Some(crate::name_store::MemberOp { add, member, tag })
                     }
                     Err(e) => {
-                        return EffectOutcome::Err(format!(
+                        return EffectOutcome::err(format!(
                             "group store effect: malformed member-op payload: {e:?}"
                         ));
                     }
                 }
             }
             Some(crate::effect::Payload::Blob(_)) => {
-                return EffectOutcome::Err(
+                return EffectOutcome::err(
                     "group store effect: blob-ref payload unsupported — inline the member-op"
                         .to_string(),
                 );
@@ -1399,7 +1399,7 @@ impl Session {
             None => None,
         };
         let Some(store) = self.name_store.as_mut() else {
-            return EffectOutcome::Err(
+            return EffectOutcome::err(
                 "group store effect: no name store attached to this session (attach_name_store)"
                     .to_string(),
             );
@@ -1422,10 +1422,10 @@ impl Session {
             Ok(
                 crate::name_store::StoreOutcome::Set(_)
                 | crate::name_store::StoreOutcome::Resolved(_),
-            ) => EffectOutcome::Err(format!(
+            ) => EffectOutcome::err(format!(
                 "group store effect on {name:?}: a single-value outcome from the group path (misroute)"
             )),
-            Err(e) => EffectOutcome::Err(format!("group store effect on {name:?}: {e:?}")),
+            Err(e) => EffectOutcome::err(format!("group store effect on {name:?}: {e:?}")),
         }
     }
 
@@ -1774,7 +1774,7 @@ fn clamp_now_outcome(outcome: EffectOutcome, last_now: &mut u64) -> EffectOutcom
             let raw = u64::from_le_bytes(arr);
             let Some(floor) = last_now.checked_add(1) else {
                 // last_now == u64::MAX: no strictly-greater value exists. Fail loud, don't regress.
-                return EffectOutcome::Err(
+                return EffectOutcome::err(
                     "PERMANENT: monotonic clock exhausted (last_now at u64::MAX ns)".to_string(),
                 );
             };
@@ -2516,7 +2516,7 @@ mod monotonic_now_tests {
             u64::MAX.to_le_bytes().to_vec().into(),
         )));
         match clamp_now_outcome(reading, &mut last) {
-            EffectOutcome::Err(msg) => {
+            EffectOutcome::Err { message: msg, .. } => {
                 assert!(
                     msg.starts_with("PERMANENT:"),
                     "clock-exhausted is a PERMANENT error: {msg}"
@@ -2535,8 +2535,8 @@ mod monotonic_now_tests {
     async fn clamp_now_passes_through_non_now_shapes() {
         let mut last = 42u64;
         // An Err passes through, last unchanged.
-        let e = clamp_now_outcome(EffectOutcome::Err("boom".into()), &mut last);
-        assert!(matches!(e, EffectOutcome::Err(_)));
+        let e = clamp_now_outcome(EffectOutcome::err("boom"), &mut last);
+        assert!(matches!(e, EffectOutcome::Err { .. }));
         assert_eq!(last, 42);
         // A non-8-byte Inline payload (not a u64 ns) passes through untouched.
         let weird = EffectOutcome::Ok(Some(Payload::Inline(b"not-8".to_vec().into())));
@@ -3523,7 +3523,7 @@ mod monotonic_now_tests {
     impl Executor for FailingHttpExecutor {
         async fn perform(&mut self, req: &EffectRequest, _key: Hash) -> EffectOutcome {
             assert_eq!(req.kind, EffectKind::Http);
-            EffectOutcome::Err("PERMANENT: 400 bad request".to_string())
+            EffectOutcome::err("PERMANENT: 400 bad request".to_string())
         }
     }
 
@@ -3544,7 +3544,10 @@ mod monotonic_now_tests {
                     token: None,
                 }]),
                 EventBody::EffectResult {
-                    result: EffectOutcome::Err(reason),
+                    result:
+                        EffectOutcome::Err {
+                            message: reason, ..
+                        },
                     ..
                 } => {
                     kv.put(b"last_err".to_vec(), reason.clone().into_bytes());
@@ -3599,7 +3602,7 @@ mod monotonic_now_tests {
             s.log().iter().any(|e| matches!(
                 &e.body,
                 EventBody::EffectResult {
-                    result: EffectOutcome::Err(_),
+                    result: EffectOutcome::Err { .. },
                     ..
                 }
             )),
@@ -4321,7 +4324,7 @@ mod store_effect_tests {
                     b"test result: 277 passed".to_vec().into(),
                 )))
             } else {
-                EffectOutcome::Err(format!("unexpected effect family {family:?}"))
+                EffectOutcome::err(format!("unexpected effect family {family:?}"))
             }
         }
     }

--- a/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
+++ b/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
@@ -3582,7 +3582,7 @@ fn effect_outcome_bytes(o: &EffectOutcome) -> Option<Vec<u8>> {
     match o {
         EffectOutcome::Ok(Some(p)) => Some(payload_bytes(p)),
         EffectOutcome::Ok(None) => None,
-        EffectOutcome::Err(msg) => Some(msg.clone().into_bytes()),
+        EffectOutcome::Err { message: msg, .. } => Some(msg.clone().into_bytes()),
         EffectOutcome::TimedOut => None,
     }
 }

--- a/implementation/seed/crates/cdz-kernel/tests/loop_and_recovery.rs
+++ b/implementation/seed/crates/cdz-kernel/tests/loop_and_recovery.rs
@@ -756,7 +756,7 @@ async fn s1_route_guard_does_not_perform_an_effect_whose_dispatch_failed_to_pers
     assert_eq!(session.open_effects(), 0);
     assert!(session.log().iter().any(|e| matches!(
         &e.body,
-        EventBody::EffectResult { result: EffectOutcome::Err(msg), .. } if msg.contains("not durably logged")
+        EventBody::EffectResult { result: EffectOutcome::Err { message: msg, .. }, .. } if msg.contains("not durably logged")
     )));
 }
 


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 108017876acfc12277d5736b6ff01803668168a1, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.