### PR TITLE
guide(runnable): add expected?: to Runnable Props + thread to MultiFileRunnable (files= value-assert)

### DIFF
--- a/guide/src/components/MultiFileRunnable.tsx
+++ b/guide/src/components/MultiFileRunnable.tsx
@@ -45,10 +45,14 @@ type Status =
 export function MultiFileRunnable({
   files,
   expect = "value",
+  expected,
   title,
 }: {
   files: readonly RunnableFile[];
   expect?: "value" | "error";
+  /** When set, the exact rendered value the file set must run to — the result pane shows it (and flags a
+   *  mismatch), and the check-examples gate asserts the run result equals it. */
+  expected?: string;
   title?: string;
 }) {
   // Seed the workspace once from the authored files. A malformed set (no entry / dup names) is an AUTHORING
@@ -166,13 +170,13 @@ export function MultiFileRunnable({
       </div>
 
       {status.phase !== "idle" && (
-        <StatusLine status={status} expect={expect} />
+        <StatusLine status={status} expect={expect} expected={expected} />
       )}
     </div>
   );
 }
 
-function StatusLine({ status, expect }: { status: Status; expect: "value" | "error" }) {
+function StatusLine({ status, expect, expected }: { status: Status; expect: "value" | "error"; expected?: string }) {
   if (status.phase === "busy") {
     return (
       <div className="border-t border-slate-700/60 bg-slate-800/40 px-4 py-2.5 font-mono text-[13px] text-slate-400">
@@ -181,10 +185,18 @@ function StatusLine({ status, expect }: { status: Status; expect: "value" | "err
     );
   }
   if (status.phase === "value") {
+    // When the author pinned an `expected` value, compare the run result against it: a match reads as a
+    // confirmed assertion (green), a mismatch as a problem (rose) — the same VALUE the check-examples gate
+    // asserts, shown to the reader. Normalize layout (newlines→space) so a pinned compound is stable.
+    const norm = (s: string) => s.replace(/\s*\n\s*/g, " ").trim();
+    const mismatch = expected != null && norm(status.text) !== norm(expected);
     return (
-      <div className="flex items-start gap-2 border-t border-slate-700/60 bg-emerald-950/30 px-4 py-2.5 font-mono text-[13px] text-emerald-300">
-        <span className="mt-0.5 shrink-0"><StatusIcon kind="ok" /></span>
-        <div className="min-w-0"><code>{status.text}</code></div>
+      <div className={`flex items-start gap-2 border-t border-slate-700/60 px-4 py-2.5 font-mono text-[13px] ${mismatch ? "bg-rose-950/30 text-rose-300" : "bg-emerald-950/30 text-emerald-300"}`}>
+        <span className="mt-0.5 shrink-0"><StatusIcon kind={mismatch ? "error" : "ok"} /></span>
+        <div className="min-w-0">
+          <code>{status.text}</code>
+          {mismatch && <div className="mt-1 text-rose-400/80">expected: <code>{expected}</code></div>}
+        </div>
       </div>
     );
   }

--- a/guide/src/components/Runnable.tsx
+++ b/guide/src/components/Runnable.tsx
@@ -65,6 +65,11 @@ interface Props {
   wrap?: boolean;
   /** What this example is meant to do — tunes the status pane. */
   expect?: "value" | "error";
+  /** (MULTI-FILE only) The exact rendered value the file set must run to — when set, the check-examples gate
+   *  asserts the run result equals it (not just that it runs), and the result pane shows it as the expected
+   *  value. A single-file Runnable pins values via `<Exercise>` instead, so this is specifically for a
+   *  `files=` runnable that wants to pin a trace (e.g. the agent-loop's terminal fold value). */
+  expected?: string;
   /** Optional caption shown above the editor. */
   title?: string;
   /** "run" (default) = compile + run the entry, showing its value. "test" = run the snippet's `@test`
@@ -85,10 +90,10 @@ type TestStatus =
   | { phase: "busy" }
   | { phase: "done"; outcome: TestRunOutcome };
 
-export function Runnable({ id, files, source, authoredIn = "sexpr", wrap = true, expect = "value", title, mode = "run", prelude = true }: Props) {
+export function Runnable({ id, files, source, authoredIn = "sexpr", wrap = true, expect = "value", expected, title, mode = "run", prelude = true }: Props) {
   // MULTI-FILE mode (operator-mandated): a set of files compiled together via compileWithPreloaded. Takes
   // precedence over the single-source paths; the explorer seam owns the file-set invariants + run wiring.
-  if (files) return <MultiFileRunnable files={files} expect={expect} title={title} />;
+  if (files) return <MultiFileRunnable files={files} expect={expect} expected={expected} title={title} />;
   // Below here `source` is required — a non-multi-file Runnable must carry one. A missing source is an
   // authoring bug; render it loudly rather than compiling an empty program.
   if (source == null) {


### PR DESCRIPTION
Candidate PR for v-guide-infra's merge-request (ref 9305dc84b0039b82a31aa205188ba4ae0b43e94c, lane docs). Auto-merge armed; pr-sync's schedule-pass reaps on green.