### PR TITLE
syntax: doc-item projection descends into a top-level (module …) — document module-wrapped programs

### DIFF
--- a/implementation/seed/crates/cadenza-syntax/src/doc_item.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/doc_item.rs
@@ -251,14 +251,30 @@ fn collect_doc_text(
     }
 }
 
-/// The top-level forms of a program: the children of a top-level `(do …)`, or the single root form
-/// when the program is one form (not wrapped in a `do`).
+/// The top-level forms of a program — the module-member scope whose exported `def`/`type`/`effect` are
+/// documentable. This is the children of a top-level `(do …)`, or the single root form when unwrapped;
+/// AND, when the program is (or wraps) a `(module <name> member…)`, that module's MEMBERS (a program's
+/// public surface can live inside a `module` form, e.g. a `.sexp` module — its `def`/`export` are the
+/// members, not top-level siblings). A `(module …)` found among the `do` children is likewise unwrapped
+/// to its members, so `cdz doc-module` documents a module-wrapped program the same as a flat one.
 fn top_level_forms(program: &Arenas) -> Vec<StructId> {
-    if let Some(items) = program.as_form(program.root, "do") {
+    let roots = if let Some(items) = program.as_form(program.root, "do") {
         items.to_vec()
     } else {
         vec![program.root]
+    };
+    // Unwrap a `(module <name> member…)` to its members (the name is arg 0; members are the rest). A
+    // non-module form passes through unchanged. One level of unwrap — nested modules are a later concern.
+    let mut out = Vec::new();
+    for form in roots {
+        if let Some(args) = program.as_form(form, "module") {
+            // args[0] is the module name; args[1..] are its members.
+            out.extend(args.iter().skip(1).copied());
+        } else {
+            out.push(form);
+        }
     }
+    out
 }
 
 /// The set of names the program `export`s — the public surface. An `(export a b …)` form lists the

--- a/implementation/seed/crates/cadenza-syntax/tests/doc_item_projection.rs
+++ b/implementation/seed/crates/cadenza-syntax/tests/doc_item_projection.rs
@@ -121,6 +121,31 @@ export { map }";
 }
 
 #[test]
+fn projects_the_members_of_a_module_wrapped_program() {
+    // A program's public surface can live inside a `(module <name> member…)` form (e.g. a `.sexp`
+    // module), NOT only as top-level siblings. The projection unwraps a top-level `(module …)` to its
+    // members, so a module-wrapped def/type/effect is documented the same as a flat one. (Built via the
+    // s-expr reader, which produces the `(module …)` form directly.)
+    let arena = sexpr::read("(module m (def (inc (: n Int64)) (+ n 1)) (export inc))")
+        .expect("module s-expr reads");
+    let doc = doc_item::project(&arena, "m");
+    let items = doc_items(&doc);
+    let names: Vec<_> = items.iter().filter_map(|&i| item_name(&doc, i)).collect();
+    assert_eq!(
+        names,
+        vec!["inc"],
+        "the module's exported member `inc` is projected as a doc-item"
+    );
+    // And it carries the structured signature head (the member is projected exactly like a top-level def).
+    let sig = item_sig_node(&doc, items[0]).expect("a sig node");
+    assert_eq!(
+        doc.head_name(sig),
+        Some("inc"),
+        "the member's signature head"
+    );
+}
+
+#[test]
 fn projects_only_the_exported_public_surface() {
     // `helper` is defined but NOT exported → it must NOT appear; only the exported `pub_fn` does.
     let src = "\


### PR DESCRIPTION
Candidate PR for v-syntax's merge-request (ref b71b6ec28, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.