### PR TITLE
duvet: cite compile-time-eval-is-one-tier macro-is-ordinary-fn MUST on desugar_eval (metaprogramming)

### DIFF
--- a/.duvet/coverage-floor.json
+++ b/.duvet/coverage-floor.json
@@ -1,5 +1,5 @@
 {
   "_note": "Citation-coverage floor for `cargo xtask duvet-check` (wired into `xtask check`). `cited` = number of //= / //# duvet citation annotations; the gate FAILS if live cited drops below it (a deleted/stranded citation). v-duvet-coverage bumps this with `xtask duvet-check --save` when it adds citations. NOT the churny .duvet/snapshot.txt — this is a machine-stable count.",
-  "cited": 717,
+  "cited": 718,
   "total": 1094
 }

--- a/implementation/seed/crates/rcdzc/src/eval_ast.rs
+++ b/implementation/seed/crates/rcdzc/src/eval_ast.rs
@@ -71,6 +71,11 @@ fn reachable(ast: &Arenas, root: StructId) -> std::collections::HashSet<u32> {
 //# The compiler MUST NOT require `eval` to compile programs — the compiler constructs and analyzes AST but does not execute dynamically-constructed AST.
 //= spec/capabilities/metaprogramming.md#compile-time-evaluation-is-one-tier
 //# Macro expansion, generic reduction, monomorphization, and constant folding MUST be the same compile-time evaluation mechanism rather than separate subsystems, so that there is one place the meaning of compile-time computation lives and the four cannot drift apart.
+// So a macro is not a distinct construct: `(eval AST)` desugars to the source the AST denotes and runs
+// through the ONE ordinary compile-time path, i.e. an ordinary compile-time function applied to a
+// program's AST data — not a separate macro interpreter.
+//= spec/capabilities/metaprogramming.md#compile-time-evaluation-is-one-tier
+//# A macro MUST be an ordinary compile-time function over the abstract syntax tree, so that a macro is not a distinct construct but an application of the one compile-time tier to a program's data.
 pub fn desugar_eval(ast: &mut Arenas) {
     // Only ORIGINAL nodes can be a source `(eval …)`; reconstruction APPENDS, so bound the scan.
     let original_len = ast.structure.len() as u32;


### PR DESCRIPTION
Candidate PR for v-duvet-coverage's merge-request (ref c3a5b24cb, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.