### PR TITLE
syntax: ML formatter — capture own-line leading comments at match-arm-body + let-value + let-body (operator directive, unit 3)

### DIFF
--- a/implementation/seed/crates/cadenza-syntax/src/parser.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/parser.rs
@@ -1949,10 +1949,16 @@ impl<'a> Parser<'a> {
                 self.binder()
             };
             self.expect(Kind::Eq, "`=`");
+            // An own-line `//` comment BETWEEN `=` and the value (`let y =<newline> // note<newline>
+            // x + 1`) sits at the value's first-token leading slot, which `expr` does not drain — capture
+            // + wrap `(comment "text" value)` so it round-trips (else `cdz fmt` refuses). Same own-line
+            // leading-comment capture as if_expr's branches / the binding's own leading comment.
+            let e_lead = self.take_comments_here();
             // The bound value is a single expression (`PREC_SEQ + 1`), delimited by `in` (or the next
             // `,` binding). A `;` after it belongs to the enclosing sequence — `let x = a in b; c` is
             // `(do (let x=a in b) c)` — so a sequence VALUE parenthesizes: `let x = (a; b) in …`.
             let e = self.expr(crate::token::PREC_SEQ + 1);
+            let e = self.wrap_comments(e_lead, e);
             let b_span = b_start.merge(self.prev_span());
             let binding = self.list(vec![n, e], b_span);
             bindings.push(self.wrap_comments(leading, binding));
@@ -1973,7 +1979,13 @@ impl<'a> Parser<'a> {
         // body's own `expr` leading-slot would carry).
         let in_trail = self.take_trailing_comment_here();
         let binds = self.wrap_comment_after(in_trail, binds);
+        // An OWN-LINE `//` comment leading the body (`let x = a in<newline> // note<newline> body`) — a
+        // NON-trailing lead remaining after the same-line trailing capture above — sits at the body's
+        // leading slot. Capture + wrap `(comment "text" body)` so it prints own-line above the body
+        // (round-trips; else stranded → `cdz fmt` refuses).
+        let body_lead = self.take_comments_here();
         let body = self.expr(0);
+        let body = self.wrap_comments(body_lead, body);
         let span = start.merge(self.prev_span());
         self.list(vec![let_head, binds, body], span)
     }
@@ -2788,10 +2800,16 @@ impl<'a> Parser<'a> {
             pat = self.list(vec![guard_head, pat, g], g_span);
         }
         self.expect(Kind::FatArrow, "`=>`");
+        // An own-line `//` comment leading the arm BODY (`| A() =><newline> // note<newline> body`) sits
+        // at the body's first-token leading slot, which `expr` does not drain — capture + wrap
+        // `(comment "text" body)` so it prints own-line above the body (round-trips; else stranded →
+        // `cdz fmt` refuses). Same own-line leading-comment capture as the arm's own leading comment.
+        let body_lead = self.take_comments_here();
         let saved = self.arm_bar_terminates;
         self.arm_bar_terminates = true;
         let body = self.expr(0);
         self.arm_bar_terminates = saved;
+        let body = self.wrap_comments(body_lead, body);
         let span = start.merge(self.prev_span());
         self.list(vec![pat, body], span)
     }

--- a/implementation/seed/crates/cadenza-syntax/src/printer.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/printer.rs
@@ -7666,6 +7666,33 @@ mod tests {
     }
 
     #[test]
+    fn own_line_comments_leading_match_arm_body_and_let_value_and_let_body_round_trip() {
+        // Own-line `//` comments in three more mid-expression leading slots the reader previously dropped
+        // (so `cdz fmt` refused): leading a MATCH-ARM BODY (`=> <newline> // note <newline> body`),
+        // leading a LET-BINDING VALUE (`let y = <newline> // note <newline> value`), and leading the LET
+        // BODY (`in <newline> // note <newline> body`). Each is now captured `(comment "text" …)` +
+        // printed own-line above its expr. assert_roundtrip pins re-parse + idempotence for each.
+        let arm = assert_roundtrip(
+            "def f(x) = match x with\n  | A() =>\n// note\n1\n  | _ => 2",
+            100,
+        );
+        assert!(
+            arm.contains("// note"),
+            "match-arm-body leading comment preserved: {arm}"
+        );
+        let val = assert_roundtrip("def f(x) = let y =\n// vnote\nx + 1 in\ny", 100);
+        assert!(
+            val.contains("// vnote"),
+            "let-value leading comment preserved: {val}"
+        );
+        let body = assert_roundtrip("def f(x) = let y = x in\n// bnote\ny + 1", 100);
+        assert!(
+            body.contains("// bnote"),
+            "let-body leading comment preserved: {body}"
+        );
+    }
+
+    #[test]
     fn an_own_line_comment_before_else_round_trips_not_dropped() {
         // An OWN-LINE `//` sitting BEFORE the `else` keyword (`if a then 1` ⏎ `// note` ⏎ `else 2`) was
         // in the `else` token's leading slot and dropped when `expect_keyword` consumed past it. Now


### PR DESCRIPTION
Candidate PR for v-syntax's merge-request (ref 319ac8e3b, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.