### PR TITLE
guide(platform): add 'Finding another agent' to Events & state — naming, groups, multicast (task 3)

### DIFF
--- a/guide/src/content/chapters/PlatformState.tsx
+++ b/guide/src/content/chapters/PlatformState.tsx
@@ -8,6 +8,12 @@ import { Link } from "react-router-dom";
 /// (storage tiers + the immutable-by-hash vs. mutable-current-view bridge rule). Deliberately does NOT
 /// claim the cross-version replay contract (§16b-B is an OPEN gap audit) — determinism here is stated at
 /// the already-established "fold over recorded events" level. Follows PlatformOverview in the pillar.
+/// The "Finding another agent" section (naming / prefix-authority + resolve-freeze / groups + multicast)
+/// is fact-confirmed by v-agent-harness (2026-08-07) against DESIGN-session-directory.md + the code: BOTH
+/// single-name naming (store/set+store/resolve, name→Hash=SessionId, prefix-authority anti-hijack, resolve
+/// freezes the hash into the resolver's log, effect.rs:94) AND the OR-set group + multicast layer
+/// (store/add/remove/resolve-all, group_multicast_e2e) are BUILT + E2E on trunk, so stated present-tense.
+/// Forward-tense (kept light): a richer directory-query/discovery surface beyond resolve + resolve-all.
 export default function PlatformState() {
   return (
     <article>
@@ -139,8 +145,51 @@ export default function PlatformState() {
       <P>
         One rule, cleanly drawn, and the crown-jewel property survives contact with a whole system of
         agents reading each other: everything a fold depends on is either an unchanging value or a recorded
-        answer, so an agent's history always replays to exactly the same place. The next sections build on
-        this: what an agent is allowed to do, and how the kernel runs many of them at once.
+        answer, so an agent's history always replays to exactly the same place.
+      </P>
+
+      <H2>Finding another agent</H2>
+      <P>
+        Reading another agent's status assumes you can already <em>refer</em> to it. So how does one agent
+        name another? The platform gives them a shared name service: an agent registers under a stable name,
+        and another resolves that name to the target's session. A session's identity is a content hash of
+        its starting state, so a name resolves to exactly one session with no ambiguity, and the name
+        outlives any particular run. Resolve it again later and you find the same agent, or its successor if
+        the name has since been repointed, never a stale address.
+      </P>
+      <P>
+        A name isn't a free-for-all, and this is where addressing meets the safety model. Names are
+        authority-scoped by their prefix: who may point a name at a session is gated by the same capability
+        check as any other effect, so only a holder of authority over <C>system/</C> may set a{" "}
+        <C>system/…</C> name. That's what makes a well-known name trustworthy. Resolving{" "}
+        <C>system/compiler/latest</C> can't be silently hijacked to point at an impostor, because repointing
+        it takes an authority almost no one holds. And resolution <em>freezes</em>: when an agent resolves a
+        name, the answer it got is recorded into its own log, so a later repoint can't retroactively change
+        what a resolver already acted on. It's the same rule as reading anything else that changes, reach out
+        once, record the answer, and every replay reads the record, now applied to addresses.
+      </P>
+      <P>
+        Naming generalizes from one session to a set. A <em>group</em> name holds a collection of live
+        members: an agent adds itself or is added, it can leave, and resolving the group returns the whole
+        current membership. That gives two things at once, a directory (who is in this group right now?) and
+        multicast (send one message to every member). A supervisor with a pool of workers resolves the group
+        and fans a message out to all of them; a worker joining or finishing changes the membership the next
+        resolve sees. Because membership is itself folded from add and remove events on the group's log, it
+        merges cleanly even when several members join at the same moment, with no lost writes, and the group
+        is as replayable and auditable as any other agent state.
+      </P>
+      <Note>
+        a name → one session (its identity is a content hash of its starting state), authority-scoped by prefix
+        <br />
+        resolve freezes the answer into your log → a later repoint can't rewrite what you already acted on
+        <br />
+        a group name → a live set of members you add/remove and multicast to: a directory and a broadcast at once
+      </Note>
+      <P>
+        That closes the loop opened at the top of the chapter. An agent's own state is a fold over its log;
+        reading the changing world is a query frozen into that log; and now even <em>who</em> the other
+        agents are is just another name resolved and recorded. The next sections build on all of it: what an
+        agent is allowed to do, and how the kernel runs many of them at once.
       </P>
     </article>
   );


### PR DESCRIPTION
Candidate PR for v-guide-editor's merge-request (ref ced55ebfe49d3bb520a1bd9f65f608d630f3803a, lane docs). Auto-merge armed; pr-sync's schedule-pass reaps on green.