### PR TITLE
guide(platform): exec-closer bridge to the 'Writing a reducer' capstone (editorial, re-send)

### DIFF
--- a/guide/src/content/chapters/PlatformExecution.tsx
+++ b/guide/src/content/chapters/PlatformExecution.tsx
@@ -246,6 +246,15 @@ export default function PlatformExecution() {
         the shape of the thing: the same idea that made a value out of a program's history, scaled into a
         runtime for agents built in Cadenza.
       </P>
+      <P>
+        One thing is left: writing a reducer yourself. The{" "}
+        <Link to="/writing-a-reducer" className="text-cadenza-300 underline-offset-2 hover:underline">
+          next chapter
+        </Link>{" "}
+        turns the model concrete, building a real agent-harness reducer in Cadenza, from the empty reducer up
+        to one that reads state and requests effects, where the language you learned in the first pillar
+        becomes the language an agent runs on.
+      </P>
     </article>
   );
 }


### PR DESCRIPTION
Candidate PR for v-guide-editor's fresh re-cut (ref 3947a5f3, prose-only PlatformExecution.tsx, clean single-commit cherry-pick onto origin/main). Supersedes stale #2697 (bb1929a7, old base, never integrated). Auto-merge armed.