### PR TITLE
compiler-ml: ARC-B5 S1b — hm-collect NVar coverage + de-nest per operator readability directive

### DIFF
--- a/implementation/compiler-ml/src/hm-collect.cdz
+++ b/implementation/compiler-ml/src/hm-collect.cdz
@@ -20,15 +20,37 @@
 /// an unseeded node reads as TyErr (a gap the caller must fill), never a silent default.
 import { Ty, is-int-ty } from "ty"
 import { Node, Tree, node-at } from "parse-db"
+import { Resolved } from "resolve-db"
 
 /// The Bool type, named for the cond/scrutinee constraints (an `if`/`match` cond must be Bool).
 def ty-bool() = Ty.TyBool
+
+/// The type-var of the VALUE that an NVar's binder binds (S1b — mirrors infer-db's var-type as a constraint
+/// SOURCE, not a lookup): given the binder node-id, return the env-var to constrain the use against.
+///   binder is an NLet(_, valId, _) → the let's VALUE var (env[valId]) — a `let x = v in .. x ..` use shares v's type.
+///   binder is an NVar (a PARAMETER's own node) → the param's own var (env[binder]) — a param use shares the param's type.
+///   otherwise → None (defensive: a malformed binder; the caller emits no constraint).
+def binder-value-ty(tree: Tree, env: Map(Int64, Ty), binder: Int64) = match node-at(tree, binder) with
+  | Option.Some(Node.NLet(_, valId, _)) => Option.Some(node-ty(env, valId))
+  | Option.Some(Node.NVar(_)) => Option.Some(node-ty(env, binder))
+  | _ => Option.None(unit)
 
 /// The type assigned to node `id` in env `env` — a direct lookup (the caller seeds every relevant node's type,
 /// params to fresh vars). An unseeded id reads TyErr (typed absence: the caller left a gap), never a default.
 def node-ty(env: Map(Int64, Ty), id: Int64) = match Map.lookup(env, id) with
   | Option.Some(t) => t
   | Option.None(_) => Ty.TyErr
+
+/// Append a list of constraints `cs` onto `acc` (replaces hand-rolled nested `List.push(List.push(..),..)` —
+/// the caller writes the node's constraints as a flat list and pushes them in one call).
+def push-cs(acc: List(Tuple(Ty, Ty)), cs: List(Tuple(Ty, Ty))) = List.concat(acc, cs)
+
+/// Fold `collect` over a list of child node-ids, threading the accumulator left-to-right (replaces the 4-deep
+/// nested `collect(.. collect(.. collect(..)))` — this is the idiomatic accumulator fold, one child per step).
+def collect-children(tree: Tree, rcol: Map(Int64, Resolved), env: Map(Int64, Ty), ids: List(Int64), acc: List(Tuple(Ty, Ty))) =
+  match ids with
+    | [] => acc
+    | [child, .. rest] => collect-children(tree, rcol, env, rest, collect(tree, rcol, env, child, acc))
 
 /// COLLECT the type-equality constraints imposed by the subtree at `id`, over env `env`, appending to `acc`.
 /// The generation rules (the equalities HM inference imposes on the covered node subset):
@@ -43,43 +65,60 @@ def node-ty(env: Map(Int64, Ty), id: Int64) = match Map.lookup(env, id) with
 ///     `thenTy ~ elseTy`, `nodeTy ~ thenTy`. Recurse into all four. (Mirrors the ad-hoc match-type, now as
 ///     constraints: scrut~lit sameness + arm join.)
 ///   NLet: the body's type is the let's — emit `nodeTy ~ bodyTy`; recurse value + body.
-///   leaf (NLit/NBoolLit/NAnnLit/NVar): no sub-constraint (its type is its seed) — nothing to emit, no recursion.
-///   other composites (NApp/NMatchCtor): NOT generated here yet (need the resolve column / ct-decl identity —
-///     S1b/S1c) — no emit, no recursion (the caller handles them until then).
-def collect(tree: Tree, env: Map(Int64, Ty), id: Int64, acc: List(Tuple(Ty, Ty))) =
+///   NVar (S1b): a variable USE shares the type of the value its binder binds — read the resolve column `rcol`
+///     for the var's binder (RBound(binder)), then emit `useTy ~ binderValueTy` (via binder-value-ty). An
+///     unbound/RPoison/RDef var emits nothing here (RDef = a def-name-as-value → HO arrow, an S1c concern).
+///   leaf (NLit/NBoolLit/NAnnLit): no sub-constraint (its type is its seed) — nothing to emit, no recursion.
+///   other composites (NApp/NMatchCtor): NOT generated here yet (NApp arg~param / ct-decl identity — S1c) —
+///     no emit, no recursion (the caller handles them until then).
+/// THREADS the resolve column `rcol` (S1b): NVar needs its binder resolution. Every recursion passes it through.
+def collect(tree: Tree, rcol: Map(Int64, Resolved), env: Map(Int64, Ty), id: Int64, acc: List(Tuple(Ty, Ty))) =
   match node-at(tree, id) with
     | Option.Some(Node.NBin(op, l, r)) =>
         (if (op >= 60)
          then (if (op <= 65)
                // relational: operands share a type (left ~ right); node is Bool (no nodeTy constraint here)
-               then (let a1 = List.push(acc, (node-ty(env, l), node-ty(env, r))) in
-                     collect(tree, env, r, collect(tree, env, l, a1)))
+               then (let a1 = push-cs(acc, [(node-ty(env, l), node-ty(env, r))]) in
+                     collect-children(tree, rcol, env, [l, r], a1))
                else acc)                                              // unknown op ≥ 66 → no constraint
          // arithmetic: node ~ left, node ~ right (so left ~ right transitively), then recurse operands
          else (let nt = node-ty(env, id) in
-               (let a1 = List.push(List.push(acc, (nt, node-ty(env, l))), (nt, node-ty(env, r))) in
-                collect(tree, env, r, collect(tree, env, l, a1)))))
+               (let cs = [(nt, node-ty(env, l)), (nt, node-ty(env, r))] in
+                (let a1 = push-cs(acc, cs) in
+                 collect-children(tree, rcol, env, [l, r], a1)))))
     | Option.Some(Node.NIf(c, t, e)) =>
         // cond is Bool (cond ~ Bool); branches join (then ~ else); the if IS that type (node ~ then); recurse all three
         (let nt = node-ty(env, id) in
-         (let a1 = List.push(List.push(List.push(acc, (node-ty(env, c), ty-bool())), (node-ty(env, t), node-ty(env, e))), (nt, node-ty(env, t))) in
-          collect(tree, env, e, collect(tree, env, t, collect(tree, env, c, a1)))))
+         (let cs = [(node-ty(env, c), ty-bool()), (node-ty(env, t), node-ty(env, e)), (nt, node-ty(env, t))] in
+          (let a1 = push-cs(acc, cs) in
+           collect-children(tree, rcol, env, [c, t, e], a1))))
     | Option.Some(Node.NMatch(scrutId, litId, thenId, elseId)) =>
         // S1a integer match: scrutinee ~ literal-pattern (they are compared), arms join (then ~ else), the match
         // IS that type (node ~ then). Recurse into all four children.
         (let nt = node-ty(env, id) in
-         (let a1 = List.push(List.push(List.push(acc, (node-ty(env, scrutId), node-ty(env, litId))), (node-ty(env, thenId), node-ty(env, elseId))), (nt, node-ty(env, thenId))) in
-          collect(tree, env, elseId, collect(tree, env, thenId, collect(tree, env, litId, collect(tree, env, scrutId, a1))))))
+         (let cs = [(node-ty(env, scrutId), node-ty(env, litId)), (node-ty(env, thenId), node-ty(env, elseId)), (nt, node-ty(env, thenId))] in
+          (let a1 = push-cs(acc, cs) in
+           collect-children(tree, rcol, env, [scrutId, litId, thenId, elseId], a1))))
     | Option.Some(Node.NLet(_, valId, bodyId)) =>
         // the let's type is the body's; recurse value + body
-        (let a1 = List.push(acc, (node-ty(env, id), node-ty(env, bodyId))) in
-         collect(tree, env, bodyId, collect(tree, env, valId, a1)))
+        (let a1 = push-cs(acc, [(node-ty(env, id), node-ty(env, bodyId))]) in
+         collect-children(tree, rcol, env, [valId, bodyId], a1))
+    | Option.Some(Node.NVar(_)) =>
+        // S1b: a var USE shares its binder's value type. Look up the binder via the resolve column; emit
+        // useTy ~ binderValueTy. Unbound (RPoison) / RDef / no-fact → no constraint (leaf). A leaf: no recursion.
+        (match Map.lookup(rcol, id) with
+          | Option.Some(Resolved.RBound(binder)) =>
+              (match binder-value-ty(tree, env, binder) with
+                | Option.Some(bvt) => List.push(acc, (node-ty(env, id), bvt))
+                | Option.None(_) => acc)
+          | _ => acc)
     | Option.Some(_) => acc                                          // leaf or not-covered composite → no constraint
     | Option.None(_) => acc
 
-/// COLLECT from an empty accumulator — the entry point. `collect-all(tree, env, root)` = the full constraint
-/// set of the subtree at `root`, ready to hand to `hm-solve.solve`.
-def collect-all(tree: Tree, env: Map(Int64, Ty), root: Int64) = collect(tree, env, root, ([] : List(Tuple(Ty, Ty))))
+/// COLLECT from an empty accumulator — the entry point. `collect-all(tree, rcol, env, root)` = the full
+/// constraint set of the subtree at `root`, ready to hand to `hm-solve.solve`.
+def collect-all(tree: Tree, rcol: Map(Int64, Resolved), env: Map(Int64, Ty), root: Int64) =
+  collect(tree, rcol, env, root, ([] : List(Tuple(Ty, Ty))))
 
 // ---- TESTS: constraint generation over hand-built trees; solve propagates the fresh vars -------------
 import { add-node, empty-tree } from "parse-db"
@@ -90,6 +129,10 @@ import { apply } from "subst"
 
 /// A fresh int-var Ty at counter `n` (sign-var n, width-var n+1); returns (ty, next-counter).
 def fv(n: Int64) = fresh-int-ty(n)
+
+/// An empty resolve column — for tests with no variables (arith/if/match over literals). S1b's NVar rule reads
+/// rcol, but a var-free tree hits no NVar arm so the empty column is inert.
+def re() = (Map.empty : Map(Int64, Resolved))
 
 @test
 def hc-arith-emits-two-constraints() =
@@ -102,7 +145,7 @@ def hc-arith-emits-two-constraints() =
   let (vb, n2) = fv(n1) in
   let (vn, _n3) = fv(n2) in
   let env = Map.insert(Map.insert(Map.insert((Map.empty : Map(Int64, Ty)), aId, va), bId, vb), binId, vn) in
-  (if List.len(collect-all(tree, env, binId)) == 2 then unit else trap("arith (+ a b) emits 2 constraints (node~a, node~b)"))
+  (if List.len(collect-all(tree, re(), env, binId)) == 2 then unit else trap("arith (+ a b) emits 2 constraints (node~a, node~b)"))
 
 @test
 def hc-arith-propagates-fixed-width-to-both-operands() =
@@ -116,7 +159,7 @@ def hc-arith-propagates-fixed-width-to-both-operands() =
   let (vn, _n2) = fv(n1) in
   // env: a -> fresh var (the "param"), b -> fixed Int8, node -> fresh result var
   let env = Map.insert(Map.insert(Map.insert((Map.empty : Map(Int64, Ty)), aId, va), bId, ty-fixed-int(true, 8)), binId, vn) in
-  (match solve(collect-all(tree, env, binId)) with
+  (match solve(collect-all(tree, re(), env, binId)) with
     | Option.Some(su) => (match apply(su, va) with
         | Ty.TyInt(IntType.IntType(Sign.Signed, Width.WFixed(w))) => (if w == 8 then unit else trap("param a inferred Int8 from use"))
         | _ => trap("param a's fresh var resolves to Int8 via the shared arith constraint"))
@@ -132,7 +175,7 @@ def hc-mixed-width-arith-conflicts() =
   let (binId, tree) = add-node(t2, Node.NBin(43, aId, bId)) in
   let (vn, _n1) = fv(0) in
   let env = Map.insert(Map.insert(Map.insert((Map.empty : Map(Int64, Ty)), aId, ty-fixed-int(true, 8)), bId, ty-fixed-int(true, 16)), binId, vn) in
-  (match solve(collect-all(tree, env, binId)) with
+  (match solve(collect-all(tree, re(), env, binId)) with
     | Option.None(_) => unit
     | Option.Some(_) => trap("Int8 + Int16 must CONFLICT via the shared-type constraint"))
 
@@ -145,7 +188,7 @@ def hc-relational-shares-operand-type-node-is-bool() =
   let (cmpId, tree) = add-node(t2, Node.NBin(60, aId, bId)) in
   let (va, _n1) = fv(0) in
   let env = Map.insert(Map.insert(Map.insert((Map.empty : Map(Int64, Ty)), aId, va), bId, ty-fixed-int(true, 8)), cmpId, Ty.TyBool) in
-  let cs = collect-all(tree, env, cmpId) in
+  let cs = collect-all(tree, re(), env, cmpId) in
   (if List.len(cs) == 1
    then (match solve-apply(cs, va) with
           | Option.Some(Ty.TyInt(IntType.IntType(Sign.Signed, Width.WFixed(w)))) => (if w == 8 then unit else trap("compared operand a infers Int8"))
@@ -167,7 +210,7 @@ def hc-nested-arith-propagates-through-chain() =
   let (vinner, n3) = fv(n2) in
   let (vouter, _n4) = fv(n3) in
   let env = Map.insert(Map.insert(Map.insert(Map.insert(Map.insert((Map.empty : Map(Int64, Ty)), aId, va), bId, vb), cId, ty-fixed-int(true, 8)), innerId, vinner), outerId, vouter) in
-  (match solve-apply(collect-all(tree, env, outerId), va) with
+  (match solve-apply(collect-all(tree, re(), env, outerId), va) with
     | Option.Some(Ty.TyInt(IntType.IntType(Sign.Signed, Width.WFixed(w)))) => (if w == 8 then unit else trap("a infers Int8 through the nested chain"))
     | _ => trap("nested arith propagates Int8 to the deep fresh var a"))
 
@@ -185,7 +228,7 @@ def hc-if-branches-join-and-node-is-branch-type() =
   let (vt, n1) = fv(0) in
   let (vn, _n2) = fv(n1) in
   let env = Map.insert(Map.insert(Map.insert(Map.insert((Map.empty : Map(Int64, Ty)), cId, Ty.TyBool), tId, vt), eId, ty-fixed-int(true, 8)), ifId, vn) in
-  (match solve-apply(collect-all(tree, env, ifId), vn) with
+  (match solve-apply(collect-all(tree, re(), env, ifId), vn) with
     | Option.Some(Ty.TyInt(IntType.IntType(Sign.Signed, Width.WFixed(w)))) => (if w == 8 then unit else trap("if type joins to Int8"))
     | _ => trap("if branches join + node is the branch type"))
 
@@ -201,7 +244,7 @@ def hc-if-non-bool-cond-conflicts() =
   let (ve, n2) = fv(n1) in
   let (vn, _n3) = fv(n2) in
   let env = Map.insert(Map.insert(Map.insert(Map.insert((Map.empty : Map(Int64, Ty)), cId, ty-fixed-int(true, 8)), tId, vt), eId, ve), ifId, vn) in
-  (match solve(collect-all(tree, env, ifId)) with
+  (match solve(collect-all(tree, re(), env, ifId)) with
     | Option.None(_) => unit
     | Option.Some(_) => trap("a non-Bool if-cond must conflict (cond ~ Bool)"))
 
@@ -218,7 +261,7 @@ def hc-match-scrut-shares-lit-and-arms-join() =
   let (vt, n2) = fv(n1) in
   let (vn, _n3) = fv(n2) in
   let env = Map.insert(Map.insert(Map.insert(Map.insert(Map.insert((Map.empty : Map(Int64, Ty)), sId, vs), litId, ty-fixed-int(true, 8)), thenId, vt), elseId, ty-fixed-int(true, 8)), mId, vn) in
-  (match solve(collect-all(tree, env, mId)) with
+  (match solve(collect-all(tree, re(), env, mId)) with
     | Option.Some(su) => (match apply(su, vs) with
         | Ty.TyInt(IntType.IntType(Sign.Signed, Width.WFixed(w))) => (if w == 8 then unit else trap("scrut infers Int8 from lit"))
         | _ => trap("match scrut shares the literal-pattern's Int8 type"))
@@ -236,8 +279,64 @@ def hc-match-mismatched-arms-conflict() =
   let (vl, n2) = fv(n1) in
   let (vn, _n3) = fv(n2) in
   let env = Map.insert(Map.insert(Map.insert(Map.insert(Map.insert((Map.empty : Map(Int64, Ty)), sId, vs), litId, vl), thenId, ty-fixed-int(true, 8)), elseId, ty-fixed-int(true, 16)), mId, vn) in
-  (match solve(collect-all(tree, env, mId)) with
+  (match solve(collect-all(tree, re(), env, mId)) with
     | Option.None(_) => unit
     | Option.Some(_) => trap("Int8-then vs Int16-else must conflict (arm join)"))
+
+// ---- S1b: NVar coverage (a var use shares its binder's value type, via the resolve column) ----------
+
+@test
+def hc-var-use-shares-let-value-type() =
+  // `let x = (: 5 Int8) in x` — the body var x's use shares the let VALUE's type. Build: val=NAnnLit Int8,
+  // useVar=NVar, let=NLet(name, val, use). rcol maps the use → RBound(letId). Seed use as a fresh var; collect
+  // over the let emits (let~body) + (useVar ~ valInt8) → the use var infers Int8. Apply to the use's var → Int8.
+  let (valId, t1) = add-node(empty-tree(), Node.NAnnLit(5, 1, 8)) in
+  let (useId, t2) = add-node(t1, Node.NVar(1)) in
+  let (letId, tree) = add-node(t2, Node.NLet(1, valId, useId)) in
+  let (vuse, n1) = fv(0) in
+  let (vlet, _n2) = fv(n1) in
+  let env = Map.insert(Map.insert(Map.insert((Map.empty : Map(Int64, Ty)), valId, ty-fixed-int(true, 8)), useId, vuse), letId, vlet) in
+  let rcol = Map.insert((Map.empty : Map(Int64, Resolved)), useId, Resolved.RBound(letId)) in
+  (match solve(collect-all(tree, rcol, env, letId)) with
+    | Option.Some(su) => (match apply(su, vuse) with
+        | Ty.TyInt(IntType.IntType(Sign.Signed, Width.WFixed(w))) => (if w == 8 then unit else trap("var use infers Int8 from let value"))
+        | _ => trap("the body var shares the let value's Int8 type"))
+    | Option.None(_) => trap("let x=Int8 in x is solvable"))
+
+@test
+def hc-param-use-shares-param-var() =
+  // a PARAMETER use: the binder is the param's OWN NVar node (not a let). `(+ p (: 1 Int8))` where p is a param
+  // used in the body. paramNode=NVar (the binder), useNode=NVar (the use), both resolve the use → RBound(paramNode).
+  // Seed the param node + use node as the SAME... no: seed each its own var, the NVar rule constrains use~param.
+  // Then arith constrains use~Int8. So param infers Int8 (its use is added to an Int8). Apply to the PARAM's var → Int8.
+  let (paramId, t1) = add-node(empty-tree(), Node.NVar(1)) in                 // the param binder node
+  let (useId, t2) = add-node(t1, Node.NVar(1)) in                             // a use of the param
+  let (litId, t3) = add-node(t2, Node.NAnnLit(1, 1, 8)) in
+  let (binId, tree) = add-node(t3, Node.NBin(43, useId, litId)) in
+  let (vparam, n1) = fv(0) in
+  let (vuse, n2) = fv(n1) in
+  let (vbin, _n3) = fv(n2) in
+  let env = Map.insert(Map.insert(Map.insert(Map.insert((Map.empty : Map(Int64, Ty)), paramId, vparam), useId, vuse), litId, ty-fixed-int(true, 8)), binId, vbin) in
+  let rcol = Map.insert((Map.empty : Map(Int64, Resolved)), useId, Resolved.RBound(paramId)) in
+  (match solve(collect-all(tree, rcol, env, binId)) with
+    | Option.Some(su) => (match apply(su, vparam) with
+        | Ty.TyInt(IntType.IntType(Sign.Signed, Width.WFixed(w))) => (if w == 8 then unit else trap("param infers Int8 from its use in Int8 arith"))
+        | _ => trap("param var shares its use's type, which arith fixes to Int8"))
+    | Option.None(_) => trap("param used in Int8 arith is solvable"))
+
+@test
+def hc-unbound-var-emits-no-constraint() =
+  // an unbound var (RPoison, or no rcol fact) emits NO constraint — collect just skips it (a leaf). `(+ x 1)`
+  // with x unbound: collect emits only the arith constraints (2), not a var constraint. Pins the RPoison/no-fact
+  // path is inert (the caller/driver handles unbound-name declines separately, as TErr — not this module's job).
+  let (xId, t1) = add-node(empty-tree(), Node.NVar(9)) in
+  let (litId, t2) = add-node(t1, Node.NLit(1)) in
+  let (binId, tree) = add-node(t2, Node.NBin(43, xId, litId)) in
+  let (vx, n1) = fv(0) in
+  let (vl, n2) = fv(n1) in
+  let (vb, _n3) = fv(n2) in
+  let env = Map.insert(Map.insert(Map.insert((Map.empty : Map(Int64, Ty)), xId, vx), litId, vl), binId, vb) in
+  // rcol has NO fact for xId (unbound) → the NVar arm emits nothing; only the 2 arith constraints remain.
+  (if List.len(collect-all(tree, re(), env, binId)) == 2 then unit else trap("an unbound var adds no constraint — only the 2 arith constraints"))
 
 export { collect, collect-all, node-ty }


### PR DESCRIPTION
Candidate PR for v-compiler-ml's merge-request (ref 5ef9fd434, lane compiler-ml). Auto-merge armed; pr-sync's schedule-pass reaps on green.