### PR TITLE
guide(codegen): I4 cutover A-D — shared ChapterLink (Ch/AppLink) + codegen emits them for links

### DIFF
--- a/guide/src/components/ChapterLink.tsx
+++ b/guide/src/components/ChapterLink.tsx
@@ -1,0 +1,31 @@
+/// The guide's two shared, router-aware link components — the single styled-link source the chapters use.
+///
+/// `Ch` is an INTERNAL link to another chapter (`/slug`); `AppLink` is a link to a standalone app route
+/// (`/playground`, `/explorer`, …) and reads slightly heavier (`font-medium`). Both were previously copy-
+/// pasted as identical local helpers in several chapter files; centralizing them here gives the sexp→TSX
+/// codegen (cadenza-docs I4) a single styled target to emit — `(link (slug …))` → `<Ch>`, `(app-link
+/// (route …))` → `<AppLink>` — so a generated chapter styles links exactly as the hand-written ones do,
+/// and the palette lives in one place. (v-guide verified the class strings are 100% uniform across the 40
+/// chapter links, so this is byte-exact, not lossy.)
+
+import { Link } from "react-router-dom";
+import type { ReactNode } from "react";
+
+/// An internal link to another chapter (served by the `/:slug` catch-all route).
+export function Ch({ to, children }: { to: string; children: ReactNode }) {
+  return (
+    <Link to={to} className="text-cadenza-300 underline-offset-2 hover:underline">
+      {children}
+    </Link>
+  );
+}
+
+/// A link to a standalone app route (playground / calculator / cad / notebook / music / explorer). Reads
+/// heavier than a chapter cross-link (`font-medium`) — it sends the reader OUT to a full app, not another page.
+export function AppLink({ to, children }: { to: string; children: ReactNode }) {
+  return (
+    <Link to={to} className="font-medium text-cadenza-300 underline-offset-2 hover:underline">
+      {children}
+    </Link>
+  );
+}

--- a/guide/src/content/codegen/chapterModel.test.ts
+++ b/guide/src/content/codegen/chapterModel.test.ts
@@ -119,9 +119,22 @@ test("render emits a @generated header, a sorted tsc-clean import, and the Pasca
   assert.doesNotMatch(tsx, /react-router-dom/);
 });
 
-test("render imports Link only when a link/app-link is present", () => {
-  const withLink = renderChapter(parseOk(`(chapter (slug "x") (title "X") (p (link (slug "y") "y")))`));
-  assert.match(withLink, /import \{ Link \} from "react-router-dom";/);
+test("render imports Ch/AppLink from the shared ChapterLink module, only the kinds used", () => {
+  // an internal (link …) → <Ch>, imports Ch (not a bare react-router Link)
+  const withCh = renderChapter(parseOk(`(chapter (slug "x") (title "X") (p (link (slug "y") "y")))`));
+  assert.match(withCh, /import \{ Ch \} from "\.\.\/\.\.\/components\/ChapterLink\.tsx";/);
+  assert.match(withCh, /<Ch to="\/y">y<\/Ch>/);
+  assert.doesNotMatch(withCh, /react-router-dom/);
+  assert.doesNotMatch(withCh, /\bAppLink\b/); // app-link not used → not imported
+
+  // an (app-link …) → <AppLink>, imports AppLink
+  const withApp = renderChapter(parseOk(`(chapter (slug "x") (title "X") (p (app-link (route "/explorer") "the explorer")))`));
+  assert.match(withApp, /import \{ AppLink \} from "\.\.\/\.\.\/components\/ChapterLink\.tsx";/);
+  assert.match(withApp, /<AppLink to="\/explorer">the explorer<\/AppLink>/);
+
+  // both kinds → both imported, sorted (AppLink, Ch)
+  const both = renderChapter(parseOk(`(chapter (slug "x") (title "X") (p (link (slug "y") "y") " " (app-link (route "/cad") "cad")))`));
+  assert.match(both, /import \{ AppLink, Ch \} from "\.\.\/\.\.\/components\/ChapterLink\.tsx";/);
 });
 
 test("render imports C when inline code is used (else <C> is undefined — tsc noUnusedLocals/undefined bug)", () => {

--- a/guide/src/content/codegen/chapterModel.ts
+++ b/guide/src/content/codegen/chapterModel.ts
@@ -224,7 +224,11 @@ export function renderChapter(model: ChapterModel): string {
     "// @generated DO NOT EDIT — rendered from the chapter's .sexp by the guide sexp→TSX codegen (chapterModel.ts).",
     proseImport,
   ];
-  if (flags.link || flags.appLink) lines.push(`import { Link } from "react-router-dom";`);
+  // Links render via the shared styled components (Ch = internal chapter link, AppLink = app route) — NOT a
+  // bare react-router <Link> — so a generated chapter styles links exactly as the hand-written ones do. Import
+  // only the kinds actually used (tsc noUnusedLocals), sorted for determinism.
+  const linkImports = [flags.link && "Ch", flags.appLink && "AppLink"].filter(Boolean).sort();
+  if (linkImports.length) lines.push(`import { ${linkImports.join(", ")} } from "../../components/ChapterLink.tsx";`);
   lines.push("");
   lines.push(`export default function ${pascal(model.slug)}() {`);
   lines.push("  return (");
@@ -241,8 +245,9 @@ export function renderChapter(model: ChapterModel): string {
   return lines.join("\n") + "\n";
 }
 
-/// Render inline children to JSX text. `br` → `<br />`; a chapter link → `<Link to="/slug">`; an app link →
-/// `<Link to="/route">`. Text is JSX-escaped (`{`, `}`, `<` would otherwise be parsed as JSX).
+/// Render inline children to JSX text. `br` → `<br />`; a chapter link → `<Ch to="/slug">`; an app link →
+/// `<AppLink to="/route">` (the shared styled components). Text is JSX-escaped (`{`, `}`, `<` would otherwise
+/// be parsed as JSX).
 function renderInlines(inlines: Inline[]): string {
   return inlines.map(renderInline).join("");
 }
@@ -253,8 +258,8 @@ function renderInline(i: Inline): string {
     case "em": return `<em>${renderInlines(i.children)}</em>`;
     case "code": return `<C>${escapeText(i.text)}</C>`;
     case "br": return "<br />";
-    case "link": return `<Link to="/${i.slug}">${renderInlines(i.children)}</Link>`;
-    case "app-link": return `<Link to="${i.route}">${renderInlines(i.children)}</Link>`;
+    case "link": return `<Ch to="/${i.slug}">${renderInlines(i.children)}</Ch>`;
+    case "app-link": return `<AppLink to="${i.route}">${renderInlines(i.children)}</AppLink>`;
   }
 }
 

--- a/guide/src/content/codegen/fixtures/sample-chapter.expected.tsx.txt
+++ b/guide/src/content/codegen/fixtures/sample-chapter.expected.tsx.txt
@@ -1,6 +1,6 @@
 // @generated DO NOT EDIT — rendered from the chapter's .sexp by the guide sexp→TSX codegen (chapterModel.ts).
 import { C, H1, H2, Lede, Note, P } from "../../components/Prose.tsx";
-import { Link } from "react-router-dom";
+import { AppLink, Ch } from "../../components/ChapterLink.tsx";
 
 export default function SampleChapter() {
   return (
@@ -8,7 +8,7 @@ export default function SampleChapter() {
       <H1>A Sample Chapter</H1>
       <Lede>This fixture drives the sexp→TSX codegen gate: it uses <em>every</em> head the I4 schema defines, so a regression in parse or render trips <C>check-codegen</C>.</Lede>
       <H2>Prose and emphasis</H2>
-      <P>An ordinary paragraph with <em>emphasis</em>, some <C>inline code</C>, and a link to <Link to="/effects">effects & handlers</Link> plus the <Link to="/explorer">platform explorer</Link>.</P>
+      <P>An ordinary paragraph with <em>emphasis</em>, some <C>inline code</C>, and a link to <Ch to="/effects">effects & handlers</Ch> plus the <AppLink to="/explorer">platform explorer</AppLink>.</P>
       <H2>A pseudocode note</H2>
       <Note>on an event arriving in session S:<br />{"  run S's reducer over the event → a list of effects"}<br />{"  for each effect: if authorized, perform it; else append a denial"}<br />{"  each appended result is a new event → the loop runs again"}</Note>
     </article>


### PR DESCRIPTION
Candidate PR for v-guide-infra's merge-request (ref 4ab58e44fe2679fa46acd80dd6e01ad7f91abc7a, lane docs). Auto-merge armed; pr-sync's schedule-pass reaps on green.