### PR TITLE
chore(emoji-ban): strip decorative emojis from compiler-source comments (operator directive; comment-only, zero behavior)

### DIFF
--- a/implementation/seed/crates/cadenza-syntax/src/extern_name.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/extern_name.rs
@@ -33,7 +33,7 @@
 /// is caught upstream by `invalid_kebab_export_name` (rcdzc backend/wasm/mod.rs), the same guard that
 /// catches a non-ASCII char — see the precondition.
 ///
-/// ⚠ PRECONDITION — the "always a valid kebab word" guarantee holds ONLY for names over ASCII letters,
+/// WARNING: PRECONDITION — the "always a valid kebab word" guarantee holds ONLY for names over ASCII letters,
 /// digits, `_` and `-`. A Cadenza identifier may contain NON-ASCII letters (the ML lexer's
 /// `is_ident_start` admits `c.is_alphabetic()` and any `!c.is_ascii() && !c.is_whitespace()` char — so
 /// `π`, `café`, `ναμε` are valid identifiers). Such a char is NOT `[a-z0-9-]`, so this function passes it

--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -413,7 +413,7 @@ impl HostedSession {
     /// genesis-hash-hex (the operator ruling — provenance-derived + self-certifying), which the naming layer
     /// resolves a name to (name → genesis-hash = the routable id, no separate hash→id map needed).
     ///
-    /// ⚠ NOT a GLOBAL identity — a [`SessionId`] is OPAQUE host-assigned metadata: a spawned child gets
+    /// WARNING: NOT a GLOBAL identity — a [`SessionId`] is OPAQUE host-assigned metadata: a spawned child gets
     /// genesis-hash-hex, but a root / named session may carry a VANITY id (e.g. `"concierge"`). So code
     /// holding a genesis `Hash` (e.g. [`Session::parent`]) must resolve it to a registry entry via
     /// [`AgentHost::session_id_by_genesis_hash`] (matches on `genesis_hash()`), NEVER by assuming
@@ -1050,7 +1050,7 @@ impl AgentHost {
             // when the child HAS a parent that is STILL registered — a root session (`None`) or a gone/
             // already-terminated parent = no-op, no bounce (the supervisor, if any, is gone too).
             //
-            // ⚠ Resolve the parent by its GENESIS HASH, not by `hex(parent_hash)` as a SessionId: the id is
+            // WARNING: Resolve the parent by its GENESIS HASH, not by `hex(parent_hash)` as a SessionId: the id is
             // OPAQUE host metadata (a spawned child gets genesis-hash-hex, but a top-level NAMED supervisor
             // can be registered under a vanity id like "concierge"). Hex-ing the hash into a SessionId would
             // miss a vanity-id parent → the signal would be SILENTLY DROPPED and the supervisor would never
@@ -1088,7 +1088,7 @@ impl AgentHost {
     /// there would need a kernel mut-seam / owner-driven path; v0 ships the canonical-store path the shared
     /// directory uses). `suspend` is transparent (only terminate evicts).
     ///
-    /// ⚠ COST (concierge-flagged, documented): O(groups × ops) per death — it scans every group's OR-set log
+    /// WARNING: COST (concierge-flagged, documented): O(groups × ops) per death — it scans every group's OR-set log
     /// in the canonical store. Fine at v0 scale (deaths rare, few groups); the REVISIT TRIGGER is a central
     /// group-store OR a measured perf issue (whichever first), at which point a session→groups reverse index
     /// (or the central store's own index) becomes the O(1) path. See the directory-i5 index note.

--- a/implementation/seed/crates/cdz-agent-host/src/metric_exec.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/metric_exec.rs
@@ -13,7 +13,7 @@
 //! **The host's job is MECHANISM + a SAFETY BOUND (operator standing-order: host = mechanism, policy = wasm).**
 //! - MECHANISM: decode the sample, map `kind` → the registry's metric type (counter → [`Counter::increment`],
 //!   gauge → [`Gauge::set`], timing → [`Summary::record_value`]), record it.
-//! - 🔴 SAFETY BOUND (why this executor holds state): a metric name/label is GUEST-CONTROLLED and ships
+//! - SAFETY BOUND (why this executor holds state): a metric name/label is GUEST-CONTROLLED and ships
 //!   OFF-BOX to the metric backends. Two hazards the host must bound (a bound is mechanism, not policy) —
 //!   CARDINALITY: an unbounded set of distinct guest names/labels is a cardinality bomb (registry bloat +
 //!   backend cost), so the executor caps the number of DISTINCT metric names it admits per session; and
@@ -135,7 +135,7 @@ impl Executor for MetricExecutor {
             }
         };
 
-        // 🔴 GUEST-STRING SAFETY: the name + every label key/val must be safe to carry off-box (bounded
+        // SAFETY: GUEST-STRING SAFETY: the name + every label key/val must be safe to carry off-box (bounded
         // charset + length). Reject the whole publish PERMANENT otherwise — never record or log an unsafe
         // guest string into the telemetry pipeline.
         if !Self::is_safe_str(&sample.name) {
@@ -151,7 +151,7 @@ impl Executor for MetricExecutor {
             }
         }
 
-        // 🔴 CARDINALITY BOUND: admit a new distinct name only under the cap; an already-admitted name always
+        // SAFETY: CARDINALITY BOUND: admit a new distinct name only under the cap; an already-admitted name always
         // records. This bounds the guest's contribution to registry/backend cardinality.
         if !self.admitted.contains(&sample.name) {
             if self.admitted.len() >= MAX_DISTINCT_NAMES {

--- a/implementation/seed/crates/cdz-kernel/src/blob.rs
+++ b/implementation/seed/crates/cdz-kernel/src/blob.rs
@@ -152,7 +152,7 @@ impl BlobStore for DiskBlobStore {
         // PR#903/#929). Recover ONLY from the specific "destination already exists" error by removing the
         // target + retrying once.
         //
-        // ⚠ It must be THAT error kind only (Copilot PR#1018 DATA-LOSS regression): the earlier fallback
+        // WARNING: It must be THAT error kind only (Copilot PR#1018 DATA-LOSS regression): the earlier fallback
         // removed `path` on ANY rename error as long as the target existed — but rename also fails for
         // permission/IO/cross-filesystem reasons, so it would DELETE A VALID BLOB and then fail. On any
         // error that isn't AlreadyExists, leave `path` untouched, clean up tmp, and surface the error.

--- a/implementation/seed/crates/cdz-kernel/src/executor.rs
+++ b/implementation/seed/crates/cdz-kernel/src/executor.rs
@@ -155,7 +155,7 @@ impl Executor for RecordingExecutor {
 /// - non-zero exit → `Err("exit <code>: <stderr>")`
 /// - spawn failure / empty command → `Err`.
 ///
-/// **No shell = no injection (PR#992 ⚠⚠ command injection):** the previous `sh -c <target>` let shell
+/// **No shell = no injection (PR#992 WARNING:WARNING: command injection):** the previous `sh -c <target>` let shell
 /// metacharacters in the target (`;`, `|`, `&&`, `$()`, backtick) execute arbitrary commands, DEFEATING
 /// the SEC-F1 `Prefix` allow-list — `echo ok; rm -rf /` passes `starts_with("echo ")` but `sh` ran the
 /// `rm`. Direct exec makes every token a LITERAL argument: a `;` is an argument to the program, not a

--- a/implementation/seed/crates/cdz-kernel/src/selector.rs
+++ b/implementation/seed/crates/cdz-kernel/src/selector.rs
@@ -10,7 +10,7 @@
 //! log) wire in at the effect-integration slice, which pairs the CAS write with v-agent-harness-host's
 //! store. Keeping the decision pure makes it fully unit-testable and keeps the I/O seam separate.
 //!
-//! 🔑 KEYSTONE INVARIANT (operator seq 109): the host/kernel knows NOTHING about the compiler or any
+//! KEYSTONE INVARIANT (operator seq 109): the host/kernel knows NOTHING about the compiler or any
 //! program — its entire model is (1) a method got invoked, (2) a response came back, (3) outputs get
 //! routed to locations. So the selector matches ONLY on an artifact's OPAQUE `kind`/`name` strings; it
 //! never encodes "this is a .wasm from the compiler" or any program-specific knowledge. The CALLER

--- a/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
+++ b/implementation/seed/crates/cdz-kernel/src/wasm_host.rs
@@ -1030,7 +1030,7 @@ impl<T: 'static> HeapHandle<T> {
 
     /// `sum-new(disc, payload) -> u32` (idx 10): build a sum handle with discriminant `disc` and payload
     /// handle `payload` — an `option` is `sum-new(0, some_handle)` / `sum-new(1, unit_handle)`; a nullary
-    /// variant carries the UNIT value as its payload. ⚠ the runtime's unit is the INLINE-UNIT handle
+    /// variant carries the UNIT value as its payload. WARNING: the runtime's unit is the INLINE-UNIT handle
     /// (`IMM_UNIT`), NOT handle 0 (a NULL handle/token) — obtain it via [`HeapHandle::unit`] (`arr-alloc(0)`,
     /// the empty array = inline unit, per runtime.wit "a nullary variant carries the unit value (an arr of
     /// length 0)"). Passing 0 would build a sum with a NULL payload = a malformed value.
@@ -4794,7 +4794,7 @@ mod tests {
     // of two artifacts. Synthetic WAT (no wit-bindgen toolchain): the core `run` lays out the record
     // array in linear memory and returns the (ptr,len) the canon lift reads. Exercises the WHOLE invoke
     // decode: navigate the export → call → lift the artifact list → decode records/strings/byte-lists.
-    // 🪤 An exported func referencing a named record type requires that TYPE to be EXPORTED first (aliased),
+    // TRAP: An exported func referencing a named record type requires that TYPE to be EXPORTED first (aliased),
     // else `Component::new` rejects it "func not valid to be used as export".
     fn two_artifact_component() -> Vec<u8> {
         wat::parse_str(

--- a/implementation/seed/crates/cdz-kernel/tests/loop_and_recovery.rs
+++ b/implementation/seed/crates/cdz-kernel/tests/loop_and_recovery.rs
@@ -1247,7 +1247,7 @@ async fn live_shell_denied_command_never_executes() {
     let _ = std::fs::remove_file(&marker);
 }
 
-/// PR#992 ⚠⚠ CWE-78: the fix — direct exec (no `sh -c`) makes shell metacharacters LITERAL, so a
+/// PR#992 WARNING:WARNING: CWE-78: the fix — direct exec (no `sh -c`) makes shell metacharacters LITERAL, so a
 /// compound like `echo ok; touch <file>` that passes the `echo ` prefix allow-list does NOT run the
 /// second command. Before the fix, `sh -c` executed the `touch`; now `;` and the rest are just literal
 /// arguments to `echo`, and the file is never created.

--- a/implementation/seed/crates/cdz-runtime/src/lib.rs
+++ b/implementation/seed/crates/cdz-runtime/src/lib.rs
@@ -3284,7 +3284,7 @@ fn op_str_from_bytes(buf: Handle) -> Handle {
 ///
 /// ⚡ COST — O(scalar_index): reaching the i-th scalar walks the UTF-8 from the START (a String is not
 /// scalar-indexable in O(1) — variable-width encoding). This is INHERENT to random access by scalar
-/// index, NOT a defect. ⚠ CONSEQUENCE for the compiler agent: a LEXER that scans a string left-to-right
+/// index, NOT a defect. WARNING: CONSEQUENCE for the compiler agent: a LEXER that scans a string left-to-right
 /// via repeated `scalar-at(s, 0)`, `scalar-at(s, 1)`, … is O(N²) (measured: ~67 ns/scalar at N=64 rising
 /// to ~3300 ns/scalar at N=4096). A sequential scan wants a CURSOR (`scalar-next(buf, byte_off) ->
 /// (codepoint, next_byte_off)`, advancing by the scalar's width) — that would be a SEPARATE coordinated
@@ -4317,7 +4317,7 @@ fn op_vec_get(v: Handle, index: u32) -> Handle {
 // heap traffic for the single-threaded push/update chains that dominate. Observationally IDENTICAL to
 // the path-copy version; the win is fewer allocations.
 //
-// 🚨 ALIASING SAFETY (a violation silently corrupts a shared persistent version). `mine` means "this
+// CRITICAL: ALIASING SAFETY (a violation silently corrupts a shared persistent version). `mine` means "this
 // node is on a fully-unique path and is safe to mutate in place". It propagates STRICTLY DOWNWARD:
 //   mine(root)  = header.rc == 1 && root.rc == 1
 //   mine(child) = mine(parent)  && child.rc == 1
@@ -7074,7 +7074,7 @@ fn champ_insert_node(
 // in place) instead of alloc-new + drop-old. Observationally IDENTICAL to the path-copy core, and
 // canonical-shape-identical (the in-place builders mirror the copy path's ordering byte-for-byte).
 //
-// 🚨 ALIASING SAFETY (a violation silently corrupts a shared persistent map/set). `mine` = "this node
+// CRITICAL: ALIASING SAFETY (a violation silently corrupts a shared persistent map/set). `mine` = "this node
 // is on a fully-unique path, rc==1, safe to reuse in place". It propagates STRICTLY monotone-false
 // downward: the map/set handle IS the root node (no separate header like the vector), so the ops gate
 // on `node_rc(m)==1`, then `child_mine = mine && node_rc(child)==1`. At the FIRST node with rc>1 we
@@ -7970,7 +7970,7 @@ fn op_map_iter(m: Handle) -> Handle {
 // cursor, then drops the consumed cursor. FBIP reuses the cursor SHELL in place when it is uniquely
 // owned — the WIT's zero-steady-state-alloc promise for a non-forked walk.
 //
-// 🚨 ALIASING SAFETY: gate on `node_rc(cur) == 1`. A forked/peeked/teed cursor (rc>1) MUST take the
+// CRITICAL: ALIASING SAFETY: gate on `node_rc(cur) == 1`. A forked/peeked/teed cursor (rc>1) MUST take the
 // copy path so the other owner's walk is undisturbed. The cursor is a leaf handle (no descent into
 // it), so the check is a single rc read — no downward propagation like the trie ops.
 //
@@ -10698,7 +10698,7 @@ mod tests {
     /// set union 431 / ∩ 356 / ∖ 362, ∖ unique-small-b 774≈build-only; they are UPPER BOUNDS so noise never trips them but a
     /// regression toward the old 6779/8397/5248/1000 does.
     ///
-    /// ⚠ MUST run alone: the counter is PROCESS-WIDE, so a concurrent test thread's allocations pollute
+    /// WARNING: MUST run alone: the counter is PROCESS-WIDE, so a concurrent test thread's allocations pollute
     /// the reading (observed ~51k when run in the default multi-threaded suite). It is therefore
     /// `#[ignore]`d in the normal run (and in `cargo test`/`cargo xtask check`) and exercised on demand:
     ///   `cargo test -p cdz-runtime hot_op_allocation_ceilings -- --ignored --test-threads=1 --nocapture`
@@ -11703,7 +11703,7 @@ mod tests {
         // AND the reused `ENCODE_BUILDER`/`ENCODE_OUT` pools (grown warm by the earlier value_encode reps in
         // this same test), a 1000-entry encode reallocates almost nothing — just the entries Vec + the
         // output byte Vec's own growth + the returned Bytes leaf. Was 2065 (per-int Vec) → 67 (IntScalar) →
-        // ~42 (pool reuse). ⚠ this row runs AFTER the value_encode/stringkeymap rows, so the thread-local
+        // ~42 (pool reuse). WARNING: this row runs AFTER the value_encode/stringkeymap rows, so the thread-local
         // pools are already at a high-water mark — the figure measures steady-state reuse, not cold growth.
         // A per-entry transient Vec or an O(N²) CHAMP re-walk would be orders of magnitude over (O(N²) ≈ 10⁶).
         assert!(
@@ -12121,7 +12121,7 @@ mod tests {
     /// LAYOUT GUARD: `Node` is paid by EVERY heap value, so its size is load-bearing for allocation +
     /// cache behavior. There is otherwise no signal if a change bloats it (a new field, a widened
     /// `Handles`/`Raw` variant). Pin the NATIVE-host sizes so a structural regression is caught in the
-    /// std test suite. ⚠ These are the 64-bit NATIVE sizes (`Handle` = `*mut Node` = 8, `Vec` = 24); the
+    /// std test suite. WARNING: These are the 64-bit NATIVE sizes (`Handle` = `*mut Node` = 8, `Vec` = 24); the
     /// SHIPPED wasm32 layout is smaller (`Handle` = 4, `Vec` = 12) — this test can't run on wasm, but the
     /// native size moves TOGETHER with wasm for STRUCTURAL changes (an added field / a wider enum variant
     /// bloats both), which is the regression worth catching. Node=64 is already minimal for its fields:

--- a/implementation/seed/crates/cdz/src/lsp.rs
+++ b/implementation/seed/crates/cdz/src/lsp.rs
@@ -1918,7 +1918,7 @@ fn package_hover_at(
 /// entry's dir) is handled best-effort by prefixing a slash (`file:///<encoded>`). `None` only if the
 /// assembled string still does not parse as a `Uri` (it does for any real path).
 ///
-/// 🪤 Encoding a literal `%` is LOAD-BEARING for the `uri_to_path`/`percent_decode` round-trip: the
+/// TRAP: Encoding a literal `%` is LOAD-BEARING for the `uri_to_path`/`percent_decode` round-trip: the
 /// decoder turns any `%XX` back into a byte, so a real path segment like `a%2Fb` MUST be emitted as
 /// `a%252Fb` — else it would decode to `a/b` (a different path). Encoding only a space (the old behavior)
 /// broke that and also produced invalid URIs for `#`/`?`.
@@ -2425,7 +2425,7 @@ fn package_references_at(
     // which is NEVER a `Symbols` node — so it fails the guard and returns empty (the single-buffer path,
     // with its own guard, handles the local). This is the package twin of `references_at`'s guard.
     //
-    // 🪤 The earlier `resolves_to.is_some()` test was too permissive: `ResolveOf` succeeds for a LOCAL
+    // TRAP: The earlier `resolves_to.is_some()` test was too permissive: `ResolveOf` succeeds for a LOCAL
     // binder too (it resolves to itself), so a cursor on a shadowing local passed the guard and leaked
     // the top-level's uses. Requiring the resolve TARGET to be a `Symbols` node is what distinguishes a
     // genuine top-level from a shadowing local. `symbols_lines` is parsed once and reused for the

--- a/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
@@ -1789,7 +1789,7 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
         }
         // `List.update` → replace the element at `index`, returning the NEW list; an out-of-bounds index
         // TRAPS (Cadenza `List.update` traps OOB, `value-heap-runtime.md`). The index is an Int64 occurrence
-        // cast to `usize` (a negative index or `>= len` → the trap). 🔑 TRAP KIND: the wasm runtime's
+        // cast to `usize` (a negative index or `>= len` → the trap). KEYSTONE: TRAP KIND: the wasm runtime's
         // `List.update` OOB is a GENERIC `unreachable` abort (the runtime op traps message-lessly under
         // `panic = abort`), which the corpus grades `(trap "unreachable")` — NOT a bounds-specific string.
         // So panic `"unreachable"` (whose `trap_kind` is `unreachable`) to AGREE with wasm; `"index out of
@@ -2884,7 +2884,7 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
             // `from_i128`/`from_u64`, but `i128_to_sign_magnitude_bytes_into` writes `[sign][LE magnitude]`
             // (≤17 bytes) and `from_sign_magnitude_bytes` rebuilds the `Big`. Correct for BOTH a signed
             // negative and a large unsigned — one uniform path.
-            // 🔑 the operand MUST be widened `as <its own rust int type> as i128` — NOT a bare `(v) as i128`.
+            // KEYSTONE: the operand MUST be widened `as <its own rust int type> as i128` — NOT a bare `(v) as i128`.
             // A genuine `UInt64` operand whose emit carries an i64 REP (e.g. a `(bin (u64 n))` binder, whose
             // BinIntRead assembles bits into an i64) would SIGN-EXTEND under `(i64-expr) as i128` — the top
             // half of u64 flips negative (`2^63+9` → -9223372036854775799, `% 1000` = -799 not 817). Casting

--- a/implementation/seed/crates/rcdzc/src/backend/rust/types.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/types.rs
@@ -549,7 +549,7 @@ pub(super) fn ty_is_ord_key(db: &mut Db, ty: &Ty) -> bool {
         // A bare float keys/elements via the `__CdzF{N}` wrapper — representable and totally ordered.
         Ty::Float(_) => true,
         // A bare BUILT-IN `Option` key/element keys via the `__CdzOpt` declared-order wrapper (#42 witness 2)
-        // — admitted. 🔑 A USER `(type Option …)` shadow (name `Option`, 1 arg, but a source-node decl) must
+        // — admitted. KEYSTONE: A USER `(type Option …)` shadow (name `Option`, 1 arg, but a source-node decl) must
         // NOT reach the wrapper: `ord_key_type`/`wrap_ord_key` are Db-free and key on the NAME-only
         // `is_flip_order_option_key_shallow`, so they'd wrap it as `__CdzOpt<..>` while its VALUE is the user
         // enum → rustc mismatch (PR#894). Since the Db-free wrap path can't tell them apart, DECLINE a
@@ -754,7 +754,7 @@ fn int_type(it: IntTy) -> Option<&'static str> {
         // An UNUSUAL in-range width (`UInt48`, `UInt12`, `Int24` — 1..=64 but not an aliased boundary) has
         // no exact Rust primitive, so it is STORED in the next-larger machine width (`UInt48`→`u64`,
         // `UInt12`→`u16`, `Int24`→`i32`). A value of the unusual width always fits its storage width, so a
-        // const/wrap value + a boundary render are exact. ⚠ RUNTIME ARITHMETIC on an unusual width would
+        // const/wrap value + a boundary render are exact. WARNING: RUNTIME ARITHMETIC on an unusual width would
         // need the overflow check at `2^N` (not the storage width's `2^machine`), so `emit_arith`/shift/
         // convert on an unusual width must DECLINE (defense-in-depth — no corpus case runs arith on an
         // unusual width today: the only `(+ (UInt48) (UInt48))` case is a compile-time CDZ0304 reject). The

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/envelope.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/envelope.rs
@@ -8094,7 +8094,7 @@ fn component_instantiate_roundtrip_item(
 /// `(self:borrow<0>)->list u8` → 5; imported `make` → func 0; imported `encode` → func 1; RE-EXPORTED
 /// resource → type 6; `own<6>` → 7; make-exp-ft → 8; `borrow<6>` → 9, `list u8` → 10, encode-exp-ft → 11.
 ///
-/// ⚠ NOT yet wired in: the `borrow<t>` encode is the correct R2-dtor fix (so the host keeps ownership
+/// WARNING: NOT yet wired in: the `borrow<t>` encode is the correct R2-dtor fix (so the host keeps ownership
 /// and drops → dtor fires), but it currently regresses the composed walk under wasmtime 37 with an
 /// un-root-caused host-side trap in encode. Kept here (byte-layout worked out, byte-identity verified
 /// against the ComponentBuilder borrow oracle) as scaffolding for the follow-up; the live path still

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
@@ -83,7 +83,7 @@ pub struct Emit {
     /// all BORROWING `Elem` reads — sound because `op_sum-payload` is TOTAL (never traps) and BORROWING (no
     /// refcount change), so computing it once when the arm is entered matches per-element re-walks exactly.
     ///
-    /// 🩸 The key carries the FULL prefix STEPS, NOT just its length: a TUPLE-OF-TWO-SUMS match
+    /// The key carries the FULL prefix STEPS, NOT just its length: a TUPLE-OF-TWO-SUMS match
     /// (`match (a, b) with (TArrow(a1,a2), TArrow(b1,b2)) => …`) produces TWO distinct prefixes of the SAME
     /// length off the SAME tuple scrutinee — `[Elem(0), Payload]` (a's payload) and `[Elem(1), Payload]`
     /// (b's payload). A length-only key `(scrutinee, 2)` COLLIDED them, so the second overwrote the first and
@@ -429,7 +429,7 @@ fn binding_escapes_dup_aware(
         // A reference to the binding: it escapes UNLESS this occurrence is a borrow (the operand of a
         // `Proj`, which `arr-get`-borrows). `tail_borrowed` is set by the `Proj` arm below for its
         // operand; every other occurrence (the result, a tuple element, a call arg) is consuming.
-        // ⚠ A CONSUMING occurrence that is a Perceus retain (`dup_sites`) does NOT escape: the `dup`
+        // WARNING: A CONSUMING occurrence that is a Perceus retain (`dup_sites`) does NOT escape: the `dup`
         // gave the consuming op its own reference, so the binding's slot reference survives + must be
         // reclaimed by the `let` drop (see the fn doc). Only applies when `dup_sites` is `Some`.
         Core::LocalRef { binder: b } => {
@@ -1095,7 +1095,7 @@ fn collect_row_op_field_dups(db: &mut Db, id: StructId, dup_sites: &mut HashSet<
                 // `get-int`/`get-bool`/…) and must NOT be dup'd (rc++ on a non-handle corrupts). The proj
                 // must root at THIS binder.
                 //
-                // ⚠ `get_op` returns `Ok(None)` for BOTH a heap handle AND `Ty::Unit` (the inline `IMM_UNIT`
+                // WARNING: `get_op` returns `Ok(None)` for BOTH a heap handle AND `Ty::Unit` (the inline `IMM_UNIT`
                 // sentinel — PR#914 Copilot): a Unit field-proj is `Drop`'d INLINE by the `Core::Proj`
                 // emitter (never reaches the dup branch), so marking it a dup site imports `dup` with no
                 // matching emit → breaks "import exactly the ops we call" (a spurious import that can perturb
@@ -1489,7 +1489,7 @@ fn cont_child_ids(cont: &crate::core::SumCont, cs: &mut Vec<StructId>) {
 /// (borrow-vs-consume) of each child mirrors [`binding_escapes`] exactly (its `tail_borrowed` = borrow).
 /// Does `binder` occur anywhere in the subtree at `id`? A CHEAP occurrence-only walk (a plain membership
 /// scan over `core_child_ids` — NO site marking, NO borrow/consume/liveness logic), used by `seq`'s
-/// pre-pass to decide whether a sibling references the binder. ⚠ It must NOT call `mark_binder_dups`: that
+/// pre-pass to decide whether a sibling references the binder. WARNING: It must NOT call `mark_binder_dups`: that
 /// full two-pass walk, invoked from every `seq` level's pre-pass, is EXPONENTIAL on a deeply-nested term
 /// (a `push(push(push(xs)))` chain re-walks its inner subtree once per enclosing level, 2^depth). This
 /// occurrence scan visits each node of the subtree ONCE per call (the enclosing `seq` levels make it
@@ -6218,7 +6218,7 @@ fn emit_tail(
             // SHELL RECLAIM (the tail twin of the non-tail `MatchSum` reclaim): deep-`drop` the owned
             // freshly-stashed boxed-sum shell after the arms (it is a dead temporary). Consuming child
             // extractions were `dup`'d upfront (`collect_shell_reclaim_child_dups`), so the deep drop nets
-            // correctly. ⚠ TAIL-SPECIFIC GUARD: skip the reclaim when ANY arm is a MEMBER TAIL-CALL
+            // correctly. WARNING: TAIL-SPECIFIC GUARD: skip the reclaim when ANY arm is a MEMBER TAIL-CALL
             // (`sum_cont_has_member_tail_call`) — that arm `br`s to the loop top and NEVER reaches the post-
             // match drop, so a drop here would (a) not run on the looping path (leak, harmless) but worse
             // (b) the shell slot is a fresh scratch above the params that the next iteration's scrutinee emit
@@ -6229,7 +6229,7 @@ fn emit_tail(
             let scrut_ty = type_of(db, scrutinee);
             let arms_tail_call =
                 matches!(tl, Some(t) if sum_cont_has_member_tail_call(db, &root, t.members));
-            // ⚠ SAFETY RESTRICTION (sread UAF fix, 2026-07-19): reclaim ONLY an ALL-SCALAR-payload shell —
+            // WARNING: SAFETY RESTRICTION (sread UAF fix, 2026-07-19): reclaim ONLY an ALL-SCALAR-payload shell —
             // same sound floor as the non-tail arm. The inc2 compound broadening was unsound for a child
             // BORROWED OUT via an aliasing op (`Map.lookup`/`List.at` return a handle aliasing into the shell
             // child; the deep drop then frees a still-read value → the sread OOB/unreachable UAF). A scalar
@@ -8574,7 +8574,7 @@ fn emit(
             scratch_ty.insert(val_slot, ValType::I32);
             scratch_ty.insert(map_slot, ValType::I32);
             // `map-lookup` BORROWS the map; if the map is an OWNED TEMPORARY (`Map.lookup (build …) k` — not
-            // a reused param/kept-local) it must be reclaimed or it LEAKS. ⚠ DELICATE ORDERING: the looked-up
+            // a reused param/kept-local) it must be reclaimed or it LEAKS. WARNING: DELICATE ORDERING: the looked-up
             // VALUE is stored borrowed in `val_slot` and `dup`'d in the Some arm — so the map's drop must come
             // AFTER that dup (THEN), and in the None arm (val is NULL, nothing to preserve). Dropping right
             // after `map-lookup` would free the value `val_slot` still borrows → a UAF. Stash the map now.
@@ -9524,7 +9524,7 @@ fn emit(
             // Unit is never a live-compound FBIP target, so it skips the child-dup/retain logic below.
             let unit_elem =
                 scalar_elem.is_none() && matches!(type_of(db, id).strip_nominal(), Ty::Unit);
-            // ⚠ A MATERIALIZED-SLOT operand is BORROWED, not owned-by-this-Proj. When `operand` is a node
+            // WARNING: A MATERIALIZED-SLOT operand is BORROWED, not owned-by-this-Proj. When `operand` is a node
             // stashed in `slots` (a `local.get` here — a sum-match scrutinee materialized ONCE into a slot,
             // re-read by every arm), the ENCLOSING construct owns that slot and reclaims it; this Proj only
             // reads it. Reclaiming (drop) here frees-early: the guarded-record UAF
@@ -9570,7 +9570,7 @@ fn emit(
                         // A NESTED-COMPOUND element: retain the returned child (rc++) so it outlives the
                         // parent, then drop the parent. `dup` POPS its handle, so re-read the child from a
                         // scratch slot for the dup and leave the original copy on the stack as the result.
-                        // ⚠ The child slot floats ABOVE `*high` — NOT `base + 1` — because the `operand`
+                        // WARNING: The child slot floats ABOVE `*high` — NOT `base + 1` — because the `operand`
                         // emit above may have spent scratch ABOVE `base + 1` and, crucially, may have bound
                         // a `let` there at a DIFFERENT width (a wasm local has ONE type function-wide). At
                         // MODULE SCALE this is a real miscompile: `(Map.size (. r 1))` where the record `r`'s
@@ -9722,7 +9722,7 @@ fn emit(
                     }
                     crate::core::PathStep::RestFrom(k) => {
                         // Tail sublist from `k`: `vec-drop(list, k)` returns the `[k, len)` tail as ONE
-                        // handle (dropping the `[0, k)` prefix internally). ⚠ `vec-drop` CONSUMES its
+                        // handle (dropping the `[0, k)` prefix internally). WARNING: `vec-drop` CONSUMES its
                         // argument (rc--). But the handle on the stack here is a BORROW of the shared match-
                         // arm scrutinee slot (from `emit(scrutinee)` = a plain `local.get`), and a SIBLING
                         // binder in the SAME arm may still read it — e.g. `((list x .. rest) (f rest (+ acc
@@ -9757,7 +9757,7 @@ fn emit(
             // (rc++ → 2) so the consumer takes the persistent copy path and the scrutinee's payload stays
             // intact; the consumer's own drop reclaims the extra reference. Only a COMPOUND leaf (`unboxed`
             // None AND not Unit — a real handle) aliases; a scalar `unboxed` COPIES out and is never a marked
-            // site. ⚠ `get_op` returns `None` for BOTH a compound handle AND a `Unit` payload (Unit has no
+            // site. WARNING: `get_op` returns `None` for BOTH a compound handle AND a `Unit` payload (Unit has no
             // machine value — the walk lands on the `IMM_UNIT` sentinel that `emit_heap_read_tail` DROPS). A
             // Unit has no heap cell to alias, so it must NOT take the dup fast path (which would `dup` +
             // return, leaving the sentinel un-dropped → an extra stack value → INVALID WASM). Route Unit
@@ -10282,7 +10282,7 @@ fn emit(
             // reclaims as before. Requires a freshly-stashed owned scrutinee (a reused param/local is borrowed,
             // left to its owner), a REAL BOXED SUM (`is_heap_type && !ty_is_enum_disc`), and a non-diverging
             // match.
-            // ⚠ SAFETY RESTRICTION (sread UAF fix, 2026-07-19): reclaim ONLY an ALL-SCALAR-payload shell.
+            // WARNING: SAFETY RESTRICTION (sread UAF fix, 2026-07-19): reclaim ONLY an ALL-SCALAR-payload shell.
             // The inc2 broadening ("any owned boxed sum + dup the consumed children") was UNSOUND: it handled
             // a child MOVED OUT (consumed → dup'd) but NOT a child BORROWED OUT via an ALIASING op — e.g.
             // `(match tree ((Arena m _) (Map.lookup m id)))` where `Map.lookup` returns a handle that ALIASES
@@ -11919,7 +11919,7 @@ fn emit_match_arms_tailable(
     // must not force a `select` on a probe that is always false). Recurses with the kept arms only when the
     // filter removed something (else infinite recursion / wasted re-run); order preserved.
     //
-    // ⚠ The probe's NUMERIC value (`to_i64()`), NOT its bit pattern (`to_i64_bits()`), is what `value_range`
+    // WARNING: The probe's NUMERIC value (`to_i64()`), NOT its bit pattern (`to_i64_bits()`), is what `value_range`
     // reasons about: a wide UNSIGNED probe (`UInt64` `2^63`) has a NEGATIVE bit pattern that would falsely
     // read as "below [0, …]" and drop a LIVE arm — a miscompile. `to_i64()` is `None` for such a value (out
     // of i64), so the arm is conservatively KEPT.
@@ -19685,7 +19685,7 @@ mod tests {
         // -key concern from the owned-temporary-map reclaim (a fresh inline map IS an owned temporary the
         // emit now correctly drops — see `an_owned_temporary_map_lookup_map_is_reclaimed`).
         //
-        // ⚠ EXACTLY ONE drop is now expected — but it is the OWNED OPTION SHELL, not the borrowed key/map.
+        // WARNING: EXACTLY ONE drop is now expected — but it is the OWNED OPTION SHELL, not the borrowed key/map.
         // `Map.lookup` returns a FRESH owned `Option` (Some boxes a scalar copy of the value; None is fresh);
         // in a TAIL match (this body's whole match is `pv`'s result) the wrapper-scrutinee shell reclaim
         // deep-drops that dead Option shell. Its payload is a SCALAR (Int64, copied out), so the deep drop
@@ -19725,7 +19725,7 @@ mod tests {
     #[test]
     fn an_owned_temporary_map_lookup_map_is_reclaimed() {
         // The COLLECTION-operand reclaim: a `Map.lookup` whose MAP is a fresh OWNED TEMPORARY (built inline,
-        // used once) must be dropped after the borrowing lookup, or it leaks. ⚠ the drop must come AFTER the
+        // used once) must be dropped after the borrowing lookup, or it leaks. WARNING: the drop must come AFTER the
         // value is dup'd out (the Some arm) — not right after `map-lookup` (that would free the value the
         // val-slot still borrows → UAF). Here the key is a constant (also owned → also dropped), so we get
         // ≥2 drops (key + map). Pins that the owned-temporary map is reclaimed.
@@ -19924,7 +19924,7 @@ mod tests {
         // Golden pinned from the current (pre-refactor) emit: 0 retain-dups, 3 drops (one per push-result
         // temporary). The traversal-share refactor MUST reproduce both exactly.
         //
-        // ⚠ WHAT drops==3 ENCODES: the 3 drops are the 3 `List.push` RESULT temporaries. The 3 `xi`
+        // WARNING: WHAT drops==3 ENCODES: the 3 drops are the 3 `List.push` RESULT temporaries. The 3 `xi`
         // let-bindings themselves are NOT dropped (push BORROWS xi; the fresh `(list n)` is never
         // reclaimed) — a bounded 3-cell LEAK, the known borrowed-through-scope let/param-drop KNOWN-GAP
         // (the general Perceus param-drop pass is not yet implemented in this backend; a known gap tracked

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/serialize.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/serialize.rs
@@ -1818,7 +1818,7 @@ pub enum SumArmPayload {
 /// body to branch on the flattened boundary disc and build each arm's cell via `sum-new` (the exact
 /// `Core::SumNew` shape), pushing the resulting handle in place of the raw params. Proven runnable by the
 /// `an_option_scalar_closure_arg_crosses_by_native_flattening` + `a_result_scalar_closure_arg_crosses_by_
-/// native_flattening` oracles. 🪤 the disc has TWO conventions: the guest BRANCHES on the boundary disc
+/// native_flattening` oracles. TRAP: the disc has TWO conventions: the guest BRANCHES on the boundary disc
 /// (`option`/`result` send case-1 for the 2nd case), but BUILDS with each arm's DECL disc.
 #[derive(Clone)]
 pub struct SumArgRebuild {

--- a/implementation/seed/crates/rcdzc/src/db.rs
+++ b/implementation/seed/crates/rcdzc/src/db.rs
@@ -1011,7 +1011,7 @@ pub struct Db {
     /// this name?", it never decides meaning (`prelude-and-resolution.md`; the operator's rule "a
     /// program-written binding is keyed by OCCURRENCE, never its own name map").
     ///
-    /// ⚠ FLAT-NAMESPACE ASSUMPTION — revisit when nested modules / imports land. `scan_top_level` is
+    /// WARNING: FLAT-NAMESPACE ASSUMPTION — revisit when nested modules / imports land. `scan_top_level` is
     /// flat today (`top_items` does NOT recurse into a nested `(module …)`), so ALL defs share one
     /// namespace and a bare `String` key is correct. Under nesting, two same-named defs in sibling
     /// submodules are still DISTINCT (different occurrences) but would COLLIDE in this map. The fix is
@@ -1742,7 +1742,7 @@ pub struct Db {
     /// caches per node. Without it a wide structural-record type ANNOTATION (`{tree, resolved: Map(Int64,
     /// Resolved), …}`) re-reduces from scratch at every one of its ~1M referencing uses through the
     /// resolve→infer→lower chain, exhausting the per-query reduction budget → a spurious CDZ0999 "does not
-    /// reduce within limits" on a whole-project check (the DB-records self-host case). 🪤 STALENESS: filled
+    /// reduce within limits" on a whole-project check (the DB-records self-host case). TRAP: STALENESS: filled
     /// ONLY when [`Self::typeval_memo_live`] is set — the newtype precompute reduces payloads BEFORE
     /// `newtype_inner` is complete (a pre-normalization `Ty::Sum`), so the memo must not capture those; the
     /// flag flips true right after the post-population evict at load's end. Invalidated per node by
@@ -5560,7 +5560,7 @@ pub(crate) fn scan_type_decl(ast: &Arenas, item: StructId) -> Option<TypeDecl> {
 /// `(Option a)` / `(Tuple a b)` into its arguments. A duplicate is not re-added (a `HashSet`-like
 /// linear check keeps the small param list ordered by first appearance).
 ///
-/// ⚠ A `(Record (field Type)…)` payload's field NAME is a LABEL, not a type expression — a lowercase
+/// WARNING: A `(Record (field Type)…)` payload's field NAME is a LABEL, not a type expression — a lowercase
 /// field name (`(Record (v Int64))`) must NOT be mistaken for a type parameter, or the sum spuriously
 /// becomes generic over `v` and its ctor arrow breaks (the payload reads as an unresolvable variable, so
 /// the variant looks nullary). So a `(Record …)` form descends only into each field pair's TYPE (the

--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -938,7 +938,7 @@ fn op_arm_arity(db: &Db, ty: StructId) -> usize {
 /// the tail-resumptive fold" decline — neither said the arm's parameter count is wrong. This is the
 /// handler-arm analogue of a function applied at the wrong arity.
 ///
-/// ⚠ The ELIDED-UNIT convention: a `(-> Unit R)` operation accepts BOTH a 0-binder arm (`(op () s …)`,
+/// WARNING: The ELIDED-UNIT convention: a `(-> Unit R)` operation accepts BOTH a 0-binder arm (`(op () s …)`,
 /// unit elided) AND a 1-binder arm (`(op (u) s …)`, unit bound explicitly) — the corpus uses both — so a
 /// unit op's accepted set is `{0, 1}`, and only an arm outside it (2+ binders) is a mismatch. A genuine
 /// N-parameter op (`N ≥ 1`, no elided unit) requires EXACTLY N. `op_arm_arity` gives the elided count
@@ -1493,7 +1493,7 @@ fn check_no_home_walk(
             // A DELEGATED NAME THAT RESOLVES TO A VALUE DEFINITION. `(host (foo) …)` where `foo` is a
             // top-level `(def foo …)` names a VALUE, not an effect — a malformed grant (a `host` delegates
             // EFFECTS, `capabilities-and-effects.md` §Host Delegation Is An Entrypoint's Prerogative), not a
-            // silently-ignored no-op. Reject it CDZ0201, anchored at the name. ⚠ CONSERVATIVE — flags ONLY a
+            // silently-ignored no-op. Reject it CDZ0201, anchored at the name. WARNING: CONSERVATIVE — flags ONLY a
             // name that is UNAMBIGUOUSLY a value def (`def_by_name`): a nested-module effect
             // (`(module m (effect log …) (def (main) (host (log) …)))`) is NOT in the TOP-LEVEL
             // `effect_decls`/`def_by_name` registries (it lives in the module's own scope), so testing "is a

--- a/implementation/seed/crates/rcdzc/src/eval.rs
+++ b/implementation/seed/crates/rcdzc/src/eval.rs
@@ -2762,7 +2762,7 @@ pub fn reduce_ctor(
         // `reduce_to_tuple_elems`/`reduce_to_record_id`, member projection, the host-escape walk,
         // `type_of`, `lower`) treats it IDENTICALLY to a value written with the string primitive.
         //
-        // ⚠ `push_list` RE-PARENTS the arg subtrees under the new head, which would orphan a field/
+        // WARNING: `push_list` RE-PARENTS the arg subtrees under the new head, which would orphan a field/
         // element value like the runtime param `a` in `(record (x a) …)` from its lexical scope (a
         // spurious unbound name — the re-parenting hazard `apply_lambda` documents). So PIN each arg's
         // resolution first (`resolve_subtree` memoizes every node against its CURRENT scope), exactly as
@@ -2899,7 +2899,7 @@ pub const NOT_A_CTOR_PRIM: &str = "not a type constructor";
 /// unknown. (The analogue of `reduce_ctor` for `TupleCtor`, but keyed on the head's metadata rather
 /// than the prim alone — one prim serves every generic sum.)
 ///
-/// ⚡ Returns the `Ty` value, NOT an encoded `(typeval …)` arena node: its one caller (`typeval_of`'s
+/// COST: Returns the `Ty` value, NOT an encoded `(typeval …)` arena node: its one caller (`typeval_of`'s
 /// `SumCtor` arm) wants the `Ty` and previously got it by `encode_typeval`-ing this result then
 /// `typeval_of`-DECODING it right back — a full encode→decode arena round-trip PER LEVEL, so a
 /// deeply-nested `(Option (Option … Int64))` annotation was O(N²) in arena node churn (measured: 400
@@ -3780,7 +3780,7 @@ fn encode_ty(db: &mut Db, ty: &crate::ty::Ty) -> StructId {
         // A quantity type-value: `(Qty <inner-ty> (unit (base <name> <exp>)…))` — the inner numeric type
         // then the unit encoded as a canonical `(unit …)` node listing each base's `(base NAME EXP)` pair
         // in sorted order (the dimensionless unit is the empty `(unit)`). Round-trips with
-        // `resolve::decode_ty`'s `"Qty"` arm. ⚠ WITHOUT this arm the catch-all below would encode a
+        // `resolve::decode_ty`'s `"Qty"` arm. WARNING: WITHOUT this arm the catch-all below would encode a
         // quantity as `Unit`, so a `(-> T (Qty T u))` scheme (Qty.of) would round-trip to `(-> T Unit)`
         // and mis-type — the same round-trip hole the `Bytes`/`String` arms fixed for those leaves.
         Ty::Qty { inner, unit } => {

--- a/implementation/seed/crates/rcdzc/src/infer.rs
+++ b/implementation/seed/crates/rcdzc/src/infer.rs
@@ -1629,7 +1629,7 @@ fn nested_width_fault_by_ty(db: &mut Db, value: StructId, want: &Ty) -> Option<R
 /// different literal) is theirs to confirm. Shared by both CDZ0302 literal-range sites (the value
 /// annotation `(: v T)` and the let-binder/param `((: name T) v)`), so both carry the fix.
 ///
-/// ⚠ `ty_expr` MUST be a written TYPE node (the annotation being retyped) — the fix replaces its spelling
+/// WARNING: `ty_expr` MUST be a written TYPE node (the annotation being retyped) — the fix replaces its spelling
 /// with a type name. NEVER pass a VALUE node here: a literal whose width came from a solved/inferred `Ty`
 /// (a nested compound payload, or a sibling literal's annotation) has no type-node to retype, and
 /// rewriting the literal into a type name corrupts the source. Those sites build the reject directly
@@ -8088,7 +8088,7 @@ pub(crate) fn check_unknown_units(db: &mut Db, out: &mut Vec<Reject>) {
         let mut fix = None;
         let hint = match crate::diag::suggest::nearest(&name, known.iter()) {
             Some(near) => {
-                // ⚠ The unit name is a LITERAL whose delimiter must be preserved so the applied edit
+                // WARNING: The unit name is a LITERAL whose delimiter must be preserved so the applied edit
                 // re-renders a valid `Unit.of` argument: a symbol `#"metre"` (`Leaf::Sym`) → `#"meter"`,
                 // a plain string `"metre"` (`Leaf::Str`) → `"meter"`. Detect which from the AST node —
                 // a bare `meter` would re-read as a NAME and break the `(Unit.of …)` form.

--- a/implementation/seed/crates/rcdzc/src/layout.rs
+++ b/implementation/seed/crates/rcdzc/src/layout.rs
@@ -707,7 +707,7 @@ pub fn compute_tests_consumer(
     // ALL of them so nothing from the shared closure is re-emitted here).
     let boundary: std::collections::HashSet<usize> = provider_edges.iter().copied().collect();
     let (layout, boundary_hits) = finish_layout_bounded(db, exports, &boundary)?;
-    // 🔑 INDEX-AGREEMENT: the consumer's import position for a cross-edge is its position in the PROVIDER's
+    // KEYSTONE: INDEX-AGREEMENT: the consumer's import position for a cross-edge is its position in the PROVIDER's
     // EXPORT order (`provider_edges`, the SAME sequence `compute_shared_closure_provider` exports — both from
     // `cross_component_edges`'s `layout.order` order). So `extern_order` lists ALL provider edges (not just
     // this file's hits) in provider order, and each cross-edge def maps to its provider export index. A file

--- a/implementation/seed/crates/rcdzc/src/link.rs
+++ b/implementation/seed/crates/rcdzc/src/link.rs
@@ -569,7 +569,7 @@ fn resolve_import_clause(
         // file names, so no extra plumbing is needed.
         // A near-miss also carries the STRUCTURAL fix (rewrite the mistyped path to the near file), so
         // the "did you mean?" is APPLYABLE, not just prose — the import-NAME-typo treatment extended to
-        // the path. Anchored at the PATH node `path_id`. ⚠ `path_id` is a STRING LITERAL, so the
+        // the path. Anchored at the PATH node `path_id`. WARNING: `path_id` is a STRING LITERAL, so the
         // replacement must be QUOTED (`"lib"`): the consumer re-parses it as a sub-form and a bare `lib`
         // would read as a Name → the malformed `(import lib …)`. Heuristic: the near name is a guess.
         let mut fix = None;

--- a/implementation/seed/crates/rcdzc/src/lower.rs
+++ b/implementation/seed/crates/rcdzc/src/lower.rs
@@ -695,7 +695,7 @@ fn compute(db: &mut Db, id: StructId) -> Core {
         // An `if`. FOLD when the condition reduces to a compile-time-constant boolean: the branch the
         // condition selects IS the result, so lower it directly and drop the `if`. This is dead-branch
         // elimination on a proven-constant condition — the untaken branch NEVER executes at run time.
-        // ⚠ WHAT MAY BE DROPPED from the untaken branch mirrors the reachability model
+        // WARNING: WHAT MAY BE DROPPED from the untaken branch mirrors the reachability model
         // (`compile::collect_reached_poisons`, which does NOT descend an `if`'s branches): a RUNTIME TRAP
         // shielded by an untaken branch is not a build failure, so a `ConstTrap` (CDZ0304) untaken branch
         // folds away (`(if (< 1 2) 7 (% 5 0))` → 7 — the div-by-zero is unreachable). But a NON-TRAP
@@ -6581,7 +6581,7 @@ fn desugar_refutable_nested_list_elements(
         let guard_cond = match existing_guard {
             None => len_test,
             Some(g) => {
-                // 🩸 The user guard cond `g` may read the INNER list's binders (`(guard (list (list a .. r1)
+                // The user guard cond `g` may read the INNER list's binders (`(guard (list (list a .. r1)
                 // .. r2) (> a 3))` reads `a`). Those bind only in the BODY re-match (below), NOT at the outer
                 // guard level — so ANDing `g` here left `a` unbound (a false CDZ0101). FIX (mirrors Inc-34's
                 // ctor-element guard): evaluate `g` INSIDE a match on the fresh binder `__ne` that binds the
@@ -6659,7 +6659,7 @@ fn clone_refutable_payload(db: &mut Db, e: StructId) -> StructId {
 /// guard's discriminant test, with every BARE-BINDER payload argument replaced by a wildcard `_` but every
 /// REFUTABLE payload sub-pattern (a literal, a nested constructor) KEPT.
 ///
-/// 🩸 Why keep refutable payloads: the guard's job is to decide whether this arm's element pattern matches
+/// Why keep refutable payloads: the guard's job is to decide whether this arm's element pattern matches
 /// so the arm fires or FALLS THROUGH. The body re-match `(match __lc (<ctor-pat> body) (_ (trap)))` traps in
 /// its `_` arm, so the guard MUST have already proven the FULL element pattern matches — not just the
 /// discriminant. If a payload sub-pattern is a LITERAL (`(Op.Add 0)`), wildcarding it made the guard pass on
@@ -13030,7 +13030,7 @@ fn type_specialize(db: &mut Db, callee: usize, args: &[StructId]) -> Option<(usi
                 // prior spec's each depth) is caught by the fingerprint-extension backstop below.
                 return None; // the const arg depends on runtime data — not compile-time-known
             }
-            // ⚠ MISCOMPILE GUARD: a `const` COLLECTION param (List/Map/Set) consumed by a SELF-RECURSIVE
+            // WARNING: MISCOMPILE GUARD: a `const` COLLECTION param (List/Map/Set) consumed by a SELF-RECURSIVE
             // fold cannot be specialized correctly here yet. The recursion passes a DERIVED shorter
             // collection (`(s t …)` where `t` is the rest of the const list) at each depth, but its arg
             // node is the SAME rest-binder occurrence every time, so the syntactic fingerprint collapses
@@ -21364,7 +21364,7 @@ pub(crate) fn arith_provably_in_range(
 ) -> bool {
     // The RESULT type's inclusive bounds come from `result` — the op's AUTHORITATIVE machine width/sign
     // (the caller's `Machine`, derived from the ARITH NODE's solved type), NOT from an operand's node
-    // type. ⚠ An operand's node type can be misleading: a bare-literal-branch `if` (`(if c 1 0)`) or a
+    // type. WARNING: An operand's node type can be misleading: a bare-literal-branch `if` (`(if c 1 0)`) or a
     // bare literal is still DEFERRED, and its default (Int64) is WIDER than the op when the true width
     // comes from CONTEXT — `(: (+ (if (< n 5) 100 0) 100) Int8)` is an Int8 op even though both operands'
     // nodes are deferred, and `(- 0 n)` at Int8 is Int8 though the `0` is deferred. Using the op's real
@@ -26051,7 +26051,7 @@ fn is_orderable_compound(db: &mut Db, ty: &crate::ty::Ty) -> bool {
 ///    (collections-and-text.md #Set Iteration Is Deterministic). Bytes/Char/Set/Map stay non-orderable in
 ///    BOTH modes.
 ///
-/// 🔑 `float_ok` applies to a BARE-ROOT float ONLY — it does NOT propagate into a COMPOUND's components. A
+/// KEYSTONE: `float_ok` applies to a BARE-ROOT float ONLY — it does NOT propagate into a COMPOUND's components. A
 /// float leaf INSIDE a tuple/list/record/sum makes the compound un-orderable per 03:626 / §319 (a compound
 /// is ordered EXACTLY WHEN every component offers a TOTAL order, and a float offers only the IEEE partial
 /// order — the canonical-byte order is the enumeration convenience for a bare float, not a blessed total

--- a/implementation/seed/crates/rcdzc/src/prelude.rs
+++ b/implementation/seed/crates/rcdzc/src/prelude.rs
@@ -154,7 +154,7 @@ pub fn install(ast: &mut Arenas) -> BTreeMap<String, StructId> {
     // ---- Units of measure (the optional, compile-time-only dimensional-analysis layer) ----
     // `Unit` — the ground type `Ty::Unit` (registered above with `(meta t) = Unit`) EXTENDED with the
     // unit-BUILDER fields `one` (the dimensionless group identity) and `base` (a base dimension named by
-    // a symbol), reached by member access `(. Unit one)` / `(. Unit base)`. ⚠ `Unit` is BOTH a type (the
+    // a symbol), reached by member access `(. Unit one)` / `(. Unit base)`. WARNING: `Unit` is BOTH a type (the
     // `unit` value's type) AND the units module — a record carries both a `(meta t)` and member fields
     // (exactly as `Bytes`/`String` do), so the two roles coexist and using `Unit` as a type (`(-> Unit
     // Int64)`) still reduces to `Ty::Unit`. This REPLACES the plain ground-type record inserted above
@@ -1330,7 +1330,7 @@ fn symbol_to_string_type(ast: &mut Arenas) -> StructId {
 
 /// The `Unit` module record — the ground type `Ty::Unit` (via `(meta t) = (intrinsic Unit)`, so bare
 /// `Unit` in TYPE position IS `Ty::Unit`, e.g. `(-> Unit Int64)`) EXTENDED with the unit-BUILDER fields
-/// `one` and `base`, reached by member access `(. Unit one)` / `(. Unit base)`. ⚠ `Unit` plays TWO roles
+/// `one` and `base`, reached by member access `(. Unit one)` / `(. Unit base)`. WARNING: `Unit` plays TWO roles
 /// — the `unit` value's TYPE and the units module — which coexist because a record carries both a `(meta
 /// t)` and member fields (exactly as `Bytes`/`String` do; the `Bytes` module proved a `(meta t)` and
 /// member access coexist). `Unit.one` is the dimensionless unit (the group identity); `(Unit.base

--- a/implementation/seed/crates/rcdzc/src/quote.rs
+++ b/implementation/seed/crates/rcdzc/src/quote.rs
@@ -547,7 +547,7 @@ fn reify_active(ast: &mut Arenas, node: StructId, depth: u32) -> Option<StructId
             // runtime type needed. A literal the `Ast` sum has no value variant for (a Char/Sym/Bytes)
             // BAILS (declines honestly).
             //
-            // 🔑 A RUNTIME operand — a `Leaf::Name` (a let-bound var `,n` / a param) or a non-leaf computed
+            // KEYSTONE: A RUNTIME operand — a `Leaf::Name` (a let-bound var `,n` / a param) or a non-leaf computed
             // expression (`,(f x)`) — has an unknown type at reify time (this runs pre-typecheck). Wrap it
             // in the compiler-internal `(ast-lift e)` intrinsic, which `lower` resolves by the operand's
             // INFERRED type: IDENTITY when `e` is already an `Ast` (splice a sub-tree), else wrap in the

--- a/implementation/seed/crates/rcdzc/src/resolve.rs
+++ b/implementation/seed/crates/rcdzc/src/resolve.rs
@@ -6219,7 +6219,7 @@ fn resolve_map(db: &Db, id: StructId) -> Resolved {
 fn resolve_annot(db: &Db, id: StructId) -> Resolved {
     let tail = db.ast.as_form(id, ":").unwrap_or(&[]);
     if tail.len() != 2 {
-        // Name the actual operand count + the canonical form, so the reader sees WHAT is wrong. 🪤 The
+        // Name the actual operand count + the canonical form, so the reader sees WHAT is wrong. TRAP: The
         // phrasing must NOT contain the substring "takes exactly" — that is `diag::EMIT_OPERAND_ARITY_MARKER`,
         // and `dedup_faults` DROPS a `Code::Malformed` fault matching it (+ "operand") as a redundant
         // emit-path operator-arity decline (the `Module.op … were given` consequent-suppression). A message

--- a/implementation/seed/crates/rcdzc/src/sidecar.rs
+++ b/implementation/seed/crates/rcdzc/src/sidecar.rs
@@ -980,7 +980,7 @@ fn closure_hash_text(db: &mut Db) -> String {
 /// (even at different global `StructId`s, since link splices files at an offset) hash the SAME. Independent
 /// of the def's global id and of surrounding files — only its own subtree content.
 ///
-/// ⚠ RUN-STABILITY: every `Name` leaf in the hashed subtrees is desuffixed to its
+/// WARNING: RUN-STABILITY: every `Name` leaf in the hashed subtrees is desuffixed to its
 /// [`crate::layout::source_boundary_name`] (the name before any `$acc`/`#mono{N}` transform suffix) by
 /// `hash_subtree` — both the def's OWN `#mono{N}` head name AND every body reference to a sibling
 /// specialization. A monomorphized specialization mints its name as `{base}#mono{db.defs.len()}`

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -2239,7 +2239,7 @@ fn a_runtime_string_from_bytes_of_ill_formed_bytes_takes_the_none_arm() {
 /// outlives the borrow — nothing freed early), so the value/drop-import tests miss it; only the live-objects
 /// counter sees it (~2 cells/iter). When the escape-analysis increment lands, flip the guard to `== 0`.
 ///
-/// ⚠ HISTORY: this was `..._leaks_no_more_than_the_twin_option_builder`, a DIFFERENTIAL against a `Bytes.at`
+/// WARNING: HISTORY: this was `..._leaks_no_more_than_the_twin_option_builder`, a DIFFERENTIAL against a `Bytes.at`
 /// twin — but that twin's `Some` payload is a SCALAR byte value (Int64) that scalar-shell + owned-temporary
 /// reclaim later drove to 0, while this COMPOUND `Some(String)` still leaks the gap → the `==` went stale
 /// (decode=10 vs scalar-twin=0 at k=5). A COMPOUND twin (`Bytes.slice → Some(Bytes)`) doesn't rescue it
@@ -5018,7 +5018,7 @@ fn perceus_balance_leaves_no_live_objects() {
         );
         return;
     };
-    // ⚠ The tuple must hold a RUNTIME HEAP value (a recursively-built list), else the whole tuple
+    // WARNING: The tuple must hold a RUNTIME HEAP value (a recursively-built list), else the whole tuple
     // scalarizes/const-folds away with NO heap alloc and the program no longer imports the runtime — the
     // probe then can't run (this staleness broke the earlier bare-scalar-tuple form). `pair-sum(3, 22)`
     // builds `[0,1,2]`, wraps it in `(tuple list 22)`, projects `List.len list` (3) + `22` = 25, then drops
@@ -5539,7 +5539,7 @@ fn non_final_dependent_size_bin_match_reads_leave_no_live_objects() {
 /// `option_expect_over_an_owned_some_shell_leaves_no_live_objects`, which nets to 0) — the differentiator is
 /// purely the compound payload. This witness pins the String face; the Map-value/List-of-lists faces share it.
 ///
-/// ⚠ This asserts the VALUE is right + documents the leak as a KNOWN residual (NOT `== 0`): the sound fix
+/// WARNING: This asserts the VALUE is right + documents the leak as a KNOWN residual (NOT `== 0`): the sound fix
 /// needs a NODE-KEYED "does this SumExpect's extracted payload ESCAPE its consumer" analysis (the existing
 /// `binding_escapes` is BINDER-keyed and does not answer this), so the shell can be dropped after the last
 /// borrow ONLY when the payload does not flow out. MEASURED to need THREE pieces (see the vertical log):
@@ -5767,7 +5767,7 @@ fn a_recursive_fn_holding_a_borrowed_string_payload_sum_param_leaks_one_cell_kno
 /// (`List.at`/`Map.lookup` → `Option Int64`, all-scalar payloads) builds a fresh `sum-new` Some/None shell;
 /// consuming it with a `match` used to LEAK that shell (arms only borrow the scrutinee; nothing dropped an
 /// owned one) — one heap cell PER CALL, value-correct so value/drop-import tests missed it. Driven through a
-/// LOOP so a per-call leak SCALES past the benign entrypoint-return temporary. ⚠ The MUST-NOT-REGRESS
+/// LOOP so a per-call leak SCALES past the benign entrypoint-return temporary. WARNING: The MUST-NOT-REGRESS
 /// counterexample is the HOL-kernel `term-eq (Comb x y)`: a scalar-Bool-result match whose arms bind
 /// COMPOUND payload handles (`x`/`y`) borrowed from the shell and thread them into a recursive walk that
 /// reads them AFTER the match — a scalar-RESULT gate would free the shell there → OOB/UAF. The all-scalar-
@@ -7211,7 +7211,7 @@ fn set_to_list_of_an_empty_set_folds_to_the_empty_list() {
     }
 }
 
-/// ⚠ SOUNDNESS regression (breaker #43, routed 2026-07-29): ordering an ALL-NULLARY sum (every variant
+/// WARNING: SOUNDNESS regression (breaker #43, routed 2026-07-29): ordering an ALL-NULLARY sum (every variant
 /// payload-free — a user `(type Tri (Lo)(Mid)(Hi))`, `Sign`, `Ordering` itself) mis-lowered on wasm. An
 /// all-nullary sum is an ENUM-DISC: a BARE i32 discriminant with NO heap box. But `<`/`>`/`compare` routed
 /// it to `Core::ValueCmp` (the runtime `value-cmp` heap walk, since an all-nullary `Ty::Sum` passes
@@ -8588,7 +8588,7 @@ fn map_or_set_to_list_result_over_a_borrowed_source_reclaims_the_fresh_list() {
 /// which a `(List Int64)` payload fails, so `reclaim_shell` is false and the owned `Box.Wrap` shell is left
 /// un-dropped. Even though this shape is SOUND to reclaim (the child is borrowed + non-escaping, contrast
 /// `((Mk a _) (Mk a a))` whose child flows into the returned ctor), the conservative all-scalar floor blocks it.
-/// ⚠ CRITICAL — the scrutinee `(mk n)` takes a RUNTIME param `n`: with a CONSTANT `(mk 3)` the whole
+/// WARNING: CRITICAL — the scrutinee `(mk n)` takes a RUNTIME param `n`: with a CONSTANT `(mk 3)` the whole
 /// `(if (< 3 0) …)` + 2-arm match CONST-FOLD to the `Wrap` arm, the `MatchSum` is eliminated, no shell is built,
 /// and the probe spuriously reads 0 (masking the leak — the exact `build 0 …` const-fold flaw PR#719/Copilot
 /// caught in the set-algebra probe). A runtime `n` forces the real `MatchSum` emit + reclaim gate (traced:
@@ -8638,7 +8638,7 @@ fn a_borrow_only_compound_payload_match_shell_known_gap() {
     );
 }
 
-/// ⚠ UAF GUARD (the `implementation/cad` snowflake miscompile a rejected shell-reclaim shipped, minimized to a
+/// WARNING: UAF GUARD (the `implementation/cad` snowflake miscompile a rejected shell-reclaim shipped, minimized to a
 /// lib probe): an owned COMPOUND-payload sum whose child is a COMPOUND (`hi : V`) BORROWED OUT of the shell
 /// via a nested match — `(match (mk n) ((Box.Bx lo hi) (match hi ((V.V3 a b c) …))))` — with a SCALAR final
 /// result. The extracted `hi` ALIASES INTO the `Box.Bx` shell (it is not copied — a `sum-payload`/`arr-get`
@@ -8898,7 +8898,7 @@ fn an_exported_float_op_runs_over_runtime_args() {
     }
 }
 
-/// ⚠ INVALID WASM regression: a Float32 arithmetic op with a bare float LITERAL operand mis-emitted
+/// WARNING: INVALID WASM regression: a Float32 arithmetic op with a bare float LITERAL operand mis-emitted
 /// the literal at its Float64 default (an `f64.const` beside an `f32.add`) — `wasm-tools` rejected the
 /// module ("expected f32, found f64"). This hit TRIVIAL, idiomatic code (`(+ x 1.0)` over a Float32
 /// `x` — the ONE arithmetic operator dispatched to float by operand type), the float analogue of the
@@ -15552,7 +15552,7 @@ mod runtime_ops {
         // `value_range` of a `Core::If`/`Core::Match` is the UNION of its branch ranges, so a
         // bool-materialized `(if c 1 0)` is [0,1] and `(if c 10 20)` is [10,20]. That lets a downstream
         // checked op shed a dead overflow guard: `(* bool C)` ∈ [0,C] and `(+ (if c 10 20) 5)` ∈ [15,25]
-        // cannot overflow their (wide) type. ⚠ Soundness rests on using the OP's authoritative width for
+        // cannot overflow their (wide) type. WARNING: Soundness rests on using the OP's authoritative width for
         // the fit-check, NOT a deferred operand's default: a genuinely-narrow op whose branches overflow
         // (`(: (+ (if (< n 5) 100 0) 100) Int8)` → up to 200) MUST keep its guard.
         use crate::backend::wasm::lir::Lir;
@@ -17731,7 +17731,7 @@ mod runtime_ops {
         // VARIABLE to a checked-arith node that (a) reads a refined var and (b) is PROVABLY-NO-OVERFLOW in
         // this flow context. Under `(and (>= x 0) (< x 10))` (x ∈ [0,9]), `(+ x 1) ∈ [1,10]` cannot overflow,
         // so `(< (+ x 1) 11)` is provably TRUE and folds away — dropping the checked `(+ x 1)` is trap-SAFE
-        // because it can't overflow here. 🪤 SOUNDNESS: the fold DISCARDS `(+ x 1)`; a checked `+` is not
+        // because it can't overflow here. TRAP: SOUNDNESS: the fold DISCARDS `(+ x 1)`; a checked `+` is not
         // is_trap_free, so it may fold ONLY when provably_no_overflow holds under the refinement — else the
         // discard would drop a reachable overflow trap. The soundness twin below pins that an
         // overflow-CAPABLE arith operand does NOT fold (the trap must survive).
@@ -17845,7 +17845,7 @@ mod runtime_ops {
 
     #[test]
     fn a_narrow_binary_op_with_a_constant_left_operand_emits_valid_wasm() {
-        // ⚠ INVALID WASM regression: a narrow binary op whose LEFT operand is a bare integer literal and
+        // WARNING: INVALID WASM regression: a narrow binary op whose LEFT operand is a bare integer literal and
         // whose right is a narrow-typed variable mis-emitted the literal at its i64 default beside the i32
         // variable ("expected i64, found i32"). ROOT: `unify_width`/`unify_sign` BOUND the operator's
         // shared width/sign VARIABLE to the deferred LEFT literal first, freezing it, so the RIGHT
@@ -18104,7 +18104,7 @@ mod runtime_ops {
 
     #[test]
     fn a_control_flow_operand_of_a_narrow_op_is_width_normalized_to_the_op() {
-        // ⚠ INVALID WASM regression: when an `if`/`match`/`let` is an OPERAND of a NARROW arith/bitwise op
+        // WARNING: INVALID WASM regression: when an `if`/`match`/`let` is an OPERAND of a NARROW arith/bitwise op
         // and its branches are bare deferred-width literals, the control-flow node types as its own join
         // (Int64 = an i64 slot) while the enclosing op emits at the narrow width (an i32 slot). The i64
         // operand fed the i32 op and wasm REJECTED the module ("expected i32, found i64"). Unlike a DIRECT
@@ -18226,7 +18226,7 @@ mod runtime_ops {
 
     #[test]
     fn a_nested_narrow_arith_with_control_flow_operands_takes_the_consuming_width() {
-        // ⚠ INVALID WASM regression: a NESTED narrow `+`/`-`/`*` whose operands are all deferred-width
+        // WARNING: INVALID WASM regression: a NESTED narrow `+`/`-`/`*` whose operands are all deferred-width
         // (`(+ (+ (if c 1 2) (if d 3 4)) 5) : Int8`) types as `Int(Deferred)` and was emitted at the i64
         // DEFAULT — storing an i64 result into the i32 slot the enclosing narrow op declared → wasm
         // rejected the module. The c78 leaf-operand wrap did NOT cover this (the inner op goes through
@@ -20872,7 +20872,7 @@ mod runtime_ops {
 
     #[test]
     fn a_63_bit_wide_range_does_not_overflow_the_range_lattice() {
-        // ⚠ REGRESSION (compiler panic in a CHECKED build): the range lattice computed `(1i64 << bits) - 1`
+        // WARNING: REGRESSION (compiler panic in a CHECKED build): the range lattice computed `(1i64 << bits) - 1`
         // at several sites, but at `bits == 63` the shift `1i64 << 63` is `i64::MIN`, so `− 1` OVERFLOWS
         // (a debug/`release-debug` panic; release silently wrapped to the correct i64::MAX). A `UInt64 >> 1`
         // has range `[0, 2^63-1]` (bits = 64 − 1 = 63) — the `Shr` arm's type-width bound — so ANY program
@@ -21130,7 +21130,7 @@ mod recursion {
 
     #[test]
     fn a_row_op_over_a_map_borne_record_dups_its_borrowed_heap_field_before_the_operand_drop() {
-        // ⚠ USE-AFTER-FREE regression (breaker #45, routed 2026-07-29): `Record.extend` chained onto
+        // WARNING: USE-AFTER-FREE regression (breaker #45, routed 2026-07-29): `Record.extend` chained onto
         // `Record.without` of a record READ OUT OF A MAP (a CHAMP value) trapped "out of bounds memory
         // access" (or silently returned a wrong value one wrap deeper). Root: the runtime row-op builds its
         // result by copying each kept field via a BORROWING `arr-get` (no rc++) off the operand `r`, then
@@ -21187,7 +21187,7 @@ mod recursion {
 
     #[test]
     fn a_row_op_over_a_borrowed_sum_payload_record_does_not_drop_the_borrowed_operand() {
-        // ⚠ USE-AFTER-FREE regression (breaker #45 WITNESS-2, the sum-payload-rewrap face — DISTINCT from
+        // WARNING: USE-AFTER-FREE regression (breaker #45 WITNESS-2, the sum-payload-rewrap face — DISTINCT from
         // witness 1's owned-map-lookup operand): a row op over a record `r` bound by a `(Slot.Filled r)`
         // MATCH ARM — where `r` is a `Core::SumPayload` BORROW of the scrutinee — had its materialize-`Let`
         // spuriously DROP `r` (an unconditional `kept_bindings` mark → escape-gated Let-drop, which assumed
@@ -21790,7 +21790,7 @@ mod recursion {
 
     #[test]
     fn an_i64_br_table_switch_reserves_its_index_slot_above_arm_body_scratch() {
-        // ⚠ INVALID WASM regression (routed corpus-bugfix/breaker 2026-07-27): a dense integer `if`-chain
+        // WARNING: INVALID WASM regression (routed corpus-bugfix/breaker 2026-07-27): a dense integer `if`-chain
         // over an i64 scrutinee lowers to a `br_table` (fires at ≥4 arms), which materializes the shifted
         // dispatch index `scrutinee - min` into a scratch slot for the wrap-aliasing bounds guard. That
         // i64 idx slot was claimed at `base` — the SAME slot the arm bodies' scratch reuses. A
@@ -21838,7 +21838,7 @@ mod recursion {
 
     #[test]
     fn set_to_list_over_a_float_containing_compound_declines_not_silently_empties() {
-        // ⚠ SILENT-DATA-LOSS regression (routed corpus-bugfix/breaker 2026-07-28): `Set.to-list` over a
+        // WARNING: SILENT-DATA-LOSS regression (routed corpus-bugfix/breaker 2026-07-28): `Set.to-list` over a
         // FLOAT-LEAF TUPLE element ran to an EMPTY list on wasm (Set.len correct but to-list []), silently
         // dropping every element — worse than a decline (a fold over the enumeration processes NOTHING).
         // Root: `orderable_leaf_or_compound` propagated its `float_ok` (the bare-float-root to-list mode)
@@ -21881,7 +21881,7 @@ mod recursion {
 
     #[test]
     fn a_str_slice_floats_each_bound_operand_above_the_prior_high_water() {
-        // ⚠ INVALID WASM regression (routed corpus-bugfix/breaker 2026-07-28, sibling of the br_table fix
+        // WARNING: INVALID WASM regression (routed corpus-bugfix/breaker 2026-07-28, sibling of the br_table fix
         // `4f9658803` — same "expected i32, found i64" validator signature, DIFFERENT seam): the
         // `String.slice` emit reserved scratch `base..base+6` then emitted its `start`/`end` bound operands
         // at a FIXED `base + 7`. When `start` is a checked-arith (`(+ i 1)`, whose i64 `$r` transient claims a
@@ -21926,7 +21926,7 @@ mod recursion {
 
     #[test]
     fn a_heap_match_composed_with_checked_arith_uses_disjoint_scratch_slots() {
-        // ⚠ INVALID WASM regression: a recursive body composing a heap-`match` result (an inlined
+        // WARNING: INVALID WASM regression: a recursive body composing a heap-`match` result (an inlined
         // `byte-at` → `Bytes.at` MatchSum materializing an i32 Option handle in a scratch slot) with
         // checked ARITHMETIC over another helper's result (`(* (byte-at b i) (place …))`, whose overflow
         // guards use i64 scratch slots) emitted an invalid module ("expected i64, found i32"): the i32
@@ -31628,7 +31628,7 @@ mod match_engine {
             None,
             "a well-typed nullary member is not falsely rejected"
         );
-        // 🔑 REGRESSION GUARD: a nullary member body that references a SIBLING (an effect `log`, a sibling
+        // KEYSTONE: REGRESSION GUARD: a nullary member body that references a SIBLING (an effect `log`, a sibling
         // def) resolves through the module's in-scope context — the standalone type-check must NOT report
         // that sibling as `Unbound` (CDZ0101). Such a member (performing a sibling effect via `host`)
         // compiles clean; the member-body check drops a standalone `Unbound` for exactly this reason.
@@ -31708,7 +31708,7 @@ mod match_engine {
                 "a cross-module member call returns the callee's value"
             );
         }
-        // 🔑 DEFINITION-SITE preserved: `lib`'s own literal `42` keeps `lib`'s scope (Int64), NOT `app`'s
+        // KEYSTONE: DEFINITION-SITE preserved: `lib`'s own literal `42` keeps `lib`'s scope (Int64), NOT `app`'s
         // `default-integer BigInt` — the record chains to where `lib` was WRITTEN, not to the caller. So
         // the result is Int64 (a BigInt would render/type differently); this compiles clean as Int64.
         assert_eq!(
@@ -36012,7 +36012,7 @@ mod match_engine {
 
     #[test]
     fn a_self_tail_call_with_a_heap_match_argument_emits_valid_wasm() {
-        // ⚠⚠ REGRESSION: a self-tail-recursive accumulator whose self-call passes a `match` over a HEAP
+        // WARNING:WARNING: REGRESSION: a self-tail-recursive accumulator whose self-call passes a `match` over a HEAP
         // value (Option) as an ARGUMENT emitted a STRUCTURALLY INVALID wasm module ("expected i32, found
         // i64"). The self-tail-loop lowering pushes all args onto the operand stack simultaneously (the
         // parallel move into the param slots), yet each arg was emitted at the same scratch `base`: arg 0
@@ -36064,7 +36064,7 @@ mod match_engine {
 
     #[test]
     fn a_collection_carrying_recursion_with_a_fallible_base_read_emits_valid_wasm() {
-        // ⚠ REGRESSION (the `if`-BRANCH face of the i32/i64 scratch-slot family): a self-recursive function
+        // WARNING: REGRESSION (the `if`-BRANCH face of the i32/i64 scratch-slot family): a self-recursive function
         // CARRYING a heap collection whose BASE arm materializes a fallible-read Option HANDLE emitted a
         // STRUCTURALLY INVALID module ("expected i32, found i64"). The `if`'s two branches are mutually
         // exclusive, so the emit reused one scratch slot index across them — but the base arm wants it as an
@@ -36421,7 +36421,7 @@ mod match_engine {
 
     #[test]
     fn bytes_at_of_a_runtime_element_widens_the_byte_to_the_option_payload() {
-        // ⚠ INVALID WASM regression: `(Bytes.at (Bytes.of (list n)) 0)` with `n : UInt8` a RUNTIME element,
+        // WARNING: INVALID WASM regression: `(Bytes.at (Bytes.of (list n)) 0)` with `n : UInt8` a RUNTIME element,
         // read at a CONSTANT index, mis-emitted. The `Bytes.at` fold saw a `Core::BytesOf` + constant
         // index and used the raw element occurrence as the `Some` payload — correct for a CONSTANT byte
         // (its core folds through the width), but a runtime `UInt8` element is an i32 value placed into the
@@ -38675,7 +38675,7 @@ mod match_engine {
         // returns a NEW owned list (persistence), exactly like `List.concat`/`List.update` — so a borrowing
         // op over an owned-temporary push RESULT (`List.len (List.push (build …) x)`) must reclaim it or it
         // leaks one vector per call. It was NOT in the Owned classifier, so it leaked (0 drops). Fix
-        // classifies `Core::ListPush` Owned. ⚠ THE DELICATE PART: `List.push` is the FBIP ACCUMULATOR path —
+        // classifies `Core::ListPush` Owned. WARNING: THE DELICATE PART: `List.push` is the FBIP ACCUMULATOR path —
         // classifying it Owned must NOT perturb `(build i n (List.push acc i))`, where the push is the
         // RECURSION TAIL (never a borrowing-op operand, so its ownership is never consulted → the
         // single-consume fast path + alloc bench are untouched), and must NOT double-free a BORROWED/shared
@@ -38850,7 +38850,7 @@ mod match_engine {
     #[test]
     fn set_contains_and_map_lookup_over_an_owned_temporary_reclaim_the_collection() {
         // The last READ-op faces: `Set.contains`/`Map.lookup` over an owned-temporary collection must
-        // reclaim it. ⚠ Map.lookup is DELICATE — the looked-up value is borrowed from the map and dup'd in
+        // reclaim it. WARNING: Map.lookup is DELICATE — the looked-up value is borrowed from the map and dup'd in
         // the Some arm, so the owned-map drop must come AFTER that dup (not right after map-lookup, which
         // would free the value → UAF). Both drive a stress loop building a fresh collection each iteration:
         // if the collection leaked or was double-freed, the value would drift or the run would trap.
@@ -40060,7 +40060,7 @@ mod match_engine {
 
     #[test]
     fn a_list_arm_head_survives_a_sibling_rest_binders_consuming_slice() {
-        // ⚠ MISCOMPILE REGRESSION: a `(list x .. rest)` arm binds the head `x` via `vec-get` (BORROWS the
+        // WARNING: MISCOMPILE REGRESSION: a `(list x .. rest)` arm binds the head `x` via `vec-get` (BORROWS the
         // shared arm handle) AND the tail `rest` via `vec-drop` (CONSUMES it). If the `vec-drop` runs while
         // the handle still has a live head read pending — as in a TAIL fold `(f rest (+ acc x))`, where the
         // recursive call's arg 0 (`rest`, the consuming slice) is emitted before arg 1 reads `x` — the
@@ -42091,7 +42091,7 @@ mod match_engine {
 
     #[test]
     fn a_guarded_map_arm_over_a_partial_const_map_resolves_its_value_binder_in_guard_and_body() {
-        // ⚠ INVALID-ARTIFACT regression (v-patterns self-probe, both backends): a GUARDED map arm whose
+        // WARNING: INVALID-ARTIFACT regression (v-patterns self-probe, both backends): a GUARDED map arm whose
         // LOOKED-UP key's value is a compile-time CONSTANT while the map as a whole is RUNTIME (another key
         // holds a dynamic value) — `(Map.insert (Map.insert Map.empty 1 5) 2 n)` — with the guard cond AND
         // the body BOTH reading the value binder `v` emitted `CDZ0101 unbound v` + an invalid module.
@@ -45646,7 +45646,7 @@ mod match_engine {
 
     #[test]
     fn two_equalities_to_different_constants_do_not_subsume() {
-        // ⚠ MISCOMPILE REGRESSION: the same-direction subsumption fold keyed on "same operator", which
+        // WARNING: MISCOMPILE REGRESSION: the same-direction subsumption fold keyed on "same operator", which
         // wrongly included `Eq` — so `(and (= x 5) (= x 6))` was "subsumed" to `(= x 6)` (returns 1 at x=6),
         // but the correct value is ALWAYS FALSE (x cannot equal both 5 and 6). `Eq` does NOT subsume: two
         // equalities to DIFFERENT constants are a contradiction under `and` and a 2-point set under `or` —
@@ -52290,7 +52290,7 @@ mod diagnostics {
     fn a_wrong_arity_type_annotation_names_the_operand_count_at_every_arity() {
         // A type annotation is `(: <expression> <type>)` — exactly two operands. A malformed arity (`(: 5)`,
         // `(: 5 Int64 foo)`, `(:)`) now names the actual count instead of the flat "takes an expression and
-        // a type". 🪤 REGRESSION GUARD: the message must NOT contain the substring "takes exactly" — that is
+        // a type". TRAP: REGRESSION GUARD: the message must NOT contain the substring "takes exactly" — that is
         // `diag::EMIT_OPERAND_ARITY_MARKER`, and `dedup_faults` DROPS a `Code::Malformed` fault matching it
         // (+ "operand") as a redundant emit-path operator-arity decline. An earlier wording ("takes exactly 2
         // operands") collided with that filter and was SILENTLY DROPPED for the 0- and 3-operand cases (the
@@ -64472,7 +64472,7 @@ mod stage1 {
     /// yet reducible by the tail-resumptive fold" feature-decline (too many) — neither said the parameter
     /// count is wrong. `arm_param_arity_mismatch` names the operation and the expected/actual counts, and
     /// its `HANDLER_ARM_ARITY_MARKER` makes `dedup_faults` drop the consequent fold-decline so it is ONE
-    /// primary error. ⚠ The ELIDED-UNIT convention is honored: a `(-> Unit R)` op accepts BOTH a 0-binder
+    /// primary error. WARNING: The ELIDED-UNIT convention is honored: a `(-> Unit R)` op accepts BOTH a 0-binder
     /// (`(op () s …)`) and a 1-binder (`(op (u) s …)`) arm — the corpus uses both — so only an arm outside
     /// `{0, 1}` for a unit op is a mismatch; a genuine N-parameter op requires exactly N.
     #[test]
@@ -70758,7 +70758,7 @@ mod stage1 {
 
     #[test]
     fn a_const_collection_recursively_folded_rejects_rather_than_hanging() {
-        // 🔴 MISCOMPILE GUARD: a `const` COLLECTION param consumed by a SELF-RECURSIVE fold used to compile
+        // SAFETY: MISCOMPILE GUARD: a `const` COLLECTION param consumed by a SELF-RECURSIVE fold used to compile
         // to an INFINITE LOOP — the const erasure and the tail-loop transform composed to emit a
         // `loop { … br 0 }` with no exit test (the `(list)`-nil / length check was const-folded away). A
         // valid program HUNG. `type_specialize` now DECLINES the composition (decline-don't-miscompile),
@@ -73591,7 +73591,7 @@ mod stage1 {
 
     #[test]
     fn an_all_nullary_enum_nested_in_a_boxed_sum_round_trips() {
-        // ⚠ INVALID WASM regression: an all-nullary enum (a bare i32 disc) NESTED inside a boxed sum
+        // WARNING: INVALID WASM regression: an all-nullary enum (a bare i32 disc) NESTED inside a boxed sum
         // (`(Option Color)`) mis-emitted both ends: (1) construction `box-int`ed the i32 disc WITHOUT the
         // i64 extend (i32 → the i64 box-int → wasm rejects); (2) the match's disc read used `sum-disc` on
         // the boxed-int handle instead of `get-int` + wrap, because `sum_single_payload_ty` returned the
@@ -73635,7 +73635,7 @@ mod stage1 {
 
     #[test]
     fn an_all_nullary_enum_reached_through_a_tuple_element_in_a_boxed_sum_round_trips() {
-        // ⚠ INVALID WASM regression (residual of the direct-in-sum fix above): an all-nullary enum (a bare
+        // WARNING: INVALID WASM regression (residual of the direct-in-sum fix above): an all-nullary enum (a bare
         // i32 disc) as a TUPLE ELEMENT inside a boxed sum — `(Some (tuple (Blue) 5))` — mis-emitted the
         // READ end: projecting the enum element `get-int`s the i64 cell but SKIPPED the i64→i32 narrow
         // (the wrap fired only for `is_narrow_int`, which excludes an enum-disc `Ty::Sum`), leaving an i64
@@ -74361,7 +74361,7 @@ mod stage1 {
 
     #[test]
     fn a_capturing_closure_stored_and_also_directly_called_is_force_kept() {
-        // ⚠ INVALID-ARTIFACT regression (breaker adv-50, both backends): a CAPTURING `let`-bound lambda
+        // WARNING: INVALID-ARTIFACT regression (breaker adv-50, both backends): a CAPTURING `let`-bound lambda
         // whose HANDLE ESCAPES WHOLE (stored into a heap collection / sum payload) AND is ALSO DIRECTLY
         // CALLED emitted a broken artifact — wasm `invalid component … wasm[0]::function[N]`, rust
         // `error[E0425]: cannot find value __cap0`. Mechanism: the store lowers `f1` as a value
@@ -95027,7 +95027,7 @@ mod cross_component_oracle {
     // was untested e2e (U5d built a list peer but did not run a source consumer reading it). A List
     // crosses as its u32 handle; `List.len` reads it over the shared runtime. main(7) = len([7,7,7]) = 3.
     //
-    // ⚠ KNOWN GAP (filed: queue/peerbug-list-at-of-peer-returned-list-declines…): reading an ELEMENT of
+    // WARNING: KNOWN GAP (filed: queue/peerbug-list-at-of-peer-returned-list-declines…): reading an ELEMENT of
     // a peer-returned list with `List.at` currently DECLINES ("peer-bound effect op is not in the
     // extern-import set") — a safe compile error, not a miscompile, on the emit/reclamation seam. This
     // test pins the WORKING half (length read) so the collection-result path has coverage while the
@@ -95391,7 +95391,7 @@ mod cross_component_oracle {
     // resulting `Option` down to a scalar the entrypoint returns. main(7) = match (List.at [8,9] 0) →
     // Some 8 → 8. This WORKS and is worth pinning.
     //
-    // ⚠ THE BOUNDARY (root-caused this tick, filed queue/peerbug-list-at-of-peer-returned-list-declines…):
+    // WARNING: THE BOUNDARY (root-caused this tick, filed queue/peerbug-list-at-of-peer-returned-list-declines…):
     // if the entrypoint RETURNS the raw `Option` (i.e. `List.at` IS the whole body), the export escapes a
     // compound RESULT via `emit_runtime_resource`, which does NOT thread the peer extern-import set (never
     // calls `with_extern_order`) → the peer op declines "not in the extern-import set". So the gap is NOT


### PR DESCRIPTION
Candidate PR for v-fleet-tooling's merge-request (ref 79a22f38dfa125b25db855d9fd9d2e6dc7afebdd, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.