### PR TITLE
flake: add apps.warm-keep - pin the local /nix/store warm layer as GC-roots (local-gating enabler)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,10 +32,16 @@ permissions:
   pages: write
   id-token: write
 
-# One in-flight deploy at a time; don't cancel a running publish.
-concurrency:
-  group: pages
-  cancel-in-progress: false
+# NO workflow-level `concurrency: group` on purpose. A `group: pages` (even with cancel-in-progress:false)
+# CANCELS an older PENDING run whenever a newer run queues — and cancel-in-progress:false only protects a
+# RUNNING job, not a queued one. The build runs on the scarce ARM pool, so a run can sit PENDING for a runner
+# longer than the 30-min cron interval; with a group, each new cron then cancelled the prior pending cron →
+# deploys perpetually cancelled-before-starting, site went stale (observed: dispatch cancelled at the exact
+# second the next cron queued). Serialization of the actual PUBLISH is already handled by the `github-pages`
+# ENVIRONMENT (the deploy job below) — GitHub queues concurrent deployments to that environment. So the group
+# was redundant AND harmful: dropping it lets a pending run wait for its runner instead of being cancelled,
+# and the environment still guarantees one publish at a time. Concurrent BUILD jobs are harmless (idempotent
+# — each builds the same trunk). Latest-to-finish wins the publish, which is the intent.
 
 jobs:
   build:

--- a/flake.nix
+++ b/flake.nix
@@ -1948,5 +1948,45 @@
             echo "cdz: CDZ_STORE → nix component store ($CDZ_STORE)"
           '';
         };
+
+        # ── LOCAL WARM-KEEP (v-nix+v-fleet-tooling 2026-08-08) ─────────────────────────────────────
+        #
+        # `nix run .#warm-keep` — keeps the LOCAL /nix/store hot for local-gating. Background: the
+        # operator ran out of GHA credits (2026-08-08), so the fleet gates every MR LOCALLY via
+        # `cargo xtask gate-local` / `.#checks.<sys>.local-gate`. cache-warm.yml (which kept the GHA
+        # cache hot) is itself a GHA workflow — DEAD now — so the local host's /nix/store is the ONLY
+        # warm source. If the heavy warm layer (crane's ~341M cargo-artifacts dep-closure + the
+        # component store) gets garbage-collected between MRs, gate-local drops from ~1s/warm (or ~7-8m
+        # for the changed-crate tier) to a full COLD rebuild — prohibitive per-MR. This app REALISES +
+        # pins that warm layer as durable GC-roots (via `--out-link`, which registers an indirect GC
+        # root), so `nix-collect-garbage` never reclaims it. v-ft's gate-local/drain invokes this (or a
+        # host timer runs it periodically) to replace the dead cache-warm.yml with a LOCAL warm-keep.
+        # Idempotent + fast when already warm (all cache-hit); pins the SAME set the local gate builds.
+        apps.warm-keep =
+          let
+            warmKeep = pkgs.writeShellApplication {
+              name = "cdz-warm-keep";
+              runtimeInputs = [ pkgs.nix pkgs.coreutils ];
+              text = ''
+                # GC-root dir: keep the roots with the repo (survives across MRs, one place to see/clear).
+                root_dir="''${CDZ_WARM_ROOT:-.nix-warm-roots}"
+                mkdir -p "$root_dir"
+                echo "cdz warm-keep: pinning the local warm layer as GC-roots under $root_dir/ (system ${system})"
+                # The heavy layers gate-local depends on: the crane dep-closure (~341M, the big one),
+                # the component store, and the local-gate aggregate itself (pulls the 9 required checks'
+                # closure). --out-link registers each as an indirect GC-root so the store stays hot.
+                nix build \
+                  ".#packages.${system}.cargo-artifacts" \
+                  ".#packages.${system}.store" \
+                  ".#checks.${system}.local-gate" \
+                  --out-link "$root_dir/warm" --print-build-logs
+                echo "cdz warm-keep: done — local /nix/store warm layer pinned (gate-local stays fast)."
+              '';
+            };
+          in
+          {
+            type = "app";
+            program = "${warmKeep}/bin/cdz-warm-keep";
+          };
       });
 }

--- a/guide/src/content/chapters/PlatformExecution.tsx
+++ b/guide/src/content/chapters/PlatformExecution.tsx
@@ -246,6 +246,15 @@ export default function PlatformExecution() {
         the shape of the thing: the same idea that made a value out of a program's history, scaled into a
         runtime for agents built in Cadenza.
       </P>
+      <P>
+        One thing is left: writing a reducer yourself. The{" "}
+        <Link to="/writing-a-reducer" className="text-cadenza-300 underline-offset-2 hover:underline">
+          next chapter
+        </Link>{" "}
+        turns the model concrete, building a real agent-harness reducer in Cadenza, from the empty reducer up
+        to one that reads state and requests effects, where the language you learned in the first pillar
+        becomes the language an agent runs on.
+      </P>
     </article>
   );
 }

--- a/implementation/seed/crates/cdz-agent-host/src/disk_cache.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/disk_cache.rs
@@ -1,0 +1,390 @@
+//! A bounded on-DISK cache tier over any [`BlobStore`] (operator directive: "multi-tier to disk" — the tier
+//! between the in-memory [`CachingBlobStore`](crate::CachingBlobStore) and the backing store, e.g. S3). Blob
+//! reads are content-addressed, so a cached file is IMMUTABLE and always correct for its key — a hit needs no
+//! invalidation, and eviction is safe (a re-fetch from the inner store repopulates it).
+//!
+//! **Why a bespoke file cache, not a wrapped [`DiskBlobStore`].** `DiskBlobStore` is a durable content-store
+//! with NO delete / enumerate API, so it can't be bounded (no eviction) — and the host must not edit the
+//! kernel to add one. This tier manages its OWN cache directory directly: content-hash-named files, a byte
+//! budget, and eviction by deleting the oldest cached files. It is a CACHE (evictable, bounded), distinct from
+//! `DiskBlobStore`'s durable store.
+//!
+//! **Bounded by TOTAL BYTES, FIFO eviction.** On insert, if the cache would exceed its byte budget, the
+//! OLDEST-inserted files are deleted until the newcomer fits. FIFO (insertion order) not LRU: a disk tier's
+//! value is absorbing reuse across a session, and FIFO needs no per-hit disk write (an LRU touch would rewrite
+//! metadata on every read) — the in-memory [`CachingBlobStore`] S3-FIFO tier above already does the
+//! recency-aware admission; this tier is the larger overflow catch. A blob LARGER than the whole budget is
+//! served through without caching (never evict everything for one file). `budget == 0` disables the tier
+//! (pure pass-through to the inner store).
+//!
+//! **Self-verifying + crash-safe writes** (same discipline as `DiskBlobStore`): a cached file is written to a
+//! temp path then atomically renamed into place, and a read RE-HASHES the file, refusing (and removing) a file
+//! that doesn't match its name — a truncated/corrupt cache file is a miss that re-fetches, never bad bytes.
+//!
+//! **Boot-enumeration.** On construction the cache dir is scanned to rebuild the in-memory index (which hashes
+//! are present + their sizes + a stable insertion order), so a restart reuses the on-disk cache instead of
+//! starting cold.
+//!
+//! **Single-threaded convention.** `?Send` like the other host pieces; [`BlobStore::get`] takes `&self`, so the
+//! index (map + FIFO order + byte total) lives behind a [`RefCell`].
+
+use cdz_kernel::blob::BlobStore;
+use cdz_kernel::hash::Hash;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+
+/// The in-memory index over the cache dir: byte size per cached hash + FIFO insertion order + the running
+/// total. A hash in `sizes` has a file on disk and appears once in `order`.
+struct Index {
+    sizes: HashMap<Hash, u64>,
+    /// Insertion order (front = oldest = next eviction victim). Each cached hash appears exactly once.
+    order: VecDeque<Hash>,
+    total_bytes: u64,
+}
+
+/// A bounded on-disk cache tier in front of an inner [`BlobStore`] `B`. Caches blobs as content-hash-named
+/// files under `dir`, bounded to `budget` total bytes with FIFO eviction.
+pub struct DiskCacheTier<B> {
+    inner: B,
+    dir: PathBuf,
+    /// Max total bytes of cached files. `0` disables the tier (pass-through).
+    budget: u64,
+    index: RefCell<Index>,
+}
+
+impl<B> DiskCacheTier<B> {
+    /// Wrap `inner` with an on-disk cache at `dir`, bounded to `max_bytes` total. Creates `dir` if absent and
+    /// SCANS it to rebuild the index from any pre-existing cache files (boot-enumeration — a restart reuses
+    /// the warm cache). `max_bytes == 0` disables caching (pass-through); the dir is still created (harmless).
+    /// A dir-scan I/O error starts with an empty index (the cache is best-effort — it must never fail the
+    /// host; a re-fetch repopulates).
+    pub fn new(inner: B, dir: impl Into<PathBuf>, max_bytes: u64) -> Self {
+        let dir = dir.into();
+        let _ = std::fs::create_dir_all(&dir);
+        let index = Self::scan_dir(&dir);
+        DiskCacheTier {
+            inner,
+            dir,
+            budget: max_bytes,
+            index: RefCell::new(index),
+        }
+    }
+
+    /// Rebuild the index by listing `dir`: each entry whose filename is a valid hash-hex is a cached blob;
+    /// record its size. Order across a scan is filesystem-arbitrary (a cold-start detail — FIFO order only has
+    /// to be SOME consistent order; fresh inserts append in real order). A non-hex / unreadable entry is
+    /// skipped (foreign files don't corrupt the index).
+    fn scan_dir(dir: &Path) -> Index {
+        let mut sizes = HashMap::new();
+        let mut order = VecDeque::new();
+        let mut total_bytes = 0u64;
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let Some(name) = name.to_str() else { continue };
+                let Some(hash) = Hash::from_hex(name) else {
+                    continue;
+                };
+                let Ok(meta) = entry.metadata() else { continue };
+                if !meta.is_file() {
+                    continue;
+                }
+                let len = meta.len();
+                sizes.insert(hash, len);
+                order.push_back(hash);
+                total_bytes += len;
+            }
+        }
+        Index {
+            sizes,
+            order,
+            total_bytes,
+        }
+    }
+
+    /// The cache file path for `hash` — a flat `<dir>/<hex>` (the cache is a single dir; unlike `DiskBlobStore`
+    /// it isn't sharded since it's bounded/evicted, not a large durable keyspace).
+    fn path_for(&self, hash: &Hash) -> PathBuf {
+        self.dir.join(hash.to_hex())
+    }
+
+    /// Current cached file count — for tests/inspection.
+    pub fn cached_entries(&self) -> usize {
+        self.index.borrow().sizes.len()
+    }
+
+    /// Current total cached bytes — the quantity the budget bounds.
+    pub fn cached_bytes(&self) -> u64 {
+        self.index.borrow().total_bytes
+    }
+
+    /// Write `bytes` under `hash` into the cache dir (atomic temp+rename), evicting oldest files first to stay
+    /// within budget. A blob larger than the whole budget is NOT cached (served through). Already-cached =
+    /// no-op (content-addressed → identical bytes). Best-effort: an I/O failure just leaves it uncached.
+    fn cache_write(&self, hash: &Hash, bytes: &[u8]) {
+        let len = bytes.len() as u64;
+        if self.budget == 0 || len > self.budget {
+            return;
+        }
+        {
+            if self.index.borrow().sizes.contains_key(hash) {
+                return;
+            }
+        }
+        // Evict oldest until the newcomer fits.
+        self.evict_to_fit(len);
+        // Atomic write: temp file in the same dir, then rename (intra-dir rename is atomic).
+        let final_path = self.path_for(hash);
+        let tmp_path = self.dir.join(format!("{}.tmp", hash.to_hex()));
+        if std::fs::write(&tmp_path, bytes).is_err() {
+            let _ = std::fs::remove_file(&tmp_path);
+            return;
+        }
+        if std::fs::rename(&tmp_path, &final_path).is_err() {
+            let _ = std::fs::remove_file(&tmp_path);
+            return;
+        }
+        let mut idx = self.index.borrow_mut();
+        idx.sizes.insert(*hash, len);
+        idx.order.push_back(*hash);
+        idx.total_bytes += len;
+    }
+
+    /// Delete oldest-inserted cache files until `total_bytes + incoming <= budget` (or the cache is empty).
+    fn evict_to_fit(&self, incoming: u64) {
+        let mut idx = self.index.borrow_mut();
+        while idx.total_bytes + incoming > self.budget {
+            let Some(victim) = idx.order.pop_front() else {
+                break;
+            };
+            if let Some(len) = idx.sizes.remove(&victim) {
+                idx.total_bytes -= len;
+                let _ = std::fs::remove_file(self.dir.join(victim.to_hex()));
+            }
+        }
+    }
+
+    /// Read a cached blob from disk, VERIFYING it hashes to `hash`. A mismatch (corrupt/truncated file) or a
+    /// read error is treated as a MISS (returns None) AND the bad file is removed + de-indexed, so a re-fetch
+    /// repopulates it cleanly. Only called when the index says the hash is present.
+    fn cache_read(&self, hash: &Hash) -> Option<Vec<u8>> {
+        let path = self.path_for(hash);
+        match std::fs::read(&path) {
+            Ok(bytes) if Hash::of(&bytes) == *hash => Some(bytes),
+            _ => {
+                // Corrupt/absent/mismatch: drop it from the cache so a re-fetch rewrites it.
+                let mut idx = self.index.borrow_mut();
+                if let Some(len) = idx.sizes.remove(hash) {
+                    idx.total_bytes -= len;
+                    if let Some(pos) = idx.order.iter().position(|h| h == hash) {
+                        idx.order.remove(pos);
+                    }
+                }
+                let _ = std::fs::remove_file(&path);
+                None
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl<B: BlobStore> BlobStore for DiskCacheTier<B> {
+    /// Write THROUGH to the inner store, then populate the disk cache.
+    async fn put(&mut self, bytes: &[u8]) -> std::io::Result<Hash> {
+        let hash = self.inner.put(bytes).await?;
+        self.cache_write(&hash, bytes);
+        Ok(hash)
+    }
+
+    /// Serve from the disk cache on a hit (verified); on a miss, fetch from the inner store and populate the
+    /// cache (promote-on-hit). Content-addressed → a cached file is always valid for its key, no invalidation.
+    async fn get(&self, hash: &Hash) -> std::io::Result<Option<Vec<u8>>> {
+        if self.budget > 0 && self.index.borrow().sizes.contains_key(hash) {
+            if let Some(bytes) = self.cache_read(hash) {
+                return Ok(Some(bytes));
+            }
+            // cache_read found a corrupt file (already de-indexed + removed) — fall through to the inner store.
+        }
+        let fetched = self.inner.get(hash).await?;
+        if let Some(bytes) = &fetched {
+            self.cache_write(hash, bytes);
+        }
+        Ok(fetched)
+    }
+
+    /// Existence probe: a cached file trivially exists; otherwise defer to the inner store's probe (cheaper
+    /// than a fetch on a real backend). Doesn't populate (a `has` fetches no bytes).
+    async fn has(&self, hash: &Hash) -> std::io::Result<bool> {
+        if self.budget > 0 && self.index.borrow().sizes.contains_key(hash) {
+            return Ok(true);
+        }
+        self.inner.has(hash).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cdz_kernel::blob::MemBlobStore;
+
+    fn blob(b: u8, n: usize) -> Vec<u8> {
+        vec![b; n]
+    }
+
+    /// A unique proven-fresh cache dir per test (no fixed temp path).
+    fn cache_dir(tag: &str) -> PathBuf {
+        crate::testutil::unique_temp_dir(tag)
+    }
+
+    /// An inner store that records get() calls + can go blind, to prove a disk-cache hit skips the inner store.
+    struct CountingBlobStore {
+        inner: MemBlobStore,
+        gets: std::cell::Cell<usize>,
+        blind: std::cell::Cell<bool>,
+    }
+    #[async_trait::async_trait(?Send)]
+    impl BlobStore for CountingBlobStore {
+        async fn put(&mut self, bytes: &[u8]) -> std::io::Result<Hash> {
+            self.inner.put(bytes).await
+        }
+        async fn get(&self, hash: &Hash) -> std::io::Result<Option<Vec<u8>>> {
+            self.gets.set(self.gets.get() + 1);
+            if self.blind.get() {
+                return Ok(None);
+            }
+            self.inner.get(hash).await
+        }
+    }
+
+    #[tokio::test]
+    async fn hit_after_miss_serves_from_disk_without_rehitting_inner() {
+        let dir = cache_dir("diskcache-hit");
+        let mut inner = MemBlobStore::new();
+        let bytes = blob(1, 100);
+        let hash = inner.put(&bytes).await.unwrap();
+        let counting = CountingBlobStore {
+            inner,
+            gets: std::cell::Cell::new(0),
+            blind: std::cell::Cell::new(false),
+        };
+        let c = DiskCacheTier::new(counting, &dir, 1024);
+        assert_eq!(c.get(&hash).await.unwrap().as_deref(), Some(&bytes[..]));
+        assert_eq!(
+            c.inner.gets.get(),
+            1,
+            "the miss consulted the inner store once"
+        );
+        c.inner.blind.set(true);
+        assert_eq!(
+            c.get(&hash).await.unwrap().as_deref(),
+            Some(&bytes[..]),
+            "served from the disk cache despite a blinded inner store"
+        );
+        assert_eq!(
+            c.inner.gets.get(),
+            1,
+            "the disk hit did NOT re-hit the inner store"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn fifo_evicts_oldest_at_the_byte_bound() {
+        // Budget 250. Put A(100), B(100) [200], then C(100): total would be 300 > 250 → evict A (oldest).
+        let dir = cache_dir("diskcache-evict");
+        let mut c = DiskCacheTier::new(MemBlobStore::new(), &dir, 250);
+        let a = blob(b'a', 100);
+        let bb = blob(b'b', 100);
+        let cc = blob(b'c', 100);
+        let ha = c.put(&a).await.unwrap();
+        let _hb = c.put(&bb).await.unwrap();
+        assert_eq!(c.cached_bytes(), 200);
+        let _hc = c.put(&cc).await.unwrap();
+        assert_eq!(c.cached_bytes(), 200, "stayed within the 250 budget");
+        assert!(
+            !dir.join(ha.to_hex()).exists(),
+            "A (oldest) was evicted — its file is gone"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn a_blob_larger_than_the_budget_is_served_but_not_cached() {
+        let dir = cache_dir("diskcache-oversized");
+        let mut c = DiskCacheTier::new(MemBlobStore::new(), &dir, 50);
+        let big = blob(9, 100);
+        let h = c.put(&big).await.unwrap();
+        assert_eq!(c.cached_bytes(), 0, "oversized blob not cached");
+        assert_eq!(
+            c.get(&h).await.unwrap().as_deref(),
+            Some(&big[..]),
+            "still served from the inner store"
+        );
+        assert_eq!(c.cached_bytes(), 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn budget_zero_is_a_pure_passthrough() {
+        let dir = cache_dir("diskcache-zero");
+        let mut c = DiskCacheTier::new(MemBlobStore::new(), &dir, 0);
+        let bytes = blob(7, 100);
+        let h = c.put(&bytes).await.unwrap();
+        assert_eq!(c.cached_bytes(), 0);
+        assert_eq!(c.get(&h).await.unwrap().as_deref(), Some(&bytes[..]));
+        assert_eq!(c.cached_bytes(), 0, "disabled tier never caches");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn boot_enumeration_reuses_a_warm_on_disk_cache() {
+        // Populate a cache, drop it, then construct a NEW tier over the SAME dir + a blinded inner store: the
+        // boot scan rebuilds the index, so the blob is served from the warm disk cache without the inner.
+        let dir = cache_dir("diskcache-warm");
+        let bytes = blob(5, 120);
+        let hash = {
+            let mut c = DiskCacheTier::new(MemBlobStore::new(), &dir, 1024);
+            let h = c.put(&bytes).await.unwrap();
+            assert_eq!(c.cached_bytes(), 120);
+            h
+        };
+        // Fresh tier, same dir, inner store that has NOTHING (proves the disk cache served it).
+        let c2 = DiskCacheTier::new(MemBlobStore::new(), &dir, 1024);
+        assert_eq!(
+            c2.cached_bytes(),
+            120,
+            "boot scan rebuilt the index from the warm dir"
+        );
+        assert_eq!(
+            c2.get(&hash).await.unwrap().as_deref(),
+            Some(&bytes[..]),
+            "the warm on-disk cache served the blob after a restart"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn a_corrupt_cache_file_is_a_miss_that_refetches() {
+        // Tamper a cache file so it no longer hashes to its name: the read detects the mismatch, removes it,
+        // and falls through to the inner store (which still has the real bytes).
+        let dir = cache_dir("diskcache-corrupt");
+        let mut inner = MemBlobStore::new();
+        let bytes = blob(4, 100);
+        let hash = inner.put(&bytes).await.unwrap();
+        let c = DiskCacheTier::new(inner, &dir, 1024);
+        // Populate the cache via a get (miss → inner → cache).
+        assert_eq!(c.get(&hash).await.unwrap().as_deref(), Some(&bytes[..]));
+        assert_eq!(c.cached_bytes(), 100);
+        // Corrupt the on-disk file.
+        std::fs::write(dir.join(hash.to_hex()), b"tampered bytes").unwrap();
+        // A get re-hashes, detects the mismatch, removes it, and re-fetches from the inner store.
+        assert_eq!(
+            c.get(&hash).await.unwrap().as_deref(),
+            Some(&bytes[..]),
+            "a corrupt cache file is a miss that re-fetches the real bytes"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/implementation/seed/crates/cdz-agent-host/src/lib.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lib.rs
@@ -66,6 +66,7 @@ pub mod config;
 pub mod converse;
 #[cfg(feature = "live-net")]
 pub mod converse_json;
+pub mod disk_cache;
 #[cfg(feature = "live-aws-storage")]
 pub mod dynamo_log;
 pub mod emit;
@@ -107,6 +108,7 @@ pub use config::{
     NameStoreConfig, ObservabilityConfig, RetryConfig, SessionRegistryConfig, TracingConfig,
     TracingFormat, TracingOutput,
 };
+pub use disk_cache::DiskCacheTier;
 #[cfg(feature = "live-aws-storage")]
 pub use dynamo_log::{DynamoLogSink, DynamoLogSinkBuilder};
 pub use emit::EmitExecutor;

--- a/implementation/seed/crates/cdz-kernel/src/kernel.rs
+++ b/implementation/seed/crates/cdz-kernel/src/kernel.rs
@@ -4047,6 +4047,140 @@ mod monotonic_now_tests {
             "the Err outcome is a first-class log event"
         );
     }
+
+    // ---- GAP-4 context-compaction (Option A: pure reducer policy, ZERO kernel change) --------------------
+    //
+    // The /compact problem for a self-hosting agent-reducer: its context is its event log + KV, so without a
+    // summarize-and-compact strategy the WORKING SET (kv) grows unbounded turn over turn. Option A (concierge
+    // ruling 2026-08-07, aligned with minimize-kernel-logic): the compaction is PURE REDUCER POLICY over the
+    // EXISTING kv mechanism (put/delete) — the reducer folds accumulated detail entries into a single summary
+    // entry and DELETES the detail keys, bounding the working set. NO kernel mechanism (no log pruning, no
+    // Checkpoint event, no replay-contract change — those are B/C, deferred to an operator ruling). This
+    // fold-proof pins that the pattern composes on the existing fold+kv seam, the M3/I3 precedent: prove the
+    // reducer fold in-kernel with a native Reducer before any host policy drives it.
+    //
+    // The reducer keys off the inbound payload: b"detail:<x>" accumulates a per-turn detail entry under
+    // detail/<seq>; b"compact" folds ALL detail/* into one summary/latest entry (a trivial concatenation
+    // stands in for a real model summary — the SHAPE is what's proven) + deletes every detail/* key.
+    struct CompactingReducer;
+    #[async_trait::async_trait(?Send)]
+    impl Reducer for CompactingReducer {
+        async fn fold(&self, event: &Event, kv: &mut Kv) -> FoldOutput {
+            if let EventBody::Inbound { payload, .. } = &event.body {
+                let crate::effect::Payload::Inline(bytes) = payload else {
+                    return FoldOutput::none();
+                };
+                let msg = bytes.as_ref();
+                if let Some(detail) = msg.strip_prefix(b"detail:") {
+                    // Accumulate a detail entry keyed by a monotonic index (the count of existing detail/*).
+                    let n = (0u64..)
+                        .take_while(|i| kv.get(format!("detail/{i}").as_bytes()).is_some())
+                        .count();
+                    kv.put(format!("detail/{n}").into_bytes(), detail.to_vec());
+                } else if msg == b"compact" {
+                    // Fold ALL detail/* into one summary + prune the detail keys (bound the working set).
+                    let mut keys: Vec<Vec<u8>> = Vec::new();
+                    let mut summary: Vec<u8> = Vec::new();
+                    for i in 0u64.. {
+                        let k = format!("detail/{i}").into_bytes();
+                        match kv.get(&k) {
+                            Some(v) => {
+                                if !summary.is_empty() {
+                                    summary.push(b'|');
+                                }
+                                summary.extend_from_slice(v);
+                                keys.push(k);
+                            }
+                            None => break,
+                        }
+                    }
+                    kv.put(b"summary/latest".to_vec(), summary);
+                    for k in keys {
+                        kv.delete(&k);
+                    }
+                }
+            }
+            FoldOutput::none()
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn gap4_option_a_compaction_folds_detail_into_a_summary_and_bounds_the_working_set() {
+        // Option A end-to-end: accumulate detail across turns → the working set grows → a compact turn folds
+        // it into one summary + prunes the detail, so kv shrinks back. Pure reducer policy over put/delete —
+        // no kernel change, no log pruning (the LOG still records every turn; only the KV working set is
+        // bounded, which is what drives the per-turn /compact problem).
+        let mut exec = RecordingExecutor::new();
+        let mut s = Session::genesis(Hash::of(b"gap4-compact-v1"), Hash::of(b"nonce"));
+        let authz = Authorizer::deny_all(); // the reducer emits no effects; authz is irrelevant here
+        let feed = |body: &[u8]| EventBody::Inbound {
+            content_type: ContentType {
+                family: "message".into(),
+                version: 1,
+            },
+            payload: crate::effect::Payload::Inline(body.to_vec().into()),
+        };
+
+        // Three detail turns → three detail/* entries in the working set.
+        for msg in [b"detail:alpha".as_slice(), b"detail:beta", b"detail:gamma"] {
+            s.deliver(feed(msg), None, &CompactingReducer, &authz, &mut exec)
+                .await
+                .expect("deliver detail");
+        }
+        assert_eq!(s.kv().get(b"detail/0"), Some(&b"alpha"[..]));
+        assert_eq!(s.kv().get(b"detail/2"), Some(&b"gamma"[..]));
+        assert_eq!(
+            s.kv().len(),
+            3,
+            "three detail entries accumulated in the working set"
+        );
+
+        // A compact turn: fold detail/* → summary/latest + prune the detail keys.
+        s.deliver(
+            feed(b"compact"),
+            None,
+            &CompactingReducer,
+            &authz,
+            &mut exec,
+        )
+        .await
+        .expect("deliver compact");
+
+        // The working set is now BOUNDED — one summary entry, all detail pruned.
+        assert_eq!(
+            s.kv().get(b"summary/latest"),
+            Some(&b"alpha|beta|gamma"[..]),
+            "compaction folds every detail entry into one summary"
+        );
+        assert_eq!(
+            s.kv().get(b"detail/0"),
+            None,
+            "detail keys are pruned by the fold"
+        );
+        assert_eq!(s.kv().get(b"detail/1"), None);
+        assert_eq!(s.kv().get(b"detail/2"), None);
+        assert_eq!(
+            s.kv().len(),
+            1,
+            "the working set shrank to the single summary — bounded regardless of turns folded"
+        );
+
+        // The pattern is REPLAY-DETERMINISTIC (no kernel change): a fresh replay of the same log reconstructs
+        // the identical post-compaction kv (the compaction is an ordinary fold, already on the log).
+        let replayed = Session::replay(s.log().to_vec(), &CompactingReducer)
+            .await
+            .expect("replay a compacted session");
+        assert_eq!(
+            replayed.kv().get(b"summary/latest"),
+            Some(&b"alpha|beta|gamma"[..])
+        );
+        assert_eq!(replayed.kv().get(b"detail/0"), None);
+        assert_eq!(
+            replayed.kv().len(),
+            1,
+            "replay reconstructs the identical bounded working set — compaction is just a fold on the log"
+        );
+    }
 }
 
 // §lifecycle I1: the Terminated marker + the first-class FoldRefused guard. A session terminated by another

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -6287,3 +6287,6 @@ pass	lf2 a PERFORMING recursive walk — each element visit draws, pairing eleme
 pass	lf3 the arm pushes TWO elements per dispatch (both lengths read from the PRE-push list) — the third draw reads length 5
 pass	lf4 a per-element dispatch comparing each element against the RISING state — amplify-or-pass per visit
 pass	lf5 TWO lists walked in LOCKSTEP with a per-pair 2-arg dispatch — length-guarded via projection helpers
+pass	mi1 enumeration DELTA across dispatches — dumps before and after keyed inserts, collision rows shrink the delta
+pass	mi2 SORTED Set enumeration survives a draw-keyed insert — positional reads, the collision row exposes the missing third slot
+pass	mi3 the arm AGGREGATES map values via a to-list walk — the n=1 row OVERWRITES the seed value, shrinking the total

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -6287,3 +6287,6 @@ pass	lf2 a PERFORMING recursive walk — each element visit draws, pairing eleme
 pass	lf3 the arm pushes TWO elements per dispatch (both lengths read from the PRE-push list) — the third draw reads length 5
 pass	lf4 a per-element dispatch comparing each element against the RISING state — amplify-or-pass per visit
 pass	lf5 TWO lists walked in LOCKSTEP with a per-pair 2-arg dispatch — length-guarded via projection helpers
+pass	mi1 enumeration DELTA across dispatches — dumps before and after keyed inserts, collision rows shrink the delta
+pass	mi2 SORTED Set enumeration survives a draw-keyed insert — positional reads, the collision row exposes the missing third slot
+pass	mi3 the arm AGGREGATES map values via a to-list walk — the n=1 row OVERWRITES the seed value, shrinking the total

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -6287,3 +6287,6 @@ pass	lf2 a PERFORMING recursive walk — each element visit draws, pairing eleme
 pass	lf3 the arm pushes TWO elements per dispatch (both lengths read from the PRE-push list) — the third draw reads length 5
 pass	lf4 a per-element dispatch comparing each element against the RISING state — amplify-or-pass per visit
 pass	lf5 TWO lists walked in LOCKSTEP with a per-pair 2-arg dispatch — length-guarded via projection helpers
+pass	mi1 enumeration DELTA across dispatches — dumps before and after keyed inserts, collision rows shrink the delta
+pass	mi2 SORTED Set enumeration survives a draw-keyed insert — positional reads, the collision row exposes the missing third slot
+pass	mi3 the arm AGGREGATES map values via a to-list walk — the n=1 row OVERWRITES the seed value, shrinking the total

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -16462,3 +16462,65 @@
             (export main)))
   (call   main (: 5 Int64)) (output (: 158 Int64))
   (call   main (: 0 Int64)) (output (: 143 Int64)))
+
+;; ── enumeration as OBSERVATION across mutating dispatches (breaker mi) ───────────────────────────
+;; The static enumeration pins dump once; these observe enumerations ACROSS a mutating sequence:
+;; mi1 Map.to-list dumps BEFORE and AFTER keyed inserts (collision rows shrink the delta); mi2
+;; SORTED Set enumeration after a draw-keyed insert — positional reads with first/last/collision
+;; placements; mi3 the arm aggregates map VALUES via a to-list walk inside the arm (the n=1 row
+;; overwrites the seed value — insert-replace semantics through the effect thread).
+
+(case "mi1 enumeration DELTA across dispatches — dumps before and after keyed inserts, collision rows shrink the delta"
+  (input  (do
+            (effect Db (op put (-> Int64 Int64)) (op dump (-> (List (Tuple Int64 Int64)))))
+            (def (main (: n Int64))
+              (handle Db (map (1 10))
+                ((put (k) m (resume (Map.len m) (Map.insert m k (* k 2))))
+                 (dump () m (resume (Map.to-list m) m)))
+                (let ((before (List.len (Db.dump))))
+                  (do
+                    (Db.put n)
+                    (Db.put 7)
+                    (+ (* 100 (List.len (Db.dump))) (* 10 before))))))
+            (export main)))
+  (call   main (: 5 Int64)) (output (: 310 Int64))
+  (call   main (: 1 Int64)) (output (: 210 Int64))
+  (call   main (: 7 Int64)) (output (: 210 Int64)))
+
+(case "mi2 SORTED Set enumeration survives a draw-keyed insert — positional reads, the collision row exposes the missing third slot"
+  (input  (do
+            (effect Sx (op add (-> Int64 Int64)) (op dump (-> (List Int64))))
+            (def (at-or (: xs (List Int64)) (: i Int64))
+              (match (List.at xs i) ((Some v) v) ((None) -1)))
+            (def (main (: n Int64))
+              (handle Sx (Set.of (list 20 8))
+                ((add (v) s (resume (Set.len s) (Set.insert s v)))
+                 (dump () s (resume (Set.to-list s) s)))
+                (do
+                  (Sx.add n)
+                  (let ((xs (Sx.dump)))
+                    (+ (* 100 (at-or xs 0)) (+ (* 10 (at-or xs 1)) (at-or xs 2)))))))
+            (export main)))
+  (call   main (: 5 Int64)) (output (: 600 Int64))
+  (call   main (: 30 Int64)) (output (: 1030 Int64))
+  (call   main (: 8 Int64)) (output (: 999 Int64)))
+
+(case "mi3 the arm AGGREGATES map values via a to-list walk — the n=1 row OVERWRITES the seed value, shrinking the total"
+  (input  (do
+            (effect Db (op put (-> Int64 Int64)) (op total (-> Int64)))
+            (def (sum-snd (: xs (List (Tuple Int64 Int64))) (: i Int64))
+              (match (List.at xs i)
+                ((Some p) (match p ((tuple k v) (+ v (sum-snd xs (+ i 1))))))
+                ((None) 0)))
+            (def (main (: n Int64))
+              (handle Db (map (1 100))
+                ((put (k) m (resume (Map.len m) (Map.insert m k k)))
+                 (total () m (resume (sum-snd (Map.to-list m) 0) m)))
+                (do
+                  (Db.put n)
+                  (Db.put 3)
+                  (Db.total))))
+            (export main)))
+  (call   main (: 5 Int64)) (output (: 108 Int64))
+  (call   main (: 1 Int64)) (output (: 4 Int64))
+  (call   main (: 3 Int64)) (output (: 103 Int64)))

--- a/xtask/src/fleet.rs
+++ b/xtask/src/fleet.rs
@@ -757,6 +757,14 @@ pub enum FleetCmd {
         /// Actually reap + dispatch (write trunk, send acks, open PRs). Without it, DRY preview only.
         #[arg(long)]
         execute: bool,
+        /// LOCAL-GATE mode (operator 2026-08-08: GHA credits exhausted, no more CI-dispatch): instead of
+        /// opening candidate PRs + polling GitHub, gate each queued MR LOCALLY with `gate-local` and
+        /// merge-or-reject inline (the drain model). Cherry-pick the MR's ref onto the trunk tip, run the
+        /// nix required-set gate → GREEN advances trunk + acks merged, RED rejects to the author,
+        /// NO-CHECKS leaves it queued to retry. Requires `--execute` to write; without it, DRY previews
+        /// which MRs would gate. Oldest-first, one at a time (no candidate-PR parallelism to manage).
+        #[arg(long)]
+        local_gate: bool,
     },
     /// Report where a merge-request stands in the CI-gated pipeline — in-flight as a candidate PR (with
     /// lane + how to poll its CI), queued at a position in its lane, or resolved (merged/rejected). A
@@ -1000,8 +1008,14 @@ pub fn run(paths: &Paths, cmd: FleetCmd) {
             let _ = publish_candidate(&fleet, &r#ref, &agent, &mr_file, execute);
         }
         FleetCmd::SchedulePlan { cap } => schedule_plan(&fleet, cap),
-        FleetCmd::SchedulePass { cap, execute } => {
-            if execute {
+        FleetCmd::SchedulePass {
+            cap,
+            execute,
+            local_gate,
+        } => {
+            if local_gate {
+                schedule_pass_local_gate(&fleet, execute)
+            } else if execute {
                 schedule_pass_execute(&fleet, cap)
             } else {
                 schedule_plan(&fleet, cap) // DRY preview == the read-only plan
@@ -7706,17 +7720,16 @@ fn local_gate_verdict(spawned_ok: bool, build_ok: bool) -> CiVerdict {
 /// fallback), so one build = a single green/red over the required set, no GH runner needed. Runs on the
 /// aarch64 fleet host; the warm c2 cache makes it fast. `arch` defaults to aarch64 (the only supported
 /// local-gate arch — x86/macos legs are explicitly skipped per the operator scope).
-fn gate_local(arch: &str) {
+/// Run the local nix gate for `arch` and return its verdict — the reusable core of `gate_local` (the CLI
+/// printer) AND the `--local-gate` drain (which gates each queued MR programmatically). Builds
+/// `.#checks.<arch>-linux.local-gate` (v-nix's `localGate` aggregate over the 10 aarch64 required
+/// contexts) and maps the outcome via `local_gate_verdict`: spawn-fail→NoChecks, exit0→Green,
+/// nonzero→Red (never Pending — the build blocks to completion). PATH-robust `nix` resolution (the fleet
+/// host has nix off a non-login shell's PATH). Inherits stdio so the build log is visible to the caller.
+fn run_gate_local(arch: &str) -> CiVerdict {
     let target = format!(".#checks.{arch}-linux.local-gate");
-    // Resolve the `nix` binary PATH-robustly: the fleet host HAS nix (Determinate multi-user install at
-    // /nix/var/nix/profiles/default/bin) but a non-login shell (e.g. pr-sync's invocation env) may not have
-    // it on PATH — verified live 2026-08-06. Without this, gate_local would spawn-fail → NO-CHECKS and be
-    // useless as the fallback exactly when needed. So try bare `nix` (honors PATH if present), else fall
-    // back to the standard profile path.
     let nix_bin = nix_binary();
-    eprintln!(
-        "gate-local: running `{nix_bin} build {target}` (local GHA-outage fallback; aarch64 required-set)…"
-    );
+    eprintln!("gate-local: running `{nix_bin} build {target}` (local required-set gate; aarch64)…");
     let out = Command::new(&nix_bin)
         .args(["build", &target, "--no-link", "--print-out-paths"])
         .status();
@@ -7729,7 +7742,11 @@ fn gate_local(arch: &str) {
             (false, false)
         }
     };
-    let verdict = local_gate_verdict(spawned_ok, build_ok);
+    local_gate_verdict(spawned_ok, build_ok)
+}
+
+fn gate_local(arch: &str) {
+    let verdict = run_gate_local(arch);
     println!(
         "decision: {}",
         if verdict.is_landable() {
@@ -9410,6 +9427,125 @@ fn schedule_pass_execute(fleet: &Fleet, cap: usize) {
     println!(
         "schedule-pass: reaped {reaped_merged} merged + {reaped_rejected} rejected; dispatched {dispatched_now} new (cap {cap}, in-flight now {}).",
         still_in_flight.len() + dispatched_now
+    );
+}
+
+/// LOCAL-GATE drain (operator 2026-08-08: GHA credits exhausted — no more candidate PRs / GitHub polling).
+/// This is the outage-drain logic made pr-sync's PERMANENT integration model: for each queued merge-request
+/// (oldest-first, ONE at a time — no candidate-PR parallelism to manage), cherry-pick its `--ref` onto the
+/// trunk tip in the trunk worktree, run `gate-local` (the nix required-set aggregate) on the result, and
+/// merge-or-reject INLINE by the verdict:
+///   GREEN     → keep the cherry-pick (trunk advanced) + ack the sender `merged` + move on.
+///   RED       → abort the cherry-pick (trunk untouched) + ack the sender `reject` (fix + resend).
+///   NO-CHECKS → abort + LEAVE the MR queued (couldn't gate — never a false-green; retry next pass).
+///   cherry-pick CONFLICT → abort + ack `reject` (stale base — the sender syncs onto trunk + resends).
+/// DRY unless `execute` (then it only PREVIEWS which MRs it would gate). Only pr-sync runs `--execute` (it
+/// WRITES trunk). Because there are no candidate PRs, this drops the whole ci-dispatch-record / in-flight
+/// machinery and gates straight from the queue. Forward-only preserved (only cherry-pick advances trunk;
+/// a failed gate aborts). The trunk worktree index is hard-synced after each land (the reap self-cleaning
+/// fix, so the next op sees a clean index).
+fn schedule_pass_local_gate(fleet: &Fleet, execute: bool) {
+    let queued = queued_merge_requests(fleet);
+    if queued.is_empty() {
+        println!("schedule-pass --local-gate: no queued merge-requests — nothing to gate.");
+        return;
+    }
+    if !execute {
+        println!(
+            "schedule-pass --local-gate (DRY): would gate {} queued MR(s) oldest-first via gate-local:",
+            queued.len()
+        );
+        for mr in &queued {
+            println!("  {} (from {}, ref {})", mr.file, mr.from, mr.r#ref);
+        }
+        println!("  Pass --execute to gate + merge-or-reject inline.");
+        return;
+    }
+    let wt = match trunk_worktree_dir(fleet) {
+        Some(w) => w,
+        None => {
+            eprintln!(
+                "schedule-pass --local-gate: could not find the worktree with `trunk` checked out — cannot gate (run from pr-sync's worktree)."
+            );
+            return;
+        }
+    };
+    let git_wt = |args: &[&str]| Command::new("git").current_dir(&wt).args(args).output();
+    let git_wt_ok = |args: &[&str]| git_wt(args).map(|o| o.status.success()).unwrap_or(false);
+    // Start from a clean trunk tip (never gate atop residue from a prior op).
+    let _ = git_wt(&["reset", "--hard", TRUNK]);
+    let (mut merged, mut rejected, mut left) = (0usize, 0usize, 0usize);
+    for mr in &queued {
+        // Fetch the ref (the sender's branch tip) so the cherry-pick has the object + its ancestry.
+        let _ = git_wt(&["fetch", "origin", &mr.r#ref, "--quiet"]);
+        if !git_wt_ok(&["cherry-pick", "--allow-empty", &mr.r#ref]) {
+            let _ = git_wt(&["cherry-pick", "--abort"]);
+            let _ = git_wt(&["reset", "--hard", TRUNK]);
+            ack(
+                fleet,
+                &mr.file,
+                "reject",
+                "",
+                &format!(
+                    "local-gate: `{}` does not cherry-pick cleanly onto trunk (stale base) — sync onto trunk + resend.",
+                    mr.r#ref
+                ),
+            );
+            rejected += 1;
+            println!(
+                "  ✗ {} ({}) → REJECT (stale-base conflict)",
+                mr.file, mr.r#ref
+            );
+            continue;
+        }
+        // The cherry-pick is now the trunk tip; gate THAT tree.
+        match run_gate_local("aarch64") {
+            CiVerdict::Green => {
+                // Keep the advance; re-sync index to the new tip (reap self-cleaning). ack merged.
+                let sha = git_wt(&["rev-parse", "HEAD"])
+                    .ok()
+                    .filter(|o| o.status.success())
+                    .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                    .unwrap_or_default();
+                let _ = git_wt(&["reset", "--hard", "HEAD"]);
+                ack(
+                    fleet,
+                    &mr.file,
+                    "merged",
+                    &sha,
+                    &format!("landed via local gate (gate-local GREEN); trunk @ {sha}"),
+                );
+                merged += 1;
+                println!("  ✓ {} ({}) → MERGED, trunk @ {sha}", mr.file, mr.r#ref);
+            }
+            CiVerdict::Red => {
+                let _ = git_wt(&["reset", "--hard", TRUNK]); // undo the cherry-pick; trunk untouched
+                ack(
+                    fleet,
+                    &mr.file,
+                    "reject",
+                    "",
+                    &format!(
+                        "local-gate: `{}` FAILED the required-set gate (gate-local RED) — fix + resend.",
+                        mr.r#ref
+                    ),
+                );
+                rejected += 1;
+                println!("  ✗ {} ({}) → REJECT (gate-local RED)", mr.file, mr.r#ref);
+            }
+            CiVerdict::Pending | CiVerdict::NoChecks => {
+                let _ = git_wt(&["reset", "--hard", TRUNK]); // never false-green; leave queued
+                left += 1;
+                println!(
+                    "  · {} ({}) → NO-CHECKS (couldn't run gate-local) — left queued, retry next pass.",
+                    mr.file, mr.r#ref
+                );
+            }
+        }
+    }
+    println!(
+        "schedule-pass --local-gate: {merged} merged + {rejected} rejected + {left} left-queued (of {} queued).",
+        queued.len()
     );
 }
 


### PR DESCRIPTION
Candidate PR for v-nix's merge-request (ref d23f76965, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.