### PR TITLE
syntax: ML formatter — capture own-line comment before the `then` keyword (operator directive, unit 4)

### DIFF
--- a/implementation/seed/crates/cadenza-syntax/src/parser.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/parser.rs
@@ -2006,8 +2006,14 @@ impl<'a> Parser<'a> {
         let c_lead = self.take_comments_here();
         let c = self.expr(crate::token::PREC_SEQ + 1);
         let c = self.wrap_comments(c_lead, c);
+        // Own-line `//` comment(s) BEFORE the `then` keyword (`if c<newline> // note<newline> then t`)
+        // sit in the `then` token's leading slot; `expect_keyword` would consume past them, dropping
+        // them. Capture before the bump + fold into the then-branch's leading comments so they print
+        // own-line above the then-branch (round-trips; else stranded → `cdz fmt` refuses). Symmetric with
+        // the own-line-before-`else` capture below.
+        let mut t_lead = self.take_comments_here();
         self.expect_keyword(Keyword::Then, "`then`");
-        let t_lead = self.take_comments_here();
+        t_lead.extend(self.take_comments_here());
         let t = self.expr(crate::token::PREC_SEQ + 1);
         let t = self.wrap_comments(t_lead, t);
         // A same-line TRAILING `//` after the then-branch (`if a then 1 // note<newline> else …`) sits at

--- a/implementation/seed/crates/cadenza-syntax/src/printer.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/printer.rs
@@ -7693,6 +7693,19 @@ mod tests {
     }
 
     #[test]
+    fn an_own_line_comment_before_then_round_trips_not_dropped() {
+        // An OWN-LINE `//` sitting BEFORE the `then` keyword (`if c` ⏎ `// note` ⏎ `then t`) was in the
+        // `then` token's leading slot and dropped when `expect_keyword` consumed past it (the last
+        // comment-attachment position blocking `cdz fmt` on the operator's hm-collect.cdz). Now captured +
+        // folded into the then-branch's leading comments — symmetric with the before-`else` capture.
+        let out = assert_roundtrip("def f(c) = if c\n// note\nthen 1 else 2", 100);
+        assert!(
+            out.contains("// note"),
+            "the own-line comment before `then` is preserved: {out}"
+        );
+    }
+
+    #[test]
     fn an_own_line_comment_before_else_round_trips_not_dropped() {
         // An OWN-LINE `//` sitting BEFORE the `else` keyword (`if a then 1` ⏎ `// note` ⏎ `else 2`) was
         // in the `else` token's leading slot and dropped when `expect_keyword` consumed past it. Now


### PR DESCRIPTION
Candidate PR for v-syntax's merge-request (ref f2f4fd66116139da079326a785f776dc366a2003, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.