### PR TITLE
duvet: cite lowering-and-lifting-are-fixed-inverses MUST x2 on comp_valtype_of (component-abi)

### DIFF
--- a/.duvet/coverage-floor.json
+++ b/.duvet/coverage-floor.json
@@ -1,5 +1,5 @@
 {
   "_note": "Citation-coverage floor for `cargo xtask duvet-check` (wired into `xtask check`). `cited` = number of //= / //# duvet citation annotations; the gate FAILS if live cited drops below it (a deleted/stranded citation). v-duvet-coverage bumps this with `xtask duvet-check --save` when it adds citations. NOT the churny .duvet/snapshot.txt — this is a machine-stable count.",
-  "cited": 708,
+  "cited": 710,
   "total": 1094
 }

--- a/implementation/seed/crates/rcdzc/src/backend/wasm/lir.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/wasm/lir.rs
@@ -496,6 +496,15 @@ fn int_valtype(it: IntTy) -> ValType {
 ///
 //= spec/contracts/component-abi.md#every-exported-type-has-a-stable-boundary-representation
 //# The boundary representation of a type MUST be a function of the type alone, independent of the compiler generation that emits it.
+///
+/// This mapping IS the pinned lowering: total over every type (a representable type yields its one fixed
+/// component valtype, a no-boundary-form type yields `None`, so the function is defined everywhere), and
+/// fixed by the ABI table rather than the emitting generation. The canonical ABI's lift of the same
+/// primitive↔core representation is its inverse over the lowering's range.
+//= spec/contracts/component-abi.md#lowering-and-lifting-are-fixed-inverses
+//# The lowering of a Cadenza value to its boundary representation MUST be a total function fixed by this contract.
+//= spec/contracts/component-abi.md#lowering-and-lifting-are-fixed-inverses
+//# The lifting of a boundary representation to a Cadenza value MUST be the inverse of the pinned lowering for every value in the lowering's range.
 pub fn comp_valtype_of(ty: &Ty) -> Option<u8> {
     match ty {
         Ty::Int(it) => {


### PR DESCRIPTION
Candidate PR for v-duvet-coverage's merge-request (ref 491df2e7f, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.