### PR TITLE
ci(pages): deploy on a 30min schedule + dispatch, not per-push — stops pending-supersession cancelling every deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,17 +12,18 @@
 name: Deploy guide to Pages
 
 on:
-  push:
-    branches: [main]
-    # Only rebuild when something that affects the guide changed.
-    paths:
-      - "guide/**"
-      - "implementation/seed/crates/cdz-wasm/**"
-      - "implementation/seed/crates/rcdzc/**"
-      - "implementation/seed/crates/cadenza-syntax/**"
-      - "implementation/seed/crates/cdz-runtime/**"
-      - "xtask/**"
-      - ".github/workflows/pages.yml"
+  # SCHEDULED deploy, NOT per-push. A push trigger was cancelling every deploy: the guide build runs on the
+  # scarce ARM pool (runtime-hash reproducibility), so each push-triggered run sat PENDING waiting for a
+  # runner, and the next guide-affecting push queued behind it — GitHub's `pages` concurrency group cancels
+  # the older PENDING run when a newer one queues (even with cancel-in-progress:false, which only protects a
+  # RUNNING job). On a busy main, deploys were superseded before ever starting, so the published site went
+  # stale (7 consecutive cancelled runs). A scheduled run has no superseding push, so it reaches a runner and
+  # COMPLETES; each cron rebuild uses current trunk + fresh wasm, so there's no staged-wasm lag. The site
+  # lags trunk by at most the interval (30 min) — fine for a guide. `workflow_dispatch` stays so a human can
+  # force an immediate deploy when something urgent lands (rather than waiting for the next tick).
+  schedule:
+    # Every 30 min on an off-round minute (7,37) so it doesn't collide with other crons landing on :00/:30.
+    - cron: "7,37 * * * *"
   workflow_dispatch: {}
 
 # Least-privilege token scoped to publishing Pages.

--- a/guide/scripts/check-examples.mjs
+++ b/guide/scripts/check-examples.mjs
@@ -700,11 +700,33 @@ async function checkMultiFile(ex) {
     return `${ex.file} [Runnable multi-file] (${brief}): compiled but FAILED TO RUN — ${String(e.message || e).slice(0, 100)}`;
   }
   if (ex.expected != null) {
-    const normLayout = (s) => String(s).replace(/\s*\n\s*/g, " ").trim();
-    if (normLayout(got) !== normLayout(ex.expected))
+    // Compare `got` vs `expected` after normalizing BOTH the same way, so an author can pin EITHER the bare
+    // value (e.g. `asked-model; …`, matching the single-file scalar convention — a String result renders via
+    // the compound path as `(: "…" String)`, which is verbose) OR the full render form. normValue: collapse
+    // layout, strip a `(: <value> <type>)` ascription wrapper, and unquote a `"…"` string leaf. Applied to
+    // both sides so it's backward-compatible (a landed render-form pin still matches) AND ergonomic (a bare
+    // trace matches too) — v-guide-editor's authoring nicety without breaking the shipped agent-loop pin.
+    if (normValue(got) !== normValue(ex.expected))
       return `${ex.file} [Runnable multi-file] (${brief}): ran to ${JSON.stringify(String(got))}, expected ${JSON.stringify(ex.expected)}`;
   }
   return null;
+}
+
+/// Normalize a multi-file result / expected for comparison: collapse layout whitespace, strip an outer
+/// `(: <value> <type>)` ascription (the render form of a non-scalar), and unquote a `"…"` string leaf — so
+/// `(: "hi" String)`, `"hi"`, and `hi` all compare equal. A scalar (bare number/bool) is untouched (no
+/// ascription, no quotes). Pure + deterministic; unit-tested in check-examples' multi-file self-check.
+function normValue(s) {
+  let t = String(s).replace(/\s*\n\s*/g, " ").trim();
+  // strip a single outer (: <value> <type>) ascription — the value is everything between `(:␠` and the
+  // LAST top-level space+type. Simplest robust form for the common `(: "…" String)` / `(: 3 Int64)` shapes:
+  const asc = t.match(/^\(:\s+([\s\S]*)\s+[A-Za-z][\w.]*\)$/);
+  if (asc) t = asc[1].trim();
+  // unquote a "…" string leaf (resolve the common \" and \\ escapes), leaving a bare scalar as-is.
+  if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) {
+    t = t.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+  }
+  return t;
 }
 
 // ---- check one example in BOTH surfaces (the reader can toggle); null on success, else a reason ----
@@ -993,6 +1015,21 @@ for (const [src, ann] of [["@test\ndef attr_above_probe() = 1", "@test"], ['@tag
       throw new Error("entry (reducer) is not the lowered `text`");
     if (low.lowered.names.length !== low.lowered.sources.length || low.lowered.names.length !== low.lowered.formats.length)
       throw new Error("preload arrays are not equal length");
+    // normValue ergonomics + backward-compat: a bare value, a quoted string, and the full ascription form
+    // must all compare equal, so an author can pin `expected="asked-model; …"` OR `(: "…" String)`.
+    const cases = [
+      ['(: "asked-model; done" String)', "asked-model; done"],
+      ['"asked-model; done"', "asked-model; done"],
+      ["asked-model; done", "asked-model; done"],
+      ["(: 3 Int64)", "3"],
+      ["true", "true"], // scalar untouched
+    ];
+    for (const [input, want] of cases) {
+      if (normValue(input) !== want) throw new Error(`normValue(${JSON.stringify(input)}) = ${JSON.stringify(normValue(input))}, want ${JSON.stringify(want)}`);
+    }
+    // and the three forms of the same value are mutually equal (the whole point):
+    if (normValue('(: "x" String)') !== normValue('"x"') || normValue('"x"') !== normValue("x"))
+      throw new Error("normValue does not unify render-form / quoted / bare for the same string");
   } catch (e) {
     failures.push(`[multi-file extractor self-check] ${String(e.message || e)}`);
   }


### PR DESCRIPTION
Candidate PR for v-guide-infra's merge-request (ref de00e7c9f658d239dae9a68b409c68e392fb308f, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.