### PR TITLE
rcdzc: RT3 additive — record-TYPE field readers accept `(: name T)` ascription

### DIFF
--- a/implementation/seed/crates/cadenza-syntax/src/printer.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/printer.rs
@@ -6018,6 +6018,35 @@ mod tests {
     }
 
     #[test]
+    fn record_type_fields_print_as_colon_ascription_and_round_trip() {
+        // DESIGN-record-type-syntax RT2 (operator PR #2794): the canonical record-TYPE field is the
+        // `(: name T)` ascription node — the SAME node as a param binder / `e: T`, not a bespoke pair.
+        // A `Record` type head prints each `(: field T)` child through the infix `:` path as
+        // `field : T`, and the printed surface re-parses back to the identical ascription arena. This
+        // pins the canonical-form behavior BEFORE Phase A migrates the ~141 head-app `(field T)` cases,
+        // so the atomic RT1+RT3+RT4 land cannot silently regress the ascription round-trip.
+        //
+        // Arena -> surface: the ascription children print as `a : Int64` (infix `:`, spaced), never as
+        // the head-app spelling `a(Int64)`.
+        let a = sexpr::read("(type R (Record (: a Int64) (: b Bool)))").unwrap();
+        let out = print(&a, 80);
+        assert_eq!(out, "type R =\n  | Record(a : Int64, b : Bool)");
+        assert!(
+            !out.contains("a(Int64)"),
+            "field must not print as head-app: {out:?}"
+        );
+        // Surface -> arena -> surface: the printed colon form re-parses to the same ascription arena
+        // and reprints identically (round-trip fixed point).
+        assert_eq!(
+            assert_roundtrip("type R =\n  | Record(a : Int64, b : Bool)", 80),
+            "type R =\n  | Record(a : Int64, b : Bool)"
+        );
+        // Single field, same shape.
+        let a = sexpr::read("(type R (Record (: a Int64)))").unwrap();
+        assert_eq!(print(&a, 80), "type R =\n  | Record(a : Int64)");
+    }
+
+    #[test]
     fn multi_statement_function_body_prints_bare() {
         // A `(do …)` FUNCTION body prints as a bare `;`-separated statement run under the `=` — the
         // exact surface the parser folds back into that `(do …)`. No wrapping parens.

--- a/implementation/seed/crates/rcdzc/src/eval.rs
+++ b/implementation/seed/crates/rcdzc/src/eval.rs
@@ -2759,16 +2759,32 @@ pub fn reduce_ctor(
             let mut fields: std::collections::BTreeMap<crate::resolved::Symbol, crate::ty::Ty> =
                 std::collections::BTreeMap::new();
             for (i, &a) in args.iter().enumerate() {
-                let pair = match db.ast.get(a).clone() {
-                    crate::ast::Struct::List(children) if children.len() == 2 => children,
-                    _ => return Err(format!("Record field {i} is not a (name type) pair")),
+                // The record-TYPE field is EITHER the canonical `(: name T)` ascription (the shared
+                // binder node — DESIGN-record-type-syntax Phase A) OR the legacy `(name T)` head-app
+                // pair. Read both to `(name, type)`; accepting the ascription here is the additive half
+                // of RT3, needed BEFORE the encoder flips to emit ascription. Strictly widening — an
+                // ascription in this position previously failed the `len == 2` pair check and errored,
+                // so no currently-accepted input changes. The pair arm is pruned once head-app is
+                // extinct (OQ-C).
+                let (name_occ, ty_occ) = if let Some(asc) = db.ast.as_form(a, ":") {
+                    if asc.len() != 2 {
+                        return Err(format!("Record field {i} ascription is not (: name type)"));
+                    }
+                    (asc[0], asc[1])
+                } else {
+                    match db.ast.get(a) {
+                        crate::ast::Struct::List(children) if children.len() == 2 => {
+                            (children[0], children[1])
+                        }
+                        _ => return Err(format!("Record field {i} is not a (name type) pair")),
+                    }
                 };
                 let name = db
                     .ast
-                    .as_name(pair[0])
+                    .as_name(name_occ)
                     .ok_or_else(|| format!("Record field {i} has no name"))?
                     .to_string();
-                let t = typeval_of(db, pair[1])
+                let t = typeval_of(db, ty_occ)
                     .ok_or_else(|| format!("Record field `{name}` is not a type"))?;
                 fields.insert(crate::resolved::Symbol::plain(name), t);
             }

--- a/implementation/seed/crates/rcdzc/src/resolve.rs
+++ b/implementation/seed/crates/rcdzc/src/resolve.rs
@@ -5810,13 +5810,25 @@ fn decode_ty(db: &Db, node: StructId) -> Option<crate::ty::Ty> {
         "Record" => {
             let tail = db.ast.as_form(node, "Record")?;
             let mut fields = std::collections::BTreeMap::new();
-            for &pair in tail {
-                let items = match db.ast.get(pair) {
-                    Struct::List(items) if items.len() == 2 => items,
-                    _ => return None,
+            for &field in tail {
+                // A field is EITHER the canonical `(: name T)` ascription (the shared binder node —
+                // DESIGN-record-type-syntax Phase A) OR the legacy `(name T)` head-app pair. Read both;
+                // accepting the ascription is the additive half of RT3, the dual of the `encode_ty`
+                // flip and needed before it. Strictly widening — an ascription previously failed the
+                // `len == 2` pair check and returned `None`. Pair arm pruned once head-app is extinct.
+                let (name_occ, ty_occ) = if let Some(asc) = db.ast.as_form(field, ":") {
+                    match asc {
+                        [name, t] => (*name, *t),
+                        _ => return None,
+                    }
+                } else {
+                    match db.ast.get(field) {
+                        Struct::List(items) if items.len() == 2 => (items[0], items[1]),
+                        _ => return None,
+                    }
                 };
-                let name = db.ast.as_name(items[0])?.to_string();
-                let t = decode_ty(db, items[1])?;
+                let name = db.ast.as_name(name_occ)?.to_string();
+                let t = decode_ty(db, ty_occ)?;
                 fields.insert(crate::resolved::Symbol::plain(name), t);
             }
             Some(Ty::Record(std::rc::Rc::new(fields)))

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -96282,6 +96282,70 @@ mod cross_component_oracle {
     fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
         haystack.windows(needle.len()).any(|w| w == needle)
     }
+
+    #[test]
+    fn record_type_field_ascription_is_read_by_reduce_ctor_and_decode_ty() {
+        // DESIGN-record-type-syntax Phase A, RT3 (additive half): the two pair-only record-TYPE field
+        // readers — `reduce_ctor`'s `RecordCtor` arm (`eval.rs`) and `decode_ty`'s `"Record"` arm
+        // (`resolve.rs`) — now ALSO accept the canonical `(: name T)` ascription field (the shared
+        // binder node), not only the legacy `(name T)` head-app pair. This is the widening that must
+        // land BEFORE the `encode_ty`/`render_name` flip starts EMITTING ascription; strictly additive
+        // (an ascription previously failed the `len == 2` pair match and errored/returned None), so no
+        // currently-accepted program changes. Pins BOTH readers read the field TYPES (not just the
+        // shape): a wrong field type is rejected, and the built `Ty::Record` carries the declared types.
+        use crate::db::Db;
+        use crate::eval::typeval_of;
+        use crate::testkit::parse;
+        use crate::ty::Ty;
+
+        // reduce_ctor path: `typeval_of` on the ascription-form `(Record (: a Int64) (: b Bool))` node
+        // reduces to a `Ty::Record` with exactly {a: Int64, b: Bool}.
+        let ast =
+            parse("(module m (def (main (: r (Record (: a Int64) (: b Bool)))) 0) (export main))");
+        let mut db = Db::load(ast);
+        let rec_node = (0..db.ast.structure.len() as u32)
+            .map(crate::ast::StructId)
+            .find(|&id| {
+                db.ast
+                    .as_form(id, "Record")
+                    .is_some_and(|tail| tail.len() == 2)
+            })
+            .expect("the parsed program contains a two-field (Record …) type node");
+        match typeval_of(&mut db, rec_node) {
+            Some(Ty::Record(fields)) => {
+                assert_eq!(fields.len(), 2, "two fields: {fields:?}");
+                assert_eq!(
+                    fields.get(&crate::resolved::Symbol::plain("a".to_string())),
+                    Some(&Ty::int64()),
+                    "field a is Int64 (the ascription's type position was read): {fields:?}"
+                );
+                assert_eq!(
+                    fields.get(&crate::resolved::Symbol::plain("b".to_string())),
+                    Some(&Ty::Bool),
+                    "field b is Bool: {fields:?}"
+                );
+            }
+            other => panic!("ascription-field Record must reduce to Ty::Record, got {other:?}"),
+        }
+
+        // decode_ty / end-to-end path: a value annotated with an ascription-form record type COMPILES,
+        // and a field whose value type MISMATCHES the ascription is REJECTED — proving the field TYPE
+        // (not just the name) is read through the full annotate/check pipeline.
+        let ok = "(module m \
+            (def (main) (: (record (a 1) (b true)) (Record (: a Int64) (: b Bool)))) \
+            (export main))";
+        assert!(
+            crate::compile::compile_component(&crate::codec::encode(&parse(ok))).is_ok(),
+            "a record value annotated with an ascription-form record type must compile"
+        );
+        let bad = "(module m \
+            (def (main) (: (record (a true) (b true)) (Record (: a Int64) (: b Bool)))) \
+            (export main))";
+        assert!(
+            crate::compile::compile_component(&crate::codec::encode(&parse(bad))).is_err(),
+            "a field value whose type mismatches the ascription must be rejected (the type position is checked)"
+        );
+    }
 }
 
 /// A variant whose PAYLOAD TYPE is written with the LOWERCASE compound-type alias `(tuple …)` is read as a


### PR DESCRIPTION
Candidate PR for v-syntax's merge-request (ref dbdd4d9b1, lane mixed). Auto-merge armed; pr-sync's schedule-pass reaps on green.