### PR TITLE
duvet: cite a-value-has-one-canonical-byte-form MUST x3 on op_box_float (deterministic-value-form)

### DIFF
--- a/.duvet/coverage-floor.json
+++ b/.duvet/coverage-floor.json
@@ -1,5 +1,5 @@
 {
   "_note": "Citation-coverage floor for `cargo xtask duvet-check` (wired into `xtask check`). `cited` = number of //= / //# duvet citation annotations; the gate FAILS if live cited drops below it (a deleted/stranded citation). v-duvet-coverage bumps this with `xtask duvet-check --save` when it adds citations. NOT the churny .duvet/snapshot.txt — this is a machine-stable count.",
-  "cited": 724,
+  "cited": 727,
   "total": 1093
 }

--- a/implementation/seed/crates/cdz-runtime/src/lib.rs
+++ b/implementation/seed/crates/cdz-runtime/src/lib.rs
@@ -919,7 +919,15 @@ fn op_box_float(v: f64) -> Handle {
     // canonical form makes every NaN equal to every NaN. A NON-NaN value (incl. ±0.0 and ±inf) keeps
     // its bits verbatim, so `-0.0` stays DISTINCT from `0.0` (their canonical forms genuinely differ).
     // This is the float twin of `op_box_int`'s normalize-on-construct: `box-float` is the SOLE producer
-    // of a float leaf, so canonicalizing here guarantees every stored float has one byte form.
+    // of a float leaf, so canonicalizing here guarantees every stored float has one byte form — one
+    // canonical encoding per value, equal values (every NaN) sharing identical bytes and unequal values
+    // (±0.0) keeping distinct bytes, which `champ_hash`/`champ_eq` compare rawly:
+    //= spec/contracts/deterministic-value-form.md#a-value-has-one-canonical-byte-form
+    //# Each serializable value MUST have exactly one canonical byte encoding.
+    //= spec/contracts/deterministic-value-form.md#a-value-has-one-canonical-byte-form
+    //# Two values that are equal under the language's structural equality MUST have identical canonical byte encodings.
+    //= spec/contracts/deterministic-value-form.md#a-value-has-one-canonical-byte-form
+    //# Two values that are not equal under the language's structural equality MUST have distinct canonical byte encodings.
     let bits = if v.is_nan() { f64::NAN.to_bits() } else { v.to_bits() };
     alloc_raw(Vec::new(), Raw::inline(&bits.to_le_bytes())) // 8-byte scalar: inline, no heap raw
 }


### PR DESCRIPTION
Candidate PR for v-duvet-coverage's merge-request (ref 891ae6e34, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.