### PR TITLE
duvet: cite decode-refuses-non-canonical-bytes MUST on codec decode header check (deterministic-value-form)

### DIFF
--- a/.duvet/coverage-floor.json
+++ b/.duvet/coverage-floor.json
@@ -1,5 +1,5 @@
 {
   "_note": "Citation-coverage floor for `cargo xtask duvet-check` (wired into `xtask check`). `cited` = number of //= / //# duvet citation annotations; the gate FAILS if live cited drops below it (a deleted/stranded citation). v-duvet-coverage bumps this with `xtask duvet-check --save` when it adds citations. NOT the churny .duvet/snapshot.txt — this is a machine-stable count.",
-  "cited": 702,
+  "cited": 703,
   "total": 1094
 }

--- a/implementation/seed/crates/rcdzc/src/codec.rs
+++ b/implementation/seed/crates/rcdzc/src/codec.rs
@@ -251,7 +251,11 @@ fn write_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
 /// Decode bytes to `Arenas`, verifying the header and consuming the whole input. Total: returns
 /// `None` on header mismatch, malformed structure, out-of-range id, or trailing bytes.
 pub fn decode(bytes: &[u8]) -> Option<Arenas> {
-    // Header.
+    // Header. Bytes that are not the canonical encoding of any value — a wrong header here, or a
+    // malformed structure / out-of-range id below — are REFUSED (`None`) rather than misread as a value
+    // they do not encode.
+    //= spec/contracts/deterministic-value-form.md#decoding-refuses-bytes-that-are-not-a-value-of-the-expected-type
+    //# Decoding a byte sequence that is not the canonical byte encoding of any value of the expected type MUST be refused rather than yield a value, so that a decode never misinterprets bytes as a value they do not encode.
     let header = bytes.get(..8)?;
     if header != SCHEMA_HEADER {
         return None;


### PR DESCRIPTION
Candidate PR for v-duvet-coverage's merge-request (ref 5fc28d9cc, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.