### PR TITLE
duvet: cite exact-numeric-serialize-independent-of-computation MUST on IntValue (deterministic-value-form)

### DIFF
--- a/.duvet/coverage-floor.json
+++ b/.duvet/coverage-floor.json
@@ -1,5 +1,5 @@
 {
   "_note": "Citation-coverage floor for `cargo xtask duvet-check` (wired into `xtask check`). `cited` = number of //= / //# duvet citation annotations; the gate FAILS if live cited drops below it (a deleted/stranded citation). v-duvet-coverage bumps this with `xtask duvet-check --save` when it adds citations. NOT the churny .duvet/snapshot.txt — this is a machine-stable count.",
-  "cited": 723,
+  "cited": 724,
   "total": 1093
 }

--- a/implementation/seed/crates/rcdzc/src/ast.rs
+++ b/implementation/seed/crates/rcdzc/src/ast.rs
@@ -81,6 +81,12 @@ pub enum Leaf {
 /// magnitude carries no leading zero bytes and is empty iff the value is zero, so equal values share
 /// one representation (and one leaf-pool entry). A magnitude read off the wire is stored verbatim so
 /// that `decode` is a faithful inverse of `encode`.
+///
+/// Because a compile-time-computed exact integer (`fold_arith` of `+`/`-`/`*`/…) canonicalizes to the
+/// SAME `IntValue` as the literal of that value — one canonical magnitude, hence one leaf-pool entry and
+/// one encoding — its serialized byte form depends only on the value, never on how it was computed.
+//= spec/contracts/deterministic-value-form.md#numeric-values-serialize-deterministically
+//# An exact numeric value MUST serialize to a byte form that is independent of how the value was computed.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct IntValue {
     pub negative: bool,


### PR DESCRIPTION
Candidate PR for v-duvet-coverage's merge-request (ref 3a7c2885d, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.