### PR TITLE
corpus(3 cases): TWO-effect regions with same-effect shadows inside (breaker tq1-3)

### DIFF
--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -6410,3 +6410,6 @@ pass	syd1 an op returns a SYMBOL picked by state parity — symbol equality gate
 pass	dc1 a THREE-hop def relay under ONE handler — each def draws then calls the next, weights pin the depth order
 pass	dc2 the relay call's ARGUMENT is a draw — the callee draws again and combines, argument-before-body order pinned
 pass	dc3 the MIDDLE relay hop is chosen by a draw — the branch decides between a two-draw and a one-draw callee, a tail draw pins the total
+pass	tq1 a Q-shadow inside a TWO-effect region — P draws thread THROUGH the shadow while Q is locally rebound
+pass	tq2 the Q-shadow's SEED mixes P and Q draws — both outer threads advance before the shadow opens, and resume after
+pass	tq3 a Q-shadow wraps only the MIDDLE argument of a pure call — its neighbors dispatch to the outer P and Q frames

--- a/spec/semantics/.gate-baseline-rust
+++ b/spec/semantics/.gate-baseline-rust
@@ -6410,3 +6410,6 @@ pass	syd1 an op returns a SYMBOL picked by state parity — symbol equality gate
 pass	dc1 a THREE-hop def relay under ONE handler — each def draws then calls the next, weights pin the depth order
 pass	dc2 the relay call's ARGUMENT is a draw — the callee draws again and combines, argument-before-body order pinned
 pass	dc3 the MIDDLE relay hop is chosen by a draw — the branch decides between a two-draw and a one-draw callee, a tail draw pins the total
+pass	tq1 a Q-shadow inside a TWO-effect region — P draws thread THROUGH the shadow while Q is locally rebound
+pass	tq2 the Q-shadow's SEED mixes P and Q draws — both outer threads advance before the shadow opens, and resume after
+pass	tq3 a Q-shadow wraps only the MIDDLE argument of a pure call — its neighbors dispatch to the outer P and Q frames

--- a/spec/semantics/.gate-baseline-rust-async
+++ b/spec/semantics/.gate-baseline-rust-async
@@ -6410,3 +6410,6 @@ pass	syd1 an op returns a SYMBOL picked by state parity — symbol equality gate
 pass	dc1 a THREE-hop def relay under ONE handler — each def draws then calls the next, weights pin the depth order
 pass	dc2 the relay call's ARGUMENT is a draw — the callee draws again and combines, argument-before-body order pinned
 pass	dc3 the MIDDLE relay hop is chosen by a draw — the branch decides between a two-draw and a one-draw callee, a tail draw pins the total
+pass	tq1 a Q-shadow inside a TWO-effect region — P draws thread THROUGH the shadow while Q is locally rebound
+pass	tq2 the Q-shadow's SEED mixes P and Q draws — both outer threads advance before the shadow opens, and resume after
+pass	tq3 a Q-shadow wraps only the MIDDLE argument of a pure call — its neighbors dispatch to the outer P and Q frames

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -18673,3 +18673,68 @@
   (call   main (: 4 Int64)) (output (: 5603 Int64))
   (call   main (: 0 Int64)) (output (: 102 Int64))
   (call   main (: -3 Int64)) (output (: -198 Int64)))
+
+;; ── tq: TWO-effect regions with same-effect shadows inside ───────────────────
+;; tq1 rebinds Q locally while P draws thread THROUGH the shadow untouched;
+;; tq2's shadow SEED mixes P and Q draws (both outer threads advance before
+;; the shadow opens and resume after it closes); tq3 wraps ONLY the middle
+;; argument of a pure call in a Q-shadow — its neighbors dispatch to the
+;; outer P and Q frames.
+
+(case "tq1 a Q-shadow inside a TWO-effect region — P draws thread THROUGH the shadow while Q is locally rebound"
+  (input  (do
+            (effect P (op next (-> Int64)))
+            (effect Q (op next (-> Int64)))
+            (def (main (: n Int64))
+              (handle P n
+                ((next () s (resume s (+ s 1))))
+                (handle Q 100
+                  ((next () t (resume t (+ t 10))))
+                  (+ (P.next)
+                     (+ (Q.next)
+                        (+ (handle Q 7000
+                             ((next () t (resume t (+ t 100))))
+                             (+ (Q.next) (P.next)))
+                           (Q.next)))))))
+            (export main)))
+  (call   main (: 5 Int64)) (output (: 7221 Int64))
+  (call   main (: 0 Int64)) (output (: 7211 Int64))
+  (call   main (: -8 Int64)) (output (: 7195 Int64)))
+
+(case "tq2 the Q-shadow's SEED mixes P and Q draws — both outer threads advance before the shadow opens, and resume after"
+  (input  (do
+            (effect P (op next (-> Int64)))
+            (effect Q (op next (-> Int64)))
+            (def (main (: n Int64))
+              (handle P n
+                ((next () s (resume s (+ s 1))))
+                (handle Q 100
+                  ((next () t (resume t (+ t 10))))
+                  (+ (handle Q (+ (* 100 (P.next)) (Q.next))
+                       ((next () t (resume t t)))
+                       (Q.next))
+                     (+ (Q.next) (P.next))))))
+            (export main)))
+  (call   main (: 2 Int64)) (output (: 413 Int64))
+  (call   main (: 0 Int64)) (output (: 211 Int64))
+  (call   main (: -5 Int64)) (output (: -294 Int64)))
+
+(case "tq3 a Q-shadow wraps only the MIDDLE argument of a pure call — its neighbors dispatch to the outer P and Q frames"
+  (input  (do
+            (effect P (op next (-> Int64)))
+            (effect Q (op next (-> Int64)))
+            (def (sum3 (: a Int64) (: b Int64) (: c Int64)) (+ a (+ b c)))
+            (def (main (: n Int64))
+              (handle P n
+                ((next () s (resume s (+ s 1))))
+                (handle Q 100
+                  ((next () t (resume t (+ t 10))))
+                  (sum3 (P.next)
+                        (handle Q 9000
+                          ((next () t (resume t (+ t 9))))
+                          (Q.next))
+                        (Q.next)))))
+            (export main)))
+  (call   main (: 5 Int64)) (output (: 9105 Int64))
+  (call   main (: 0 Int64)) (output (: 9100 Int64))
+  (call   main (: -3 Int64)) (output (: 9097 Int64)))


### PR DESCRIPTION
Candidate PR for breaker's merge-request (ref 01ff3e055, lane baseline). Auto-merge armed; pr-sync's schedule-pass reaps on green.