### PR TITLE
fix(cdz-agent-host): rustfmt dynamo_log.rs + host.rs to the DEFAULT toolchain (trunk-red fmt, supersedes #2609)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/dynamo_log.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/dynamo_log.rs
@@ -221,7 +221,9 @@ impl DynamoLogSink {
                 _ => break,
             }
         }
-        Ok(recovered_from_event_blobs(blobs.iter().map(|b| b.as_slice())))
+        Ok(recovered_from_event_blobs(
+            blobs.iter().map(|b| b.as_slice()),
+        ))
     }
 }
 
@@ -364,8 +366,7 @@ mod tests {
         let e0 = event_ast::encode(&genesis_event(0));
         let e1 = event_ast::encode(&genesis_event(1));
         let expected_len = (e0.len() + e1.len()) as u64;
-        let rec =
-            recovered_from_event_blobs([e0.as_slice(), e1.as_slice()]);
+        let rec = recovered_from_event_blobs([e0.as_slice(), e1.as_slice()]);
         assert_eq!(rec.kind, RecoveryKind::Clean);
         assert_eq!(rec.events.len(), 2);
         assert_eq!(rec.events[0].seq, 0);
@@ -385,7 +386,11 @@ mod tests {
         let rec = recovered_from_event_blobs([good.as_slice(), garbage, after.as_slice()]);
         assert_eq!(rec.kind, RecoveryKind::Corrupt);
         assert!(rec.is_corrupt());
-        assert_eq!(rec.events.len(), 1, "only the pre-corruption good prefix is kept");
+        assert_eq!(
+            rec.events.len(),
+            1,
+            "only the pre-corruption good prefix is kept"
+        );
         assert_eq!(rec.events[0].seq, 0);
         assert_eq!(rec.good_prefix_len, good_len);
     }

--- a/implementation/seed/crates/cdz-agent-host/src/host.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/host.rs
@@ -1440,7 +1440,10 @@ mod tests {
         let original = now_host();
         let original_id = original.genesis_hash();
         let log = original.session().log().to_vec();
-        assert!(!log.is_empty(), "a genesis'd session has at least its seq-0 event");
+        assert!(
+            !log.is_empty(),
+            "a genesis'd session has at least its seq-0 event"
+        );
 
         let recovered = Recovered {
             events: log,


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 7bf8748133c52eb46b228b61383ccc1249ec0d47, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.