### PR TITLE
duvet: cite deferred-materialization MUST on bytes_flatten (memory-and-resource-model)

### DIFF
--- a/.duvet/coverage-floor.json
+++ b/.duvet/coverage-floor.json
@@ -1,5 +1,5 @@
 {
   "_note": "Citation-coverage floor for `cargo xtask duvet-check` (wired into `xtask check`). `cited` = number of //= / //# duvet citation annotations; the gate FAILS if live cited drops below it (a deleted/stranded citation). v-duvet-coverage bumps this with `xtask duvet-check --save` when it adds citations. NOT the churny .duvet/snapshot.txt — this is a machine-stable count.",
-  "cited": 711,
+  "cited": 712,
   "total": 1094
 }

--- a/implementation/seed/crates/cdz-runtime/src/lib.rs
+++ b/implementation/seed/crates/cdz-runtime/src/lib.rs
@@ -2991,6 +2991,12 @@ fn op_bytes_len(buf: Handle) -> u32 {
 /// memory model's #Sharing Is Not Observable deferral clause). A leaf is left untouched (idempotent).
 /// The fill is ITERATIVE (an explicit `(node, dst_off, src_start, count)` worklist) so a deep rope
 /// cannot overflow the wasm call stack — same discipline as the free cascade.
+///
+/// A slice/concat rope IS a value combined or narrowed from existing Bytes whose materialization is
+/// DEFERRED to this flatten: the deferral is unobservable (every reader sees identical logical bytes) and
+/// a deterministic function of the source rope, so combining/narrowing need not eagerly copy.
+//= spec/capabilities/memory-and-resource-model.md#sharing-is-not-observable
+//# A value the compiler derives by combining or narrowing existing values MAY defer the work of materializing its contents until an operation observes them, provided the deferral is not observable and is a deterministic function of the source, so that combining and narrowing values need not eagerly copy their contents.
 fn bytes_flatten(h: Handle) {
     let arity = with_node(h, 0usize, |n| n.handles.len());
     if arity == 0 {


### PR DESCRIPTION
Candidate PR for v-duvet-coverage's merge-request (ref 42c8c2f46, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.