### PR TITLE
compiler-ml: ARC-B5 B2 — Subst whole-type tys map + apply-follow + ty-occurs (port rcdzc unify.rs)

### DIFF
--- a/implementation/compiler-ml/src/hm-vars.cdz
+++ b/implementation/compiler-ml/src/hm-vars.cdz
@@ -16,7 +16,7 @@
 /// result the SAME var-id? If so, binding would self-cycle → reject (the solver keeps the type finite). This is
 /// what guarantees the chain `apply` follows in B1 is ACYCLIC (B1's fuel bound is the belt; this is the braces).
 import { Sign, Width, IntType, Ty } from "ty"
-import { Subst, apply-sign, apply-width } from "subst"
+import { Subst, apply-sign, apply-width, subst-tys } from "subst"
 
 // ---- FRESH VARIABLE SUPPLY (explicit-counter form of rcdzc `Fresh`) ---------------------------------
 /// A fresh SIGN var from counter `n`: `(SVar(n), n+1)`. The caller threads the returned next-id.
@@ -44,8 +44,35 @@ def width-occurs(su: Subst, b: Int64, w: Width) = match apply-width(su, w) with
   | Width.WVar(c) => b == c
   | _ => false
 
+/// ARC-B5 B2: does WHOLE-TYPE var-id `v` OCCUR in type `t`, resolved through Subst `su`? (rcdzc occurs@unify.rs:548
+/// — "walk the type resolving each Ty::Var through the subst chain".) Before the solver binds `TyVar(v) := t`, it
+/// must check `v` does not occur in `t` — else `v := (Fn v ..)` etc. makes an INFINITE type (reject). Walk the
+/// structure: a TyVar resolves through the `tys` chain (a bound one continues into its solution, an unbound one is
+/// compared to `v`); a TyFn checks every param + the result; int/bool/err/sum hold no whole-type var (an int's
+/// sign/width VARs are a different axis — a TyVar never occurs inside a TyInt). Fuel-bounded on the var chain
+/// (mirrors apply's cap) so a cycle that slipped in can't loop the check forever.
+def ty-occurs(su: Subst, v: Int64, t: Ty) = ty-occurs-go(su, v, t, 64)
+def ty-occurs-go(su: Subst, v: Int64, t: Ty, fuel: Int64) =
+  (if fuel == 0 then false
+   else (match t with
+     | Ty.TyVar(w) => (match Map.lookup(subst-tys(su), w) with
+         | Option.Some(sol) => ty-occurs-go(su, v, sol, fuel - 1)   // bound → continue into its solution
+         | Option.None(_) => v == w)                                // unbound → occurs iff same id
+     | Ty.TyFn(ps, r) => (if ty-occurs-list(su, v, ps, 0, fuel) then true else ty-occurs-go(su, v, r, fuel))
+     | Ty.TyInt(_) => false                                         // int's sign/width vars are a different axis
+     | Ty.TyBool => false
+     | Ty.TyErr => false
+     | Ty.TySum(_) => false))
+
+/// Does whole-type var `v` occur in ANY element of param-type list `ps` (from index `i`)? (TyFn occurs helper.)
+def ty-occurs-list(su: Subst, v: Int64, ps: List(Ty), i: Int64, fuel: Int64) =
+  (if i == List.len(ps) then false
+   else (match List.at(ps, i) with
+     | Option.Some(p) => (if ty-occurs-go(su, v, p, fuel) then true else ty-occurs-list(su, v, ps, i + 1, fuel))
+     | Option.None(_) => false))
+
 // ---- TESTS: fresh supply threads a counter; occurs-check catches self-cycles --------------------------
-import { subst-empty, subst-bind-sign, subst-bind-width } from "subst"
+import { subst-empty, subst-bind-sign, subst-bind-width, subst-bind-ty } from "subst"
 
 @test
 def hv-fresh-sign-advances-counter() =
@@ -113,10 +140,37 @@ def hv-width-occurs-self-and-chain() =
   else
     trap("width var 0 occurs in WVar(0)")
 
+// ---- B2: ty-occurs (whole-type occurs-check, rcdzc occurs@unify.rs:548) ----
+
+@test
+def hv-ty-occurs-self() =
+  // TyVar 0 occurs in TyVar 0 (direct self) → binding 0 := TyVar(0) would self-cycle (reject).
+  if ty-occurs(subst-empty(), 0, Ty.TyVar(0)) then unit else trap("TyVar 0 occurs in itself")
+
+@test
+def hv-ty-no-occurs-in-distinct-or-concrete() =
+  // TyVar 0 does NOT occur in a distinct var (TyVar 1) nor a concrete type (TyBool) → binding is safe.
+  if ty-occurs(subst-empty(), 0, Ty.TyVar(1)) then trap("distinct var does not occur")
+  else (if ty-occurs(subst-empty(), 0, Ty.TyBool) then trap("var never occurs in a concrete type") else unit)
+
+@test
+def hv-ty-occurs-under-tyfn() =
+  // TyVar 0 occurs INSIDE a TyFn param `(TyVar0) -> TyBool` → binding 0 := that fn would make an infinite type.
+  let f = Ty.TyFn(List.push([], Ty.TyVar(0)), Ty.TyBool) in
+  if ty-occurs(subst-empty(), 0, f) then unit else trap("TyVar 0 occurs in a TyFn param")
+
+@test
+def hv-ty-occurs-through-chain() =
+  // occurs FOLLOWS the tys chain: TyVar 1 := (TyFn (TyVar0) -> Bool); does 0 occur in TyVar 1? Resolve 1 to the fn,
+  // then 0 occurs in its param → true. Pins the resolve-through-subst that rcdzc occurs does.
+  let su = subst-bind-ty(subst-empty(), 1, Ty.TyFn(List.push([], Ty.TyVar(0)), Ty.TyBool)) in
+  if ty-occurs(su, 0, Ty.TyVar(1)) then unit else trap("occurs resolves TyVar 1 through the chain, finds 0 in the fn")
+
 export {
   fresh-sign,
   fresh-width,
   fresh-int-ty,
   sign-occurs,
-  width-occurs
+  width-occurs,
+  ty-occurs
 }

--- a/implementation/compiler-ml/src/subst.cdz
+++ b/implementation/compiler-ml/src/subst.cdz
@@ -22,28 +22,37 @@
 /// Subst; B4 (`instantiate`) freshens scheme vars into a Subst. B1 gives them the container + the read side.
 import { Sign, Width, IntType, Ty } from "ty"
 
-/// The substitution: a sign-var-binding map + a width-var-binding map (the two orthogonal axes). Absent key =
-/// the var is UNBOUND (still an unknown). A single-variant compound carrier (the ML-surface record idiom).
+/// The substitution: THREE binding maps — sign-var, width-var, and whole-type-var — the three orthogonal axes
+/// (rcdzc unify.rs:71 `struct Subst { tys: Map<u32,Ty>, widths: Map<u32,Width>, signs: Map<u32,Sign> }`). Absent
+/// key = the var is UNBOUND. B2 (ARC-B5) adds the `tys` (whole-type) map so a `Ty.TyVar` can be bound to any Ty,
+/// mirroring rcdzc exactly. A single-variant compound carrier (the ML-surface record idiom).
 type Subst =
-  | Subst(Map(Int64, Sign), Map(Int64, Width))
+  | Subst(Map(Int64, Sign), Map(Int64, Width), Map(Int64, Ty))
 
 /// The empty Subst — no var bound yet (the solver's start state; rcdzc `Subst::default`).
-def subst-empty() = Subst.Subst(Map.empty : Map(Int64, Sign), Map.empty : Map(Int64, Width))
+def subst-empty() = Subst.Subst(Map.empty : Map(Int64, Sign), Map.empty : Map(Int64, Width), Map.empty : Map(Int64, Ty))
 
 /// The sign-binding map (read-only accessor).
-def subst-signs(su: Subst) = let Subst.Subst(sm, _) = su in sm
+def subst-signs(su: Subst) = let Subst.Subst(sm, _, _) = su in sm
 
 /// The width-binding map (read-only accessor).
-def subst-widths(su: Subst) = let Subst.Subst(_, wm) = su in wm
+def subst-widths(su: Subst) = let Subst.Subst(_, wm, _) = su in wm
+
+/// The whole-type-binding map (read-only accessor) — `TyVar id -> Ty` (rcdzc `subst.tys`).
+def subst-tys(su: Subst) = let Subst.Subst(_, _, tm) = su in tm
 
 /// BIND a sign var-id to a sign (the solver records `SVar id := s`). Overwrites — the solver binds a fresh/unbound
 /// var, so a well-formed solve never re-binds a distinct value (B3 guards the bind path; this is the low-level write).
 def subst-bind-sign(su: Subst, id: Int64, s: Sign) =
-  let Subst.Subst(sm, wm) = su in Subst.Subst(Map.insert(sm, id, s), wm)
+  let Subst.Subst(sm, wm, tm) = su in Subst.Subst(Map.insert(sm, id, s), wm, tm)
 
 /// BIND a width var-id to a width.
 def subst-bind-width(su: Subst, id: Int64, w: Width) =
-  let Subst.Subst(sm, wm) = su in Subst.Subst(sm, Map.insert(wm, id, w))
+  let Subst.Subst(sm, wm, tm) = su in Subst.Subst(sm, Map.insert(wm, id, w), tm)
+
+/// BIND a whole-type var-id to a `Ty` (the solver records `TyVar id := t`; rcdzc unify.rs:253 `subst.tys.insert`).
+def subst-bind-ty(su: Subst, id: Int64, t: Ty) =
+  let Subst.Subst(sm, wm, tm) = su in Subst.Subst(sm, wm, Map.insert(tm, id, t))
 
 /// Chain-following sign resolution (rcdzc `apply_sign`): if `s` is a bound `SVar`, follow to its binding, and
 /// keep following while that binding is itself a bound var. Fuel-bounded (default depth) so a malformed cyclic
@@ -67,20 +76,27 @@ def apply-width-go(su: Subst, w: Width, fuel: Int64) =
          | Option.None(_) => w)
      | _ => w))
 
-/// APPLY the Subst to a whole `Ty` (rcdzc `apply`): replace every bound var on each axis with its binding. TyInt
-/// applies both axes independently; TyBool/TyErr/TySum are var-free (unchanged); TyFn recurses into every param
-/// type + the result (a fn type's vars are solved too). The as-solved-as-current-Subst form of the type.
-def apply(su: Subst, t: Ty) = match t with
+/// APPLY the Subst to a whole `Ty` (rcdzc `apply`, unify.rs:93): replace every bound var — sign, width, AND
+/// whole-type — with its binding, following chains. TyInt applies both int axes; TyBool/TyErr/TySum are var-free;
+/// TyFn recurses into params + result; a bound TyVar FOLLOWS its `tys` binding (and recurses into the resolved
+/// type, since a var may bind to a compound holding more vars). Fuel-bounded on the TyVar chain (rcdzc's
+/// APPLY_VAR_CHAIN_LIMIT / depth cap): a cyclic binding that bypassed the occurs-check would otherwise recurse
+/// forever — past the fuel, stop and yield the var as-is (a well-formed acyclic solve is far under the cap).
+def apply(su: Subst, t: Ty) = apply-go(su, t, 64)
+def apply-go(su: Subst, t: Ty, fuel: Int64) = match t with
   | Ty.TyInt(it) => (match it with
     | IntType.IntType(s, w) => Ty.TyInt(IntType.IntType(apply-sign(su, s), apply-width(su, w))))
   | Ty.TyBool => Ty.TyBool
   | Ty.TyErr => Ty.TyErr
   | Ty.TySum(n) => Ty.TySum(n)
-  | Ty.TyFn(ps, r) => Ty.TyFn(apply-list(su, ps, 0, ([] : List(Ty))), apply(su, r))
-  // ARC-B5 B1 placeholder: a TyVar is IDENTITY under apply until B2 adds the whole-type `tys` binding map to
-  // Subst (then this follows the chain, mirroring rcdzc apply@unify.rs:118 `Ty::Var(v) => tys.get(v)`). B1 adds
-  // the arm so every Ty match is exhaustive; the Subst has no tys map yet, so an unbound TyVar stays itself.
-  | Ty.TyVar(v) => Ty.TyVar(v)
+  | Ty.TyFn(ps, r) => Ty.TyFn(apply-list(su, ps, 0, ([] : List(Ty))), apply-go(su, r, fuel))
+  // ARC-B5 B2 (rcdzc apply@unify.rs:118 `Ty::Var(v) => match tys.get(v) { Some(t) => apply(t), None => Var(v) }`):
+  // a bound TyVar follows its `tys` binding and re-applies (the binding may itself hold vars); an unbound TyVar
+  // stays. Fuel guards a cyclic binding (occurs-check bypass) from infinite recursion — stop and keep the var.
+  | Ty.TyVar(v) => (if fuel == 0 then Ty.TyVar(v)
+      else (match Map.lookup(subst-tys(su), v) with
+        | Option.Some(t2) => apply-go(su, t2, fuel - 1)   // bound → follow the chain + re-apply
+        | Option.None(_) => Ty.TyVar(v)))                 // unbound var → stays
 
 /// Apply the Subst to each element of a param-type list (index recursion, order-preserving).
 def apply-list(su: Subst, ps: List(Ty), i: Int64, acc: List(Ty)) =
@@ -161,13 +177,51 @@ def su-bool-and-err-unchanged() =
     | Ty.TyBool => (match apply(su, Ty.TyErr) with | Ty.TyErr => unit | _ => trap("TyErr unchanged"))
     | _ => trap("TyBool unchanged by a subst")
 
+// ---- B2: the whole-type `tys` map — TyVar binds to ANY Ty, apply follows the chain (rcdzc apply@118) ----
+
+@test
+def su-b2-tyvar-binds-to-bool() =
+  // bind TyVar 0 := TyBool; apply resolves the TyVar to TyBool (a whole-type binding, not an int-axis one).
+  let su = subst-bind-ty(subst-empty(), 0, Ty.TyBool) in
+  match apply(su, Ty.TyVar(0)) with
+    | Ty.TyBool => unit
+    | _ => trap("TyVar 0 := TyBool resolves to TyBool under apply")
+
+@test
+def su-b2-unbound-tyvar-stays() =
+  // an unbound TyVar is returned as-is (still an unknown — apply is not grounding).
+  match apply(subst-empty(), Ty.TyVar(7)) with
+    | Ty.TyVar(v) => (if v == 7 then unit else trap("unbound TyVar keeps its id"))
+    | _ => trap("unbound TyVar 7 stays a var")
+
+@test
+def su-b2-tyvar-binds-to-int-then-resolves-axes() =
+  // TyVar can bind to a COMPOUND: bind TyVar 0 := (Int SVar1 WFixed8) and SVar1 := Unsigned; apply follows the
+  // TyVar chain into the int AND resolves its inner sign var → UInt8. Pins the re-apply after the var-follow.
+  let su0 = subst-bind-ty(subst-empty(), 0, Ty.TyInt(IntType.IntType(Sign.SVar(1), Width.WFixed(8)))) in
+  let su = subst-bind-sign(su0, 1, Sign.Unsigned) in
+  match apply(su, Ty.TyVar(0)) with
+    | Ty.TyInt(IntType.IntType(Sign.Unsigned, Width.WFixed(w))) => (if w == 8 then unit else trap("TyVar→int resolves to UInt8"))
+    | _ => trap("TyVar bound to an int follows + re-applies inner axes")
+
+@test
+def su-b2-tyvar-chain-follows() =
+  // CHAIN: TyVar 0 := TyVar 1, TyVar 1 := TyBool. apply follows 0→1→TyBool (whole-type chain, like the sign chain).
+  let su0 = subst-bind-ty(subst-empty(), 0, Ty.TyVar(1)) in
+  let su = subst-bind-ty(su0, 1, Ty.TyBool) in
+  match apply(su, Ty.TyVar(0)) with
+    | Ty.TyBool => unit
+    | _ => trap("TyVar 0 → TyVar 1 → TyBool chain-follows")
+
 export {
   Subst.*,
   subst-empty,
   subst-signs,
   subst-widths,
+  subst-tys,
   subst-bind-sign,
   subst-bind-width,
+  subst-bind-ty,
   apply-sign,
   apply-width,
   apply


### PR DESCRIPTION
Candidate PR for v-compiler-ml's merge-request (ref 2e43890b9, lane compiler-ml). Auto-merge armed; pr-sync's schedule-pass reaps on green.