### PR TITLE
fix(xtask/emoji-ban): tighten is_unicode_test_doc — bare "byte"/"scalar" no longer excludes (was hiding decorative ⚠ markers); strip the 13 stragglers it exposed

### DIFF
--- a/implementation/seed/crates/cdz-kernel/src/component_store.rs
+++ b/implementation/seed/crates/cdz-kernel/src/component_store.rs
@@ -77,7 +77,7 @@ impl ComponentStore {
     /// Fetch a component's bytes BY CONTENT HASH — a reducer's `+<hash>` dep import (the hash is in the
     /// import name). Reads `<root>/<hash>.wasm` and verifies its content address matches `hash`.
     ///
-    /// ⚠️ `hash` is the EXTERNAL store's **SHA-256** address (the 32-byte value carried in the dep's
+    /// WARNING:`hash` is the EXTERNAL store's **SHA-256** address (the 32-byte value carried in the dep's
     /// `+<hash>` import name, e.g. via `Hash::from_hex(sha256hex)`), even though the parameter is typed as
     /// the kernel's [`Hash`] (a scheme-agnostic 32-byte container). Do NOT pass `Hash::of(bytes)` — that is
     /// the kernel-internal **blake3** address and will fail the SHA-256 content-verify below, surfacing as

--- a/implementation/seed/crates/cdz-runtime/src/lib.rs
+++ b/implementation/seed/crates/cdz-runtime/src/lib.rs
@@ -3273,7 +3273,7 @@ fn op_str_from_bytes(buf: Handle) -> Handle {
 /// no consume). Decodes the flat leaf as UTF-8 and takes the Nth `char`; a well-formed String always
 /// decodes, but an ill-formed buffer (defensive) reads as `NO_SCALAR`, never a trap.
 ///
-/// ⚠ NOT YET WIT-EXPORTED — the ready runtime half of a coordinated `str-scalar-at` op (the compiler
+/// WARNING: NOT YET WIT-EXPORTED — the ready runtime half of a coordinated `str-scalar-at` op (the compiler
 /// declines `String.scalar-at` on a RUNTIME string at lower.rs `lower_str_scalar_at`, "constant strings
 /// only"; the constant case folds to a `Leaf::Char`). Kept UNEXPORTED (no WIT line, no `Guest` method) →
 /// DCE'd from the shipped wasm → frozen runtime hash UNCHANGED. When the compiler wires
@@ -3282,7 +3282,7 @@ fn op_str_from_bytes(buf: Handle) -> Handle {
 /// the flatten + UTF-8 scalar walk is done and proven here. The SCALAR-indexed String family
 /// (`scalar-len`/`scalar-at`/`slice`) all rest on this same UTF-8 walk.
 ///
-/// ⚡ COST — O(scalar_index): reaching the i-th scalar walks the UTF-8 from the START (a String is not
+/// COST: COST — O(scalar_index): reaching the i-th scalar walks the UTF-8 from the START (a String is not
 /// scalar-indexable in O(1) — variable-width encoding). This is INHERENT to random access by scalar
 /// index, NOT a defect. WARNING: CONSEQUENCE for the compiler agent: a LEXER that scans a string left-to-right
 /// via repeated `scalar-at(s, 0)`, `scalar-at(s, 1)`, … is O(N²) (measured: ~67 ns/scalar at N=64 rising
@@ -17903,7 +17903,7 @@ mod tests {
     /// CONTRACT-BOUNDARY TRIPWIRE for `value-eq` (op 61, the language `=`): it is `champ_eq` — a PHYSICAL-
     /// byte compare, BY CONTRACT (fast, shared with the map-key path). So a ROPE Bytes/String value is
     /// value-eq-DISTINCT from its flat twin even with equal CONTENT — the COMPILER must canonicalize
-    /// (`bytes-compact`) an operand before `value-eq`, exactly as for a map key. ⚠⚠ This documents a KNOWN
+    /// (`bytes-compact`) an operand before `value-eq`, exactly as for a map key. WARNING:WARNING: This documents a KNOWN
     /// LATENT COMPILER MISCOMPILE (`spec@b4700bb9`): `ty_heap_walkable::Ty::String => true` admits a runtime
     /// String to `value-eq` on a stale premise ("String.concat never makes a rope"), but runtime
     /// `String.concat` now emits `bytes-concat` (a rope), so `(= (String.concat rt_a rt_b) other)` compares
@@ -22015,7 +22015,7 @@ mod tests {
     // differential: random concat / slice / compact / read / fork sequences vs a `Vec<u8>` reference.
     // Like the RRB vector, the rope is ELEMENT-canonical but NOT shape-canonical (a concat/slice tree
     // is a different rep from a flat leaf of the same bytes), so the invariant is CONTENT equivalence
-    // (`bytes_to_vec` + `bytes-len`), NOT `champ_eq`. ⚠ `op_bytes_get`/`bytes_to_vec` FLATTEN a rope in
+    // (`bytes_to_vec` + `bytes-len`), NOT `champ_eq`. WARNING: `op_bytes_get`/`bytes_to_vec` FLATTEN a rope in
     // place — content-preserving + unobservable, but it mutates shape, so read each handle's content
     // ONCE and compare to its reference; a forked snapshot is verified by its OWN content read.
     #[derive(Debug, bolero::TypeGenerator)]

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/mod.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/mod.rs
@@ -2323,7 +2323,7 @@ fn closure_boundary_reject(role: &str, ty: &crate::ty::Ty) -> Reject {
 /// value-heap ops), because a closure's `call` boundary is a plain component functype — it needs only the
 /// component primitive byte + the core valtype (from `valtype_of`), neither tied to the runtime-op set.
 ///
-/// ⚠ Restricted to genuine SCALARS: `comp_valtype_of` ALSO returns a byte for a `Tuple` (the u32 HANDLE it
+/// WARNING: Restricted to genuine SCALARS: `comp_valtype_of` ALSO returns a byte for a `Tuple` (the u32 HANDLE it
 /// is threaded as BETWEEN in-program functions) and for a `Nominal`-over-compound, but those are opaque
 /// runtime handles, NOT values the host can construct or read across the `call` boundary — a closure with a
 /// COMPOUND arg/result must decline (that widening is a separate later increment). So this accepts only

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/select.rs
@@ -7355,7 +7355,7 @@ fn emit(
         // then for each element `[buf] ; index ; byte ; bytes-set` — and `bytes-set(buf,index,value) ->
         // buf` RETURNS the buffer (FBIP in-place), so the buffer threads through with no scratch local. A
         // byte is a RAW i32 in `0..=255` (NOT boxed like a list element); every element folded to a
-        // constant in range at lowering (`lower_bytes_of`), so each is pushed as an `i32.const`. ⚠ the
+        // constant in range at lowering (`lower_bytes_of`), so each is pushed as an `i32.const`. WARNING: the
         // byte value uses `Lir::ConstI32`, which the serializer writes as a SIGNED LEB — a raw byte ≥ 64
         // would sign-extend negative if hand-emitted, but `Lir::ConstI32` handles the signed encoding, so
         // there is no raw-opcode hazard here (the seed's `sleb128` bug was in hand-written opcode bytes).
@@ -9404,7 +9404,7 @@ fn emit(
         // scratch slots (bytes i32, start i64, len i64, byte-count i64) above `base`; operand recursions
         // float above them.
         //
-        // ⚠ The predicate is OVERFLOW-SAFE. The naive `start + len <= bytes-len` OVERFLOWS: for
+        // WARNING: The predicate is OVERFLOW-SAFE. The naive `start + len <= bytes-len` OVERFLOWS: for
         // attacker-chosen `start`/`len` near i64::MAX the i64 sum wraps to a negative value that trivially
         // passes the signed `<=`, wrongly taking the in-range path (a wrong `Some`, or a trap when the
         // i32-wrapped index exceeds the runtime's u32 range) — a soundness hole in a FALLIBLE op that
@@ -9889,7 +9889,7 @@ fn emit(
             // (`mark_binder_dups`' `SumExpect` arm) is a compound payload consumed while its scrutinee stays
             // live, so `dup` the child (rc++) before it flows into the consuming op — else the shared payload
             // is FBIP-mutated at rc==1 and the still-live scrutinee drifts. Only a COMPOUND leaf (`unboxed`
-            // None AND not Unit — a real handle) aliases; a scalar unboxes/copies and is never a site. ⚠
+            // None AND not Unit — a real handle) aliases; a scalar unboxes/copies and is never a site. WARNING:
             // `get_op` returns `None` for BOTH a compound handle AND a `Unit` payload; a Unit has no heap cell
             // to alias and its `IMM_UNIT` sentinel must be DROPPED by `emit_heap_read_tail` — taking the dup
             // fast path would leave the sentinel un-dropped → an extra stack value in the block → INVALID
@@ -10261,7 +10261,7 @@ fn emit(
             // cell per call (a `(match (List.at (build …) i) …)` in a loop leaks N — value-correct, caught by
             // the live-objects gate). Drop the shell after the match — but ONLY when NO arm can borrow a HEAP
             // PAYLOAD HANDLE out of the shell that OUTLIVES the block: `sum_has_only_scalar_payloads` (every
-            // variant carries a scalar or nothing). ⚠ A SCALAR-RESULT gate is NOT sufficient (the bug
+            // variant carries a scalar or nothing). WARNING: A SCALAR-RESULT gate is NOT sufficient (the bug
             // v-patterns caught): the HOL-kernel `term-eq (Comb x y)` returns a scalar Bool but its arms bind
             // `x`/`y` = `sum-payload` HANDLES borrowed from the shell and thread them into a recursive walk
             // that reads them AFTER the match — freeing the shell there frees `x`/`y` mid-use (OOB/UAF). With

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -51871,7 +51871,7 @@ mod match_engine {
     #[test]
     fn a_br_table_match_in_non_tail_position_yields_into_the_enclosing_expression() {
         use wasmtime::component::Val;
-        // ⚠ REGRESSION (silent WRONG VALUE, valid wasm): a ≥4-arm scalar match (a `br_table` jump-table
+        // WARNING: REGRESSION (silent WRONG VALUE, valid wasm): a ≥4-arm scalar match (a `br_table` jump-table
         // lowering) consumed in NON-TAIL position escaped to the FUNCTION result — each arm branched ONE
         // BLOCK PAST the match's `$join` (depth `n_arms - k + 1` instead of `n_arms - k`), so the arm value
         // became the whole result and the consuming code never ran. `(+ (match a …4…) 100)`: a=0 must be

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -117,6 +117,12 @@ enum Cmd {
     /// (`target/xtask-logs/`); the console shows one ✓ per step, and the first failing step prints
     /// the whole log + its path.
     Check,
+    /// Emoji-ban lint, standalone (operator directive): fail if any emoji/pictographic/dingbat char
+    /// appears in an `implementation/**/*.rs` source COMMENT. This is the same `emoji_free_lint` the
+    /// omnibus `check` runs, exposed as its own fast subcommand so CI can gate it as an isolated
+    /// advisory job (no full build). Comment-scoped + Unicode-test-doc-excluded, so functional emoji in
+    /// string/char literals (the language's own lex/parse/print fixtures) are correctly left alone.
+    LintEmoji,
     /// Round-trip every corpus program through the syntax surfaces: `sexpr` must reproduce the exact
     /// binary AST; `ml` (the long-term syntax, allowed to canonicalize once) must round-trip to a
     /// FIXED POINT (`ml(ml(x)) == ml(x)`). Guards `cadenza-syntax` independently of the compiler.
@@ -258,6 +264,13 @@ fn main() {
             }
         }
         Cmd::Check => check(&paths, profile),
+        Cmd::LintEmoji => match emoji_free_lint(&paths) {
+            Ok(()) => println!("lint-emoji: ok — no emoji in source comments"),
+            Err(msg) => {
+                eprintln!("lint-emoji: {msg}");
+                std::process::exit(1);
+            }
+        },
         Cmd::Roundtrip { files } => roundtrip(&paths, profile, files),
         Cmd::Fmt { files, to, check } => fmt(&paths, profile, files, &to, check),
         Cmd::Emit { file, from, out } => emit(&paths, profile, &file, &from, out),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5264,22 +5264,36 @@ fn line_is_comment(line: &str) -> bool {
     t.starts_with("///") || t.starts_with("//!") || t.starts_with("//") || t.starts_with('*')
 }
 
-/// True if a comment line legitimately REFERENCES a character as the subject of Unicode-handling test
-/// documentation (e.g. "surrogate PAIR U+1F600", "a😀b scalar 1", "multibyte: é (2 bytes)"). Such a
-/// comment names the emoji ON PURPOSE to document what byte/scalar a test exercises — stripping it would
-/// break the comment's meaning, and the operator explicitly excludes deliberate-Unicode test data. Keyed
-/// on the vocabulary those comments use; deliberately conservative (an over-match only spares a comment).
+/// True if a comment line legitimately DOCUMENTS a character as the subject of Unicode-handling test
+/// data (e.g. "surrogate PAIR U+1F600 😀", `"😀" = 4 bytes`) — stripping the emoji there would break the
+/// comment's meaning, and the operator excludes deliberate-Unicode test data. The distinction that
+/// matters is whether the emoji is the SUBJECT (documented test data) vs a decorative MARKER: a marker
+/// (⚠/⚡ opening a warning) is banned even on a comment that happens to say "byte"/"scalar" in prose (a
+/// compiler discusses byte-lengths + scalars constantly). So exclude ONLY on a STRONG codepoint signal
+/// (`U+…`, surrogate/astral/codepoint) OR when an emoji appears INSIDE a quoted `"…"` string in the
+/// comment (the emoji quoted AS the datum under test). Bare "byte"/"scalar" no longer excludes — that
+/// over-match was letting decorative ⚠ markers through (v-agent-harness caught component_store.rs:80).
 fn is_unicode_test_doc(line: &str) -> bool {
-    let l = line;
-    l.contains("U+")
-        || l.contains("scalar")
-        || l.contains("byte")
-        || l.contains("surrogate")
-        || l.contains("multibyte")
-        || l.contains("astral")
-        || l.contains("codepoint")
-        || l.contains("UTF-8")
-        || l.contains("\\u")
+    let strong = line.contains("U+")
+        || line.contains("surrogate")
+        || line.contains("astral")
+        || line.contains("codepoint");
+    strong || emoji_inside_a_quote(line)
+}
+
+/// True if any emoji char appears inside a double-quoted `"…"` substring of `line` — i.e. the emoji is
+/// quoted as a literal datum (a Unicode test string the comment documents, like `"😀" = 4 bytes`), not a
+/// bare decorative marker. A simple quote-state scan; pure + unit-tested.
+fn emoji_inside_a_quote(line: &str) -> bool {
+    let mut in_quote = false;
+    for c in line.chars() {
+        if c == '"' {
+            in_quote = !in_quote;
+        } else if in_quote && is_emoji_char(c) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Every (1-based line, emoji char) an emoji-ban lint would FLAG in `text`: emoji chars that appear in a
@@ -6846,9 +6860,18 @@ mod trap_grading_tests {
         assert!(banned_emoji_hits("let s = \"👍\".repeat(3);\n").is_empty());
         assert!(banned_emoji_hits("let mark = if act { \"⚑\" } else { \".\" };\n").is_empty());
 
-        // NOT flagged: a COMMENT that documents Unicode test data (names the emoji as the test subject).
+        // NOT flagged: a COMMENT that documents Unicode test data — via a STRONG codepoint signal...
         assert!(banned_emoji_hits("// surrogate PAIR U+1F600 😀 is a 4-byte scalar\n").is_empty());
         assert!(banned_emoji_hits("// a😀b: scalar 1 = U+1F600\n").is_empty());
+        // ...OR the emoji QUOTED as the datum under test (no U+ needed, e.g. `"😀" = 4 bytes`).
+        assert!(banned_emoji_hits("// `\"😀\"` = 4 (four bytes vs one scalar)\n").is_empty());
+
+        // BUT a DECORATIVE marker is flagged even on a comment that says byte/scalar in prose — the
+        // over-broad bare-"byte" exclusion was letting these through (v-agent-harness, component_store).
+        assert_eq!(
+            banned_emoji_hits("/// ⚠ the 32-byte SHA-256 address — a scalar walk\n"),
+            vec![(1, '⚠')]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Candidate PR for v-fleet-tooling's merge-request (ref 4b7345e41, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.