### PR TITLE
duvet: cite effect-row-annotation-is-opt-in MUST on body_reached_effects (capabilities-and-effects)

### DIFF
--- a/.duvet/coverage-floor.json
+++ b/.duvet/coverage-floor.json
@@ -1,5 +1,5 @@
 {
   "_note": "Citation-coverage floor for `cargo xtask duvet-check` (wired into `xtask check`). `cited` = number of //= / //# duvet citation annotations; the gate FAILS if live cited drops below it (a deleted/stranded citation). v-duvet-coverage bumps this with `xtask duvet-check --save` when it adds citations. NOT the churny .duvet/snapshot.txt — this is a machine-stable count.",
-  "cited": 718,
+  "cited": 719,
   "total": 1094
 }

--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -1630,6 +1630,11 @@ fn check_no_home_walk(
 /// effects is a projection of this row (`host.rs::collect_host_imports`).
 //= spec/capabilities/capabilities-and-effects.md#performing-an-operation-is-typed-and-contributes-to-the-row
 //# Performing an operation MUST add its declaring effect to the effect row of the function that performs it, so that a function's inferred row is the set of effects its operations reach and the manifest of delegated effects is a projection of that row.
+///
+/// The row is computed PURELY FROM THE OPERATIONS THE BODY REACHES — no written annotation is consulted
+/// or required; a program compiles with none, the inferred escaping row being the mandatory floor.
+//= spec/capabilities/capabilities-and-effects.md#effect-row-annotation-is-opt-in
+//# A program MUST compile without any effect-row annotation, the compiler inferring each function's effect row from the operations it reaches, so that the mandatory floor is the escaping row itself, not a written annotation.
 fn body_reached_effects(db: &mut Db, node: StructId) -> std::collections::HashSet<u32> {
     let mut reached = std::collections::HashSet::new();
     let mut visited = std::collections::HashSet::new();


### PR DESCRIPTION
Candidate PR for v-duvet-coverage's merge-request (ref 5fa130696, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.