### PR TITLE
duvet: cite sharing-is-not-observable MUST on RRB structural-sharing header (memory-and-resource-model)

### DIFF
--- a/.duvet/coverage-floor.json
+++ b/.duvet/coverage-floor.json
@@ -1,5 +1,5 @@
 {
   "_note": "Citation-coverage floor for `cargo xtask duvet-check` (wired into `xtask check`). `cited` = number of //= / //# duvet citation annotations; the gate FAILS if live cited drops below it (a deleted/stranded citation). v-duvet-coverage bumps this with `xtask duvet-check --save` when it adds citations. NOT the churny .duvet/snapshot.txt — this is a machine-stable count.",
-  "cited": 710,
+  "cited": 711,
   "total": 1094
 }

--- a/implementation/seed/crates/cdz-runtime/src/lib.rs
+++ b/implementation/seed/crates/cdz-runtime/src/lib.rs
@@ -3676,8 +3676,13 @@ fn op_sum_new_reuse(disc: u32, payload: Handle, token: Handle) -> Handle {
 // 32-way radix trie over the SAME tagless `Node`. No new node field and no change to the free
 // cascade — exactly the bytes rope's trick: a vector's nodes are ordinary
 // `Node`s whose children live in `handles`, so structural sharing is just `rc > 1` on a shared
-// subtree and the existing iterative `op_drop` reclaims a whole trie transitively. Tagless dispatch
-// keeps this from colliding with tuples/lists: the compiler only ever calls `vec-*` on a value whose
+// subtree and the existing iterative `op_drop` reclaims a whole trie transitively. Sharing a subtree
+// is transparent: a shared node is immutable and byte-identical to a copied one, so whether a version
+// shares its predecessor's storage or copies it never changes what any op observes — the persistent
+// update path-copies the spine and `op_dup`s the retained children, so the two are indistinguishable.
+//= spec/capabilities/memory-and-resource-model.md#sharing-is-not-observable
+//# When the compiler represents a value by sharing another value's storage rather than by copying it, that sharing MUST NOT change the program's observable behavior, so that sharing storage is a transparent optimization rather than a distinction between two equal values.
+// Tagless dispatch keeps this from colliding with tuples/lists: the compiler only ever calls `vec-*` on a value whose
 // static type is a Vec and `arr-*` on a tuple/list, so `handles`/`raw` are interpreted as a vector
 // only inside these ops (same argument as the rope, §3 of that doc).
 //


### PR DESCRIPTION
Candidate PR for v-duvet-coverage's merge-request (ref 75fb6502e, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.