### PR TITLE
syntax: cadenza-docs I1a — doc-item model + structural projection (doc-module doc-AST)

### DIFF
--- a/implementation/seed/crates/cadenza-syntax/src/doc_item.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/doc_item.rs
@@ -1,0 +1,229 @@
+//! The doc-item projection — a program's public surface projected into a DERIVED doc-AST.
+//!
+//! `cadenza doc` (design/DESIGN-cadenza-docs.md, increment I1): fold a program's canonical [`Arenas`]
+//! into a `doc-module` construct — a rustdoc-like structured index that is ITSELF a `cdzast` value, so
+//! every existing AST surface (reader/printer, sexpr/ML, the codec, the metaprog `Ast`) applies to it
+//! uniformly. This is the STRUCTURAL half (increment I1, operator decision 9.1 = purely-syntactic):
+//! it needs no types — it reads the `(doc …)` / `(module-doc …)` nodes the parser already splices
+//! (`parser::take_docs_here`), the item's head `(name …)`, and a printed `(sig …)` via the ML
+//! printer. The RESOLVED `(ty …)` is increment I2's job (post-typecheck, in `rcdzc`) — this pass
+//! deliberately does NOT depend on inference, so it runs off the parser alone (a syntax-only doc
+//! outline / IDE symbol list needs no typecheck).
+//!
+//! The projected shape (all NEW HEAD NAMES — never a new [`Struct`]/[`Leaf`] variant, honoring the
+//! frozen 2-variant `Struct` + keywords-are-data):
+//! ```text
+//! (doc-module "<module-name>"
+//!   (module-doc "…top-of-module prose…")?          ; 0-or-1, from leading (module-doc …) siblings
+//!   (doc-item
+//!     (name "map")
+//!     (sig  "map(f, xs) = …")                       ; printed display signature (syntactic)
+//!     (doc  "Applies f to each element."))?          ; 0-or-1 (doc …), concatenated item prose
+//!   (doc-item …)…)
+//! ```
+//! A `doc-module` is `cdzast`: it canonicalizes, encodes to `\x00\x01`, and round-trips through
+//! sexpr/ML — the same bijection every other arena has (see the round-trip tests).
+//!
+//! PUBLIC surface only: an item appears iff its name is `export`ed by the program (design §8 — v1
+//! extracts the public surface; a later pass can carry `(visibility …)` to include internals).
+
+use crate::ast::{Arenas, Builder, Leaf, StructId};
+use std::collections::BTreeSet;
+
+/// Project a program's canonical `Arenas` into a `doc-module` doc-AST, named `module_name`.
+///
+/// Walks the program's top-level forms: each exported `def`/`type`/`effect` becomes a `doc-item`
+/// (name + printed syntactic signature + concatenated `(doc …)` prose); leading `(module-doc …)`
+/// siblings become the module's `(module-doc …)`. The result is a fresh, canonical-ready `Arenas`
+/// rooted at the `doc-module` node — ready to `encode`, `canonicalize`, or print.
+pub fn project(program: &Arenas, module_name: &str) -> Arenas {
+    let forms = top_level_forms(program);
+    let exported = exported_names(program, &forms);
+
+    let mut b = Builder::new();
+    let mut children = vec![
+        b.name("doc-module"),
+        b.atom_leaf(Leaf::Str(module_name.to_string())),
+    ];
+
+    // Module-doc: concatenate every top-level `(module-doc "…")` sibling's text (in source order).
+    let module_doc = collect_doc_text(program, forms.iter().copied(), "module-doc");
+    if let Some(text) = module_doc {
+        let head = b.name("module-doc");
+        let t = b.atom_leaf(Leaf::Str(text));
+        let node = b.list(vec![head, t]);
+        children.push(node);
+    }
+
+    // One `doc-item` per exported def/type/effect, in source order.
+    for &form in &forms {
+        let Some((kind, name)) = item_kind_and_name(program, form) else {
+            continue;
+        };
+        if !exported.contains(name) {
+            continue;
+        }
+        let item = build_doc_item(&mut b, program, form, kind, name);
+        children.push(item);
+    }
+
+    let root = b.list(children);
+    b.finish(root)
+}
+
+/// The head names this pass treats as a documentable item, paired with how to read the item's name.
+/// `def`'s name is either a bare `(name …)` (value def) or the head of a `(name p…)` sig list
+/// (function def); `type`/`effect` name it directly as their first argument.
+fn item_kind_and_name(program: &Arenas, form: StructId) -> Option<(&'static str, &str)> {
+    for (head, kind) in [("def", "def"), ("type", "type"), ("effect", "effect")] {
+        if let Some(args) = program.as_form(form, head) {
+            let name = item_name(program, kind, args)?;
+            return Some((kind, name));
+        }
+    }
+    None
+}
+
+/// Read an item's public name from its form arguments.
+/// - `def`: arg 0 is either an `Atom(Name)` (value def `(def name … value)`) or a `List` whose head is
+///   the name (function def `(def (name p…) … body)`).
+/// - `type` / `effect`: arg 0 is the `Atom(Name)` naming the declaration.
+fn item_name<'a>(program: &'a Arenas, kind: &str, args: &[StructId]) -> Option<&'a str> {
+    let first = *args.first()?;
+    match kind {
+        "def" => program.as_name(first).or_else(|| program.head_name(first)),
+        _ => program.as_name(first),
+    }
+}
+
+/// Build one `(doc-item (name "…") (sig "…") (doc "…")?)` node into `b`. `sig` is the item's WHOLE
+/// form printed via the ML printer (the syntactic signature as written — a def's params + a value
+/// body's shape, a type/effect's decl); `doc` is the concatenated leading `(doc …)` prose, omitted
+/// when the item carries none.
+fn build_doc_item(
+    b: &mut Builder,
+    program: &Arenas,
+    form: StructId,
+    _kind: &str,
+    name: &str,
+) -> StructId {
+    let mut item = vec![b.name("doc-item")];
+
+    // (name "…")
+    let name_head = b.name("name");
+    let name_val = b.atom_leaf(Leaf::Str(name.to_string()));
+    let name_node = b.list(vec![name_head, name_val]);
+    item.push(name_node);
+
+    // (sig "…") — the item form printed to a display string (syntactic signature).
+    let sig_head = b.name("sig");
+    let sig_val = b.atom_leaf(Leaf::Str(print_subtree(program, form)));
+    let sig_node = b.list(vec![sig_head, sig_val]);
+    item.push(sig_node);
+
+    // (doc "…") — the item's own leading `(doc …)` children, concatenated; omitted if none.
+    let item_children = match program.get(form) {
+        crate::ast::Struct::List(kids) => kids.as_slice(),
+        crate::ast::Struct::Atom(_) => &[],
+    };
+    if let Some(text) = collect_doc_text(program, item_children.iter().copied(), "doc") {
+        let doc_head = b.name("doc");
+        let doc_val = b.atom_leaf(Leaf::Str(text));
+        let doc_node = b.list(vec![doc_head, doc_val]);
+        item.push(doc_node);
+    }
+
+    b.list(item)
+}
+
+/// Concatenate the text of every `(<head> "text")` node among `nodes` (in order), joined by newlines.
+/// Returns `None` if there are none (so the caller can omit an empty `(doc …)`/`(module-doc …)`).
+fn collect_doc_text(
+    program: &Arenas,
+    nodes: impl Iterator<Item = StructId>,
+    head: &str,
+) -> Option<String> {
+    let mut texts: Vec<&str> = Vec::new();
+    for id in nodes {
+        if let Some(args) = program.as_form(id, head)
+            && let Some(&text_id) = args.first()
+            && let Some(s) = program.as_str(text_id)
+        {
+            texts.push(s);
+        }
+    }
+    if texts.is_empty() {
+        None
+    } else {
+        Some(texts.join("\n"))
+    }
+}
+
+/// The top-level forms of a program: the children of a top-level `(do …)`, or the single root form
+/// when the program is one form (not wrapped in a `do`).
+fn top_level_forms(program: &Arenas) -> Vec<StructId> {
+    if let Some(items) = program.as_form(program.root, "do") {
+        items.to_vec()
+    } else {
+        vec![program.root]
+    }
+}
+
+/// The set of names the program `export`s — the public surface. An `(export a b …)` form lists the
+/// exported names as `Atom(Name)` children; a program may carry more than one export form.
+fn exported_names<'a>(program: &'a Arenas, forms: &[StructId]) -> BTreeSet<&'a str> {
+    let mut out = BTreeSet::new();
+    for &form in forms {
+        if let Some(args) = program.as_form(form, "export") {
+            for &arg in args {
+                if let Some(n) = program.as_name(arg) {
+                    out.insert(n);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Print the subtree rooted at `id` to a display string via the ML printer. The printer prints a whole
+/// `Arenas`, so extract `id`'s subtree into a fresh dense arena first, then print that.
+fn print_subtree(program: &Arenas, id: StructId) -> String {
+    let sub = extract_subtree(program, id);
+    crate::printer::print_display(&sub, crate::printer::DEFAULT_WIDTH)
+}
+
+/// Extract the subtree rooted at `id` of `program` into its own standalone, dense `Arenas` (a fresh
+/// root). Iterative post-order (an explicit stack) so a deep item can't overflow the native stack.
+fn extract_subtree(program: &Arenas, id: StructId) -> Arenas {
+    let mut b = Builder::new();
+    enum Job {
+        Visit(StructId),
+        EmitList(usize),
+    }
+    let mut jobs = vec![Job::Visit(id)];
+    let mut results: Vec<StructId> = Vec::new();
+    while let Some(job) = jobs.pop() {
+        match job {
+            Job::Visit(sid) => match program.get(sid) {
+                crate::ast::Struct::Atom(lid) => {
+                    let leaf = program.leaf(*lid).clone();
+                    let node = b.atom_leaf(leaf);
+                    results.push(node);
+                }
+                crate::ast::Struct::List(kids) => {
+                    jobs.push(Job::EmitList(kids.len()));
+                    for &k in kids.iter().rev() {
+                        jobs.push(Job::Visit(k));
+                    }
+                }
+            },
+            Job::EmitList(n) => {
+                let kids = results.split_off(results.len() - n);
+                let node = b.list(kids);
+                results.push(node);
+            }
+        }
+    }
+    let root = results.pop().expect("extract_subtree leaves a root");
+    b.finish(root)
+}

--- a/implementation/seed/crates/cadenza-syntax/src/lib.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/lib.rs
@@ -25,6 +25,9 @@ pub mod cli;
 pub mod convert;
 pub mod debug;
 pub mod doc;
+/// The doc-item projection: fold a program's public surface into a derived `doc-module` doc-AST
+/// (`cadenza doc`, design/DESIGN-cadenza-docs.md I1). Structural/syntactic — no typecheck dependency.
+pub mod doc_item;
 pub mod extern_name;
 pub mod iter;
 /// The JSON surface: a faithful data document (`(json-object …)`/`(json-array …)`/`(json-null)` plus

--- a/implementation/seed/crates/cadenza-syntax/tests/doc_item_projection.rs
+++ b/implementation/seed/crates/cadenza-syntax/tests/doc_item_projection.rs
@@ -1,0 +1,234 @@
+//! Integration tests for the doc-item projection (`doc_item::project`, design/DESIGN-cadenza-docs.md
+//! I1). These build real programs via the ML parser (so `///` doc-comments become the `(doc …)` /
+//! `(module-doc …)` nodes the projection reads) and assert (a) the projected `doc-module` structure and
+//! (b) that a projected doc-AST is ordinary `cdzast` — it encodes → `\x00\x01` → decodes identically
+//! (the frozen bijection) and re-reads through the s-expr surface. They exercise the PUBLIC API from
+//! outside the crate, so they live here rather than in-crate.
+
+use cadenza_syntax::ast::{Arenas, StructId};
+use cadenza_syntax::{codec, doc_item, parser, sexpr};
+
+/// Parse ML `src` into its canonical arena (asserting no parse errors), the input to the projection.
+fn program(src: &str) -> Arenas {
+    let parsed = parser::read_ml(src);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors in test program: {:?}",
+        parsed.errors
+    );
+    parsed.arenas
+}
+
+/// The string payload of the `(<field> "…")` CHILD of a `doc-item` (the field is a child form, not the
+/// item's own head — so search the item's children for a form headed `field`).
+fn item_field<'a>(doc: &'a Arenas, item: StructId, field: &str) -> Option<&'a str> {
+    let children = match doc.get(item) {
+        cadenza_syntax::ast::Struct::List(kids) => kids.as_slice(),
+        cadenza_syntax::ast::Struct::Atom(_) => return None,
+    };
+    for &c in children {
+        if let Some(args) = doc.as_form(c, field) {
+            return doc.as_str(*args.first()?);
+        }
+    }
+    None
+}
+
+/// The `(name "…")` string of a `doc-item`, for assertions.
+fn item_name(doc: &Arenas, item: StructId) -> Option<&str> {
+    item_field(doc, item, "name")
+}
+
+/// The `(doc "…")` string of a `doc-item`, or None if it carries none.
+fn item_doc(doc: &Arenas, item: StructId) -> Option<&str> {
+    item_field(doc, item, "doc")
+}
+
+/// The `(sig "…")` string of a `doc-item`.
+fn item_sig(doc: &Arenas, item: StructId) -> Option<&str> {
+    item_field(doc, item, "sig")
+}
+
+/// All `doc-item` children of a `doc-module` root.
+fn doc_items(doc: &Arenas) -> Vec<StructId> {
+    let Some(children) = doc.as_form(doc.root, "doc-module") else {
+        panic!("root is not a doc-module");
+    };
+    children
+        .iter()
+        .copied()
+        .filter(|&c| doc.as_form(c, "doc-item").is_some())
+        .collect()
+}
+
+#[test]
+fn projects_an_exported_def_with_its_doc_name_and_sig() {
+    // A documented, exported function def → one doc-item carrying its name, prose, and printed sig.
+    let src = "\
+/// Applies f to each element.
+def map(f, xs) = f
+export { map }";
+    let doc = doc_item::project(&program(src), "mymod");
+
+    // root is (doc-module "mymod" …)
+    let mod_args = doc
+        .as_form(doc.root, "doc-module")
+        .expect("root is a doc-module");
+    assert_eq!(doc.as_str(mod_args[0]), Some("mymod"), "module name");
+
+    let items = doc_items(&doc);
+    assert_eq!(items.len(), 1, "exactly one exported item");
+    assert_eq!(item_name(&doc, items[0]), Some("map"));
+    assert_eq!(
+        item_doc(&doc, items[0]),
+        Some("Applies f to each element."),
+        "the item's /// prose"
+    );
+    let sig = item_sig(&doc, items[0]).expect("a sig");
+    assert!(
+        sig.contains("map"),
+        "sig prints the item's syntactic form, got {sig:?}"
+    );
+}
+
+#[test]
+fn projects_only_the_exported_public_surface() {
+    // `helper` is defined but NOT exported → it must NOT appear; only the exported `pub_fn` does.
+    let src = "\
+/// internal.
+def helper(x) = x
+/// public.
+def pub_fn(y) = y
+export { pub_fn }";
+    let doc = doc_item::project(&program(src), "m");
+    let items = doc_items(&doc);
+    let names: Vec<_> = items.iter().filter_map(|&i| item_name(&doc, i)).collect();
+    assert_eq!(
+        names,
+        vec!["pub_fn"],
+        "only the exported name is a doc-item"
+    );
+}
+
+#[test]
+fn a_module_doc_becomes_the_doc_module_module_doc() {
+    // A `///` on a NON-def form (here an `import`) is preserved by the parser as a top-level
+    // `(module-doc …)` sibling (parser.rs stmt), which the projection lifts to the doc-module's
+    // `(module-doc …)`. (A `///` directly before a def instead documents that def — see the item-doc
+    // tests — so the module-doc case is a header doc on a non-documentable form.)
+    let src = "\
+/// Top-of-module prose.
+import { x } from \"other\"
+def f(x) = x
+export { f }";
+    let doc = doc_item::project(&program(src), "m");
+    let mod_args = doc.as_form(doc.root, "doc-module").unwrap();
+    // Some child is (module-doc "Top-of-module prose.")
+    let md = mod_args
+        .iter()
+        .find_map(|&c| doc.as_form(c, "module-doc").map(|a| doc.as_str(a[0])));
+    assert_eq!(
+        md,
+        Some(Some("Top-of-module prose.")),
+        "the leading /// is the module-doc"
+    );
+}
+
+#[test]
+fn an_exported_def_without_docs_has_a_sig_and_name_but_no_doc() {
+    // No `///` → the doc-item still carries name + sig (structural), but omits the empty (doc …).
+    let src = "\
+def f(x) = x
+export { f }";
+    let doc = doc_item::project(&program(src), "m");
+    let items = doc_items(&doc);
+    assert_eq!(items.len(), 1);
+    assert_eq!(item_name(&doc, items[0]), Some("f"));
+    assert!(item_sig(&doc, items[0]).is_some(), "sig is always present");
+    assert_eq!(
+        item_doc(&doc, items[0]),
+        None,
+        "no /// → no (doc …) child (not an empty one)"
+    );
+}
+
+#[test]
+fn projects_exported_type_and_effect_items() {
+    // A doc-item is minted for an exported `type` and `effect`, not just `def`.
+    let src = "\
+/// A color.
+type Color = | Red | Green
+/// A logger.
+effect Log = | info : Str
+export { Color, Log }";
+    let doc = doc_item::project(&program(src), "m");
+    let items = doc_items(&doc);
+    let names: Vec<_> = items.iter().filter_map(|&i| item_name(&doc, i)).collect();
+    assert!(names.contains(&"Color"), "exported type is a doc-item");
+    assert!(names.contains(&"Log"), "exported effect is a doc-item");
+}
+
+#[test]
+fn the_projected_doc_ast_round_trips_through_the_codec_byte_identically() {
+    // THE GATE (design §7.2): a doc-module is ordinary cdzast — encode → \x00\x01 → decode is
+    // structurally identical, and re-encoding the decoded arena is BYTE-identical (the bijection).
+    let src = "\
+/// doc one.
+def a(x) = x
+/// doc two.
+def b(y, z) = y
+export { a, b }";
+    let doc = doc_item::project(&program(src), "roundtrip");
+
+    let bytes = codec::encode(&doc);
+    assert_eq!(&bytes[..8], b"cdzast\x00\x01", "canonical inline header");
+    let decoded = codec::decode(&bytes).expect("a doc-module decodes");
+    assert!(
+        doc.structurally_eq(&decoded),
+        "decode(encode(doc-module)) must be structurally identical"
+    );
+    assert_eq!(
+        bytes,
+        codec::encode(&decoded),
+        "re-encode is byte-identical (the frozen bijection)"
+    );
+}
+
+#[test]
+fn the_projected_doc_ast_re_reads_through_the_sexpr_surface() {
+    // A doc-module prints to s-expr and re-reads to a structurally identical arena — it is a normal
+    // arena to every surface, so the s-expr oracle (a different code path) round-trips it.
+    let src = "\
+/// prose.
+def f(x) = x
+export { f }";
+    let doc = doc_item::project(&program(src), "m");
+
+    // Print the doc-AST as raw s-expr, then read it back through the independent s-expr reader (a
+    // different code path from the codec — the corpus round-trip oracle).
+    // `sexpr::read` (single form — NOT `read_all`, which wraps a lone top-level form in a synthetic
+    // `(do …)`) so the re-read is the doc-module itself, not a do-wrapped one.
+    let printed = sexpr::print(&doc);
+    let reread = sexpr::read(&printed)
+        .unwrap_or_else(|e| panic!("doc-module s-expr must re-read, got {e:?} for:\n{printed}"));
+    assert!(
+        doc.structurally_eq(&reread),
+        "doc-module must re-read structurally identically through the s-expr surface\nprinted:\n{printed}"
+    );
+}
+
+#[test]
+fn an_empty_program_projects_an_empty_doc_module() {
+    // A program that exports nothing → a doc-module with a name and no doc-items (never a panic).
+    let src = "\
+def f(x) = x";
+    let doc = doc_item::project(&program(src), "empty");
+    assert!(
+        doc.as_form(doc.root, "doc-module").is_some(),
+        "still a doc-module"
+    );
+    assert!(
+        doc_items(&doc).is_empty(),
+        "nothing exported → no doc-items"
+    );
+}


### PR DESCRIPTION
Candidate PR for v-syntax's merge-request (ref 6c8eaa97f, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.