### PR TITLE
compiler-ml: ARC-B5 B1 — add whole-type Ty.TyVar (port of rcdzc ty.rs Ty::Var)

### DIFF
--- a/implementation/compiler-ml/src/infer-db.cdz
+++ b/implementation/compiler-ml/src/infer-db.cdz
@@ -658,6 +658,9 @@ def typed-to-ty-defer(t: Ty) = match t with
   // unify-ty(TyBool,TyBool)=TyBool flow through the arith arm, mis-accepting `(+ true false)` as Bool.)
   | Ty.TyBool => Option.None(unit)
   | Ty.TyErr => Option.None(unit)
+  // ARC-B5 B1: a TyVar is not a concrete arith operand → None (like TyFn/TySum/TyBool). A TyVar never reaches
+  // this live-infer path today (the descent driver that produces TyVars isn't wired in); arm is for exhaustiveness.
+  | Ty.TyVar(_) => Option.None(unit)
 
 /// Literal-width adaptation for a mixed-width arith pair that didn't unify. If ONE operand is a plain `NLit(v)`
 /// (which infer typed as the default Int64) and the OTHER is a FIXED NARROW width (< 64) that `v` FITS, the

--- a/implementation/compiler-ml/src/subst.cdz
+++ b/implementation/compiler-ml/src/subst.cdz
@@ -77,6 +77,10 @@ def apply(su: Subst, t: Ty) = match t with
   | Ty.TyErr => Ty.TyErr
   | Ty.TySum(n) => Ty.TySum(n)
   | Ty.TyFn(ps, r) => Ty.TyFn(apply-list(su, ps, 0, ([] : List(Ty))), apply(su, r))
+  // ARC-B5 B1 placeholder: a TyVar is IDENTITY under apply until B2 adds the whole-type `tys` binding map to
+  // Subst (then this follows the chain, mirroring rcdzc apply@unify.rs:118 `Ty::Var(v) => tys.get(v)`). B1 adds
+  // the arm so every Ty match is exhaustive; the Subst has no tys map yet, so an unbound TyVar stays itself.
+  | Ty.TyVar(v) => Ty.TyVar(v)
 
 /// Apply the Subst to each element of a param-type list (index recursion, order-preserving).
 def apply-list(su: Subst, ps: List(Ty), i: Int64, acc: List(Ty)) =

--- a/implementation/compiler-ml/src/ty.cdz
+++ b/implementation/compiler-ml/src/ty.cdz
@@ -63,6 +63,16 @@
                                    // a cross-type ctor pattern (Color.Red vs a Bit scrutinee) is REJECTED. Carrying
                                    // only the declName (not the ctor list) suffices for unify (decl-identity) —
                                    // the ctors/arg-types live in the parse-db ct + a decl table, read where needed.
+  | TyVar(Int64)                   // ARC-B5 (port of rcdzc ty.rs:943 `Ty::Var(u32)`): a WHOLE-TYPE unification
+                                   // variable — an as-yet-unsolved type the inferencer introduces (a fresh var per
+                                   // node before it is constrained). Resolved to a concrete Ty by the HM solve
+                                   // (unify binds it via the Subst `tys` map); a var that survives to the boundary
+                                   // is an UNDETERMINED type (a rejection, not a default), exactly as rcdzc. Distinct
+                                   // from the int-axis Sign.SVar / Width.WVar (those vary only an int's sign/width);
+                                   // TyVar ranges over ANY Ty (int/bool/fn/sum), so a node whose type isn't known to
+                                   // be an int (a param used only as a match scrutinee, a fn-typed param) gets a
+                                   // TyVar and unifies toward whatever concrete type its uses force. Enables the
+                                   // recursive-descent type_of to seed every node a fresh TyVar and unify inline.
 
 /// A bare integer literal's type: BOTH axes deferred (rcdzc `IntType::deferred`) — grounds to the default via
 /// unification/root-defaulting. This is the type a literal STARTS as; an annotation or operator fixes it.
@@ -182,6 +192,12 @@ def ty-eq(a: Ty, b: Ty) = match a with
   // inner). This closes recursive sums + enforces ctor-app/pattern sharing a sum's identity (cross-type reject).
   | Ty.TySum(na) => (match b with
     | Ty.TySum(nb) => na == nb
+    | _ => false
+  )
+  // ARC-B5 (rcdzc ty.rs:1025 `(Ty::Var(a), Ty::Var(b)) => a == b`): two type variables are equal iff the SAME
+  // id. A TyVar is never equal to a concrete type (it's unsolved) — that's unify's job, not equality's.
+  | Ty.TyVar(va) => (match b with
+    | Ty.TyVar(vb) => va == vb
     | _ => false
   )
 

--- a/implementation/compiler-ml/src/unify-subst.cdz
+++ b/implementation/compiler-ml/src/unify-subst.cdz
@@ -92,6 +92,11 @@ def unify-ty-su(su: Subst, a: Ty, b: Ty) = match a with
   | Ty.TySum(na) => (match b with
     | Ty.TySum(nb) => (if na == nb then Option.Some(su) else Option.None(unit))
     | _ => Option.None(unit))
+  // ARC-B5 B1 placeholder: a TyVar does NOT bind yet — B3 adds the real bind-with-occurs (mirroring rcdzc
+  // unify@unify.rs:244 `(Ty::Var(v), t) => occurs-check then subst.tys.insert(v,t)`), which needs the B2
+  // whole-type `tys` map. B1 adds the arm for exhaustiveness only; conservatively declines (a var unifies with
+  // nothing until B3). NOTE: this arm is only reachable once the descent seeds TyVars — no live caller yet.
+  | Ty.TyVar(_) => Option.None(unit)
 
 /// Unify two same-length param lists PAIRWISE, threading the Subst left-to-right (each pair sees prior bindings).
 def unify-ty-list-su(su: Subst, a: List(Ty), b: List(Ty), i: Int64) =

--- a/implementation/compiler-ml/src/unify-ty.cdz
+++ b/implementation/compiler-ml/src/unify-ty.cdz
@@ -86,6 +86,10 @@ def unify-ty(a: Ty, b: Ty) = match a with
   | Ty.TySum(na) => (match b with
     | Ty.TySum(nb) => (if na == nb then Option.Some(Ty.TySum(na)) else Option.None(unit))
     | _ => Option.None(unit))                                    // sum ~ non-sum → conflict
+  // ARC-B5 B1: this STATELESS combiner (the pre-HM live-infer primitive) has no Subst to bind a var into, so a
+  // TyVar declines here — the real var-binding unify is unify-subst.cdz's unify-ty-su (Subst-threading, B3). A
+  // TyVar never reaches this stateless path in the current live pipeline; the arm is for exhaustiveness.
+  | Ty.TyVar(_) => Option.None(unit)
 
 /// Unify two same-length param-type lists PAIRWISE (index recursion). `Some(list)` = every pair unified (the
 /// combined param types, in order); `None` = any pair conflicted. Callers guarantee equal length.


### PR DESCRIPTION
Candidate PR for v-compiler-ml's merge-request (ref 0a0cdbc40, lane compiler-ml). Auto-merge armed; pr-sync's schedule-pass reaps on green.