### PR TITLE
fix(rcdzc/rust): ground every list literal element to the unified element width — closes a mixed-width vec! differential (corpus-bugfix/fuzzer cdz-smith)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/expr.rs
@@ -1752,9 +1752,29 @@ fn emit(db: &mut Db, id: StructId, env: &Env, ctx: &Ctx) -> Result<String, Rejec
                 None
             };
             let use_ctx = elem_ctx.as_ref().unwrap_or(ctx);
+            // The list's SETTLED element WIDTH, if integer — a bare in-range literal element defaults its
+            // OWN `type_of` to Int64 (`Nu64 as i64`), but the list is `Vec<ew>`, so a MIXED-width literal
+            // list `(list (: 127 Int32) 32767)` emits `vec![(127u32 as i32), (32767u64 as i64)]` — a
+            // HETEROGENEOUS `Vec` rustc rejects (E0308). The front-end + wasm UNIFY the element type (wasm
+            // coerces both to Int32); the rust `vec!` must too. Ground each element to the list's element
+            // width (`emit_grounded` renders a bare literal at that width, a no-op when already width-
+            // carrying) — the List twin of the Map entry-key/value + Set-element sibling-width render
+            // (corpus-bugfix, fuzzer cdz-smith differential). Only INTEGER elements ground; a non-int
+            // element type leaves the bare emit (a wrong render would still error LOUD at rustc).
+            let elem_it: Option<IntTy> = match type_of(db, id).strip_nominal() {
+                Ty::List(elem) => match elem.strip_nominal() {
+                    Ty::Int(it) => Some(*it),
+                    _ => None,
+                },
+                _ => None,
+            };
             let mut parts = Vec::with_capacity(elems.len());
             for &e in &elems {
-                parts.push(emit(db, e, env, use_ctx)?);
+                let part = match elem_it {
+                    Some(it) => emit_grounded(db, e, it, env, use_ctx)?,
+                    None => emit(db, e, env, use_ctx)?,
+                };
+                parts.push(part);
             }
             Ok(format!("vec![{}]", parts.join(", ")))
         }

--- a/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
@@ -801,6 +801,39 @@ fn rustc_roundtrip_list_builds_and_runs() {
 }
 
 #[test]
+fn a_mixed_width_literal_list_grounds_every_element_to_the_unified_element_width() {
+    // REGRESSION (corpus-bugfix, fuzzer cdz-smith differential): a `(list (: 127 Int32) 32767)` whose
+    // elements are LITERALS of DIFFERING inferred widths — the annotated `(: 127 Int32)` is Int32, the
+    // bare `32767` defaults its OWN `type_of` to Int64 — USED to emit a HETEROGENEOUS
+    // `vec![(127u32 as i32), (32767u64 as i64)]`, which rustc rejects (E0308: a `Vec` is homogeneous).
+    // The front-end + wasm UNIFY the list's element type (both coerce to Int32, the list is `List Int32`);
+    // the rust `vec!` must too. `Core::ListNew` now grounds each element to the list's SOLVED element
+    // width via `emit_grounded` (the List twin of the Map entry + Set element sibling-width render). A
+    // correctness-class differential: rust REJECTED a program wasm accepts.
+    let m = compile_rust("(module m (def (main) (list (: 127 Int32) 32767)) (export main))");
+    assert!(
+        m.contains("vec![(127u32 as i32), (32767u32 as i32)]"),
+        "both literal elements ground to the unified Int32 element width (homogeneous Vec<i32>):\n{m}"
+    );
+    // e2e: compiles + runs to the canonical list form (both elements Int32), matching wasm.
+    let driver = "fn main() { let v = prog::main(); let mut s = String::from(\"(list\"); \
+                  for e in v.iter() { s.push(' '); s.push_str(&format!(\"{}\", e)); } s.push(')'); \
+                  println!(\"{}\", s); }";
+    if let Some(out) = rustc_run_driver(&m, driver) {
+        assert_eq!(
+            out, "(list 127 32767)",
+            "the mixed-width list builds + runs, both elements at Int32:\n{m}"
+        );
+    }
+    // A plain same-width list is byte-identical to before (grounding a same-width literal is a no-op).
+    let plain = compile_rust("(module m (def (main) (list 1 2 3)) (export main))");
+    assert!(
+        plain.contains("vec![(1u64 as i64), (2u64 as i64), (3u64 as i64)]"),
+        "a plain Int64 list still grounds each element to i64 (no regression):\n{plain}"
+    );
+}
+
+#[test]
 fn rustc_roundtrip_all_nullary_sum_orders_by_discriminant() {
     // breaker #43 cross-backend guard: the shared-lowering fix routes an ALL-NULLARY sum's `<`/`compare`
     // to a scalar `Core::Compare` (i32/enum tag) instead of the `Core::ValueCmp` heap walk. The finding is


### PR DESCRIPTION
Candidate PR for v-rust-backend's merge-request (ref 3930161876feae1a8dc63b3ea0d5e2fe990b96f7, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.