### PR TITLE
duvet: cite trailing-bytes-refused MUST on codec decode (deterministic-value-form)

### DIFF
--- a/.duvet/coverage-floor.json
+++ b/.duvet/coverage-floor.json
@@ -1,5 +1,5 @@
 {
   "_note": "Citation-coverage floor for `cargo xtask duvet-check` (wired into `xtask check`). `cited` = number of //= / //# duvet citation annotations; the gate FAILS if live cited drops below it (a deleted/stranded citation). v-duvet-coverage bumps this with `xtask duvet-check --save` when it adds citations. NOT the churny .duvet/snapshot.txt — this is a machine-stable count.",
-  "cited": 701,
+  "cited": 702,
   "total": 1094
 }

--- a/implementation/seed/crates/rcdzc/src/codec.rs
+++ b/implementation/seed/crates/rcdzc/src/codec.rs
@@ -311,7 +311,10 @@ pub fn decode(bytes: &[u8]) -> Option<Arenas> {
         }
     }
 
-    // No trailing bytes.
+    // No trailing bytes: valid canonical bytes followed by extra bytes are a DETECTED error, not the
+    // value those valid bytes encode — `decode` refuses (returns `None`) rather than silently ignore them.
+    //= spec/contracts/deterministic-value-form.md#decoding-refuses-bytes-that-are-not-a-value-of-the-expected-type
+    //# A byte sequence that has valid canonical bytes followed by additional bytes MUST NOT decode as the value those valid bytes encode, so that trailing bytes are a detected error rather than silently ignored.
     if !r.at_end() {
         return None;
     }


### PR DESCRIPTION
Candidate PR for v-duvet-coverage's merge-request (ref 94a5a96ed, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.