### PR TITLE
compiler-ml: ARC-A2 slice 1 — Db types column now stores canonical Ty (edge-bridged, consumers unchanged)

### DIFF
--- a/implementation/compiler-ml/src/db-infer.cdz
+++ b/implementation/compiler-ml/src/db-infer.cdz
@@ -13,6 +13,11 @@ import { Tree } from "parse-db"
 
 import { infer-node, ground-deferred } from "infer-db"
 import { Typed } from "typed"
+import { Ty } from "ty"
+// ARC-A2: the Db types column now stores `Map(Int64, Ty)`; db-infer's raw-column ops bridge at the column
+// boundary (ty-col-to-typed / typed-col-to-ty) so infer-node + downstream consumers stay on `Typed` this
+// slice. TEMPORARY — removed once infer-db/lower-db migrate to Ty.
+import { ty-col-to-typed, typed-col-to-ty } from "ty-bridge"
 
 import { Db, db-tree, typed-filled } from "db"
 
@@ -23,13 +28,15 @@ import { resolve-into-db } from "db-resolve"
 def db-resolved-col(db: Db) = match db with
   | Db.Db(_, rc, _, _) => rc
 
-/// The types column of a Db.
+/// The types column of a Db, AS `Map(Int64, Typed)` — ARC-A2 edge-bridge: the column stores `Ty`, this
+/// converts it back to `Typed` for un-migrated consumers (infer-node/lower-node/bin-type read a Typed column).
 def db-typed-col(db: Db) = match db with
-  | Db.Db(_, _, tc, _) => tc
+  | Db.Db(_, _, tc, _) => ty-col-to-typed(tc)
 
-/// Merge a type column into the Db's types column (single column-swap; infer-node produces the whole column).
+/// Merge a `Typed` type column into the Db's types column — ARC-A2 edge-bridge: infer-node produces a whole
+/// `Map(Int64, Typed)`; this converts it to the stored `Map(Int64, Ty)` (typed-col-to-ty) before merging.
 def merge-typed(db: Db, tcol: Map(Int64, Typed)) = match db with
-  | Db.Db(t, rc, _, cc) => Db.Db(t, rc, tcol, cc)
+  | Db.Db(t, rc, _, cc) => Db.Db(t, rc, typed-col-to-ty(tcol), cc)
 
 /// INFER into the Db (rcdzc `type_of` demand): resolve ONCE into the Db (P1d fill-once — a HIT if already
 /// resolved), then run `infer-node` over the Db's RESOLVED column (NOT a re-resolve) to fill the types

--- a/implementation/compiler-ml/src/db.cdz
+++ b/implementation/compiler-ml/src/db.cdz
@@ -25,14 +25,25 @@ import { Resolved } from "resolve-db"
 
 import { Typed } from "typed"
 
+import { Ty } from "ty"
+
+// ARC-A2 MIGRATION BRIDGE (TEMPORARY — deleted in the final A2 slice): the types column now stores the
+// canonical `Ty` (the single-live-type-universe target), but the pipeline consumers (infer-db/db-demand/
+// lower-db/db-state) still speak `Typed`. `fill-typed`/`require-typed` keep their `Typed` signatures by
+// bridging Typed<->Ty at the column edge, so THIS slice swaps the column's storage type WITHOUT touching any
+// consumer — they migrate to the `Ty`-native `fill-ty`/`require-ty` file-by-file in later A2 slices, and this
+// bridge (+ typed.cdz + ty-bridge.cdz) is removed once the last consumer is off `Typed`.
+import { typed-to-ty, ty-to-typed } from "ty-bridge"
+
 import { Core } from "lower-db"
 
 /// The query DB: the source `Tree` (ast column) + one memoized column per derived fact. A single-variant
   /// sum carrying the columns (the ML-surface analog of rcdzc's `Db` struct, mirroring parse-db's
   /// `Tree.Arena(Map, next)` compound-carrier idiom). Columns are `Map(NodeId, Fact)`; an absent key = a
-  /// `Slot::Absent` (fact not yet determined).
+  /// `Slot::Absent` (fact not yet determined). ARC-A2: the TYPES column now stores canonical `Ty`
+  /// (was `Typed`) — the single-type-universe target; consumers still reach it via the Typed edge-bridge below.
   type Db =
-  | Db(Tree, Map(Int64, Resolved), Map(Int64, Typed), Map(Int64, Core))
+  | Db(Tree, Map(Int64, Resolved), Map(Int64, Ty), Map(Int64, Core))
 
 /// A fresh Db over a source `Tree`: every derived column empty (all slots Absent). The load step — rcdzc's
 /// `Db::load` (here the tree is already parsed; the columns fill lazily as producers demand facts).
@@ -40,7 +51,7 @@ def db-of(tree: Tree) =
   Db.Db(
     tree,
     Map.empty : Map(Int64, Resolved),
-    Map.empty : Map(Int64, Typed),
+    Map.empty : Map(Int64, Ty),
     Map.empty : Map(Int64, Core)
   )
 
@@ -65,16 +76,32 @@ def require-resolved(db: Db, id: Int64) =
   let Db.Db(_, rc, _, _) = db in
   Map.lookup(rc, id)
 
-// ---- the TYPES column (filled by infer) -------------------------------------------------------------
-/// FILL the type fact for `id`.
-def fill-typed(db: Db, id: Int64, ty: Typed) =
+// ---- the TYPES column (filled by infer; stores canonical `Ty` as of ARC-A2) -------------------------
+/// FILL the type fact at `id` with a canonical `Ty` — the ARC-A2 `Ty`-native writer (the migration target
+/// consumers move onto slice-by-slice). Plain `Map.insert`; FILL-ONCE is the demand producer's job (see below).
+def fill-ty(db: Db, id: Int64, ty: Ty) =
   let Db.Db(t, rc, tc, cc) = db in
   Db.Db(t, rc, Map.insert(tc, id, ty), cc)
 
-/// REQUIRE the type fact at `id` (`Some` filled — incl. a filled TErr decline — else `None`).
-def require-typed(db: Db, id: Int64) =
+/// REQUIRE the `Ty` fact at `id` (`Some` filled — incl. a filled `TyErr` decline — else `None`). The
+/// `Ty`-native reader; consumers migrate to this off the `Typed` bridge below.
+def require-ty(db: Db, id: Int64) =
   let Db.Db(_, _, tc, _) = db in
   Map.lookup(tc, id)
+
+/// FILL the type fact for `id` — ARC-A2 EDGE-BRIDGE (TEMPORARY): keeps the `Typed` signature for un-migrated
+/// consumers by converting `Typed`→`Ty` at the column edge. Delegates to the `Ty`-native `fill-ty`. Removed
+/// once every consumer calls `fill-ty` directly (final A2 slice).
+def fill-typed(db: Db, id: Int64, ty: Typed) =
+  fill-ty(db, id, typed-to-ty(ty))
+
+/// REQUIRE the type fact at `id` as `Typed` — ARC-A2 EDGE-BRIDGE (TEMPORARY): reads the stored `Ty` and
+/// converts back to `Typed` for un-migrated consumers (`ty-to-typed` grounds any deferred axis, matching the
+/// pre-A2 behavior where the column already held grounded pipeline types). `Some(Typed)` filled else `None`.
+def require-typed(db: Db, id: Int64) =
+  match require-ty(db, id) with
+    | Option.Some(ty) => Option.Some(ty-to-typed(ty))
+    | Option.None(_) => Option.None(unit)
 
 // ---- the CORE column (filled by lower) --------------------------------------------------------------
 /// FILL the core fact for `id`.
@@ -188,12 +215,44 @@ def db-fill-is-a-raw-overwrite-not-fill-once() =
       trap("overwritten to Int64"))
     | _ => trap("fill-typed OVERWROTE @0 to Int64 (raw insert, not fill-once)")
 
+// ---- ARC-A2 tests: the column now stores `Ty`; the Ty-native accessors + the Typed edge-bridge ------
+import { IntType, Sign, Width } from "ty"
+
+@test
+def db-a2-ty-native-fill-require() =
+  // the column is now Ty-native: fill-ty a canonical Ty (UInt8 = TyInt(Unsigned, WFixed 8)), require-ty it back.
+  let db = fill-ty(sample-db(), 0, Ty.TyInt(IntType.IntType(Sign.Unsigned, Width.WFixed(8)))) in
+  match require-ty(db, 0) with
+    | Option.Some(Ty.TyInt(IntType.IntType(Sign.Unsigned, Width.WFixed(w)))) => (if w == 8 then unit else trap("UInt8 stored/read as Ty"))
+    | _ => trap("fill-ty/require-ty round-trips a canonical Ty")
+
+@test
+def db-a2-typed-bridge-over-ty-column() =
+  // the edge-bridge: fill via the Typed writer, read via the Ty-native reader — the stored value is the
+  // BRIDGED Ty (Typed.TBool → Ty.TyBool). Proves fill-typed converts at the edge, not stores Typed.
+  let db = fill-typed(sample-db(), 0, Typed.TBool) in
+  match require-ty(db, 0) with
+    | Option.Some(Ty.TyBool) => unit
+    | _ => trap("fill-typed bridged Typed.TBool → Ty.TyBool in the column")
+
+@test
+def db-a2-poison-survives-bridge-round-trip() =
+  // poison-as-filled-value holds across the bridge: fill-typed TErr → stored Ty.TyErr → require-typed back to
+  // Typed.TErr (a determined decline, NOT Absent). Guards the invariant under the A2 column-type swap.
+  let db = fill-ty(sample-db(), 0, Ty.TyErr) in
+  match require-typed(db, 0) with
+    | Option.Some(Typed.TErr) => unit
+    | Option.None(_) => trap("filled Ty.TyErr is a determined decline, not Absent")
+    | Option.Some(_) => trap("Ty.TyErr bridges back to Typed.TErr")
+
 export {
   Db.*,
   db-of,
   db-tree,
   fill-resolved,
   require-resolved,
+  fill-ty,
+  require-ty,
   fill-typed,
   require-typed,
   fill-core,

--- a/implementation/compiler-ml/src/ty-bridge.cdz
+++ b/implementation/compiler-ml/src/ty-bridge.cdz
@@ -59,6 +59,27 @@ def ty-list-to-typed(ps: List(Ty), i: Int64) =
      | Option.Some(p) => List.concat(List.push([], ty-to-typed(p)), ty-list-to-typed(ps, i + 1))
      | Option.None(_) => ty-list-to-typed(ps, i + 1)))
 
+// ---- ARC-A2 COLUMN-MAP bridges (TEMPORARY, deleted in the final A2 slice) ---------------------------
+// The types column stores `Map(Int64, Ty)` as of ARC-A2, but db-infer's raw-column ops (db-typed-col /
+// merge-typed) and their consumers (infer-node, lower-node, bin-type) still speak `Map(Int64, Typed)`. These
+// convert a whole column map each way at that boundary — the column-level twin of the scalar edge-bridge —
+// so the column-type swap doesn't ripple into infer-db/lower-db yet (they migrate to Ty in later A2 slices).
+/// A `Map(Int64, Ty)` column → `Map(Int64, Typed)` (each entry via ty-to-typed). Fold over the entry list.
+def ty-col-to-typed(m: Map(Int64, Ty)) = ty-col-to-typed-go(Map.to-list(m), 0, (Map.empty : Map(Int64, Typed)))
+def ty-col-to-typed-go(es: List(Tuple(Int64, Ty)), i: Int64, acc: Map(Int64, Typed)) =
+  (if i == List.len(es) then acc
+   else (match List.at(es, i) with
+     | Option.Some((k, v)) => ty-col-to-typed-go(es, i + 1, Map.insert(acc, k, ty-to-typed(v)))
+     | Option.None(_) => acc))
+
+/// A `Map(Int64, Typed)` column → `Map(Int64, Ty)` (each entry via typed-to-ty). The inverse.
+def typed-col-to-ty(m: Map(Int64, Typed)) = typed-col-to-ty-go(Map.to-list(m), 0, (Map.empty : Map(Int64, Ty)))
+def typed-col-to-ty-go(es: List(Tuple(Int64, Typed)), i: Int64, acc: Map(Int64, Ty)) =
+  (if i == List.len(es) then acc
+   else (match List.at(es, i) with
+     | Option.Some((k, v)) => typed-col-to-ty-go(es, i + 1, Map.insert(acc, k, typed-to-ty(v)))
+     | Option.None(_) => acc))
+
 // ---- TESTS: round-trip + cross-mapping -------------------------------------------------------------
 
 import { ty-eq, ty-int64 } from "ty"
@@ -101,4 +122,4 @@ def tb-sum-round-trips() =
       else trap("TSum(1) → TySum(1) keeps id"))
     | _ => trap("TSum → TySum (forward, no grounding/drop)"))
 
-export { typed-to-ty, ty-to-typed }
+export { typed-to-ty, ty-to-typed, ty-col-to-typed, typed-col-to-ty }


### PR DESCRIPTION
Candidate PR for v-compiler-ml's merge-request (ref 785fb1d48, lane compiler-ml). Auto-merge armed; pr-sync's schedule-pass reaps on green.