### PR TITLE
syntax: cadenza-lint I1b — lint-level layer (allow/warn/deny per named lint)

### DIFF
--- a/implementation/seed/crates/cadenza-syntax/src/query.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/query.rs
@@ -3247,6 +3247,88 @@ pub mod lint {
         }
     }
 
+    /// The per-lint control level (DESIGN-cadenza-lint §3, the one net-new mechanism). Distinct from
+    /// [`Severity`] — `Severity` is the rule's default REPORTING kind (error/warning/info); a `LintLevel`
+    /// is the user's OVERRIDE of whether and how a NAMED lint fires: `Allow` suppresses it entirely,
+    /// `Warn` reports it as a warning, `Deny` promotes it to an error (fails the run). Set by a module
+    /// `(allow/warn/deny NAME)` directive or a `--allow/--warn/--deny NAME` CLI flag; only a NAMED lint
+    /// (`name: Some(_)`) can be controlled (a bare report-only rule has no name to key off).
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub enum LintLevel {
+        Allow,
+        Warn,
+        Deny,
+    }
+
+    impl LintLevel {
+        /// Parse a level name; `None` for an unknown one.
+        pub fn parse(s: &str) -> Option<LintLevel> {
+            match s {
+                "allow" => Some(LintLevel::Allow),
+                "warn" | "warning" => Some(LintLevel::Warn),
+                "deny" => Some(LintLevel::Deny),
+                _ => None,
+            }
+        }
+
+        pub fn as_str(self) -> &'static str {
+            match self {
+                LintLevel::Allow => "allow",
+                LintLevel::Warn => "warn",
+                LintLevel::Deny => "deny",
+            }
+        }
+    }
+
+    /// A resolved set of per-lint level overrides, keyed by the namespaced lint name. A lookup honors
+    /// GROUP prefixes: a level set for a bare group (`idiomatic`) applies to every lint under it
+    /// (`idiomatic/if-bool`), with the MOST SPECIFIC key winning (an exact-name override beats a group
+    /// override). Two layers compose by [`Self::overlay`] — the module directive layer first, then the
+    /// CLI layer on top (CLI wins), matching the §3 resolution order CLI > module > rule-default.
+    #[derive(Clone, Debug, Default)]
+    pub struct LintLevels {
+        /// name-or-group → level. Insertion order irrelevant; lookup picks the longest matching key.
+        map: std::collections::BTreeMap<String, LintLevel>,
+    }
+
+    impl LintLevels {
+        pub fn new() -> LintLevels {
+            LintLevels::default()
+        }
+
+        /// Set `name` (an exact lint name or a group prefix) to `level`. A later set of the same key
+        /// wins (last-write), so a CLI overlay naturally overrides a module one for the same key.
+        pub fn set(&mut self, name: impl Into<String>, level: LintLevel) {
+            self.map.insert(name.into(), level);
+        }
+
+        /// Overlay `other` ON TOP of `self` (other's keys win) — the CLI layer over the module layer.
+        pub fn overlay(&mut self, other: &LintLevels) {
+            for (k, v) in &other.map {
+                self.map.insert(k.clone(), *v);
+            }
+        }
+
+        /// The effective level for a lint `name`, or `None` if neither the name nor any of its group
+        /// prefixes was overridden (the caller then uses the rule's default). A namespaced name
+        /// `a/b/c` is probed most-specific first: `a/b/c`, then `a/b`, then `a` — the longest match
+        /// wins, so an exact override beats a broader group one.
+        pub fn effective(&self, name: &str) -> Option<LintLevel> {
+            if let Some(&l) = self.map.get(name) {
+                return Some(l);
+            }
+            // Walk group prefixes from most to least specific by trimming trailing `/segment`s.
+            let mut probe = name;
+            while let Some(cut) = probe.rfind('/') {
+                probe = &probe[..cut];
+                if let Some(&l) = self.map.get(probe) {
+                    return Some(l);
+                }
+            }
+            None
+        }
+    }
+
     /// One reported diagnostic: the rule's message + severity, and the matched node's span (if the
     /// subject carried one). Rules are applied in order; within a rule, matches are pre-order.
     #[derive(Clone, Debug)]
@@ -3260,14 +3342,37 @@ pub mod lint {
 
     /// Run every lint rule over `subject`, collecting diagnostics. Rules run in order; each rule's
     /// matches are reported in pre-order. `spans` (if any) attaches a source span to each diagnostic.
+    /// This is the level-free path (every rule reports at its default severity).
     pub fn run(set: &LintSet, subject: &Tree, spans: Option<&SpanTable>) -> Vec<Diagnostic> {
+        run_with_levels(set, subject, spans, &LintLevels::default())
+    }
+
+    /// Run every lint rule, applying the per-lint level overrides. For a NAMED rule, its effective
+    /// level (from `levels`, else its default severity) decides the outcome: `Allow` DROPS every match
+    /// (no diagnostic), `Deny` reports at `error` severity, `Warn` at `warning`. A rule with no name,
+    /// or a named rule with no override, reports at its own `severity` unchanged. Match order is
+    /// preserved (rules in order, matches pre-order).
+    pub fn run_with_levels(
+        set: &LintSet,
+        subject: &Tree,
+        spans: Option<&SpanTable>,
+        levels: &LintLevels,
+    ) -> Vec<Diagnostic> {
         let empty = Query::default();
         let mut out = Vec::new();
         for rule in &set.rules {
+            // Resolve the effective severity for this rule. Only a NAMED rule can be level-controlled.
+            let level = rule.name.as_deref().and_then(|n| levels.effective(n));
+            let severity = match level {
+                Some(LintLevel::Allow) => continue, // suppressed — emit nothing for this rule
+                Some(LintLevel::Deny) => Severity::Error,
+                Some(LintLevel::Warn) => Severity::Warning,
+                None => rule.severity,
+            };
             for m in search_with(&rule.pattern, &empty, subject, spans) {
                 out.push(Diagnostic {
                     message: rule.message.clone(),
-                    severity: rule.severity,
+                    severity,
                     span: m.span,
                     matched: m.node.to_sexpr(),
                 });
@@ -5538,7 +5643,7 @@ mod tests {
 
     mod lint_tests {
         use super::subj;
-        use crate::query::lint::{self, Applicability, LintSet, Severity};
+        use crate::query::lint::{self, Applicability, LintLevel, LintLevels, LintSet, Severity};
 
         #[test]
         fn severity_parses_and_defaults_to_warning() {
@@ -5747,6 +5852,113 @@ mod tests {
                 .unwrap();
             assert_eq!(set.rules[0].severity, Severity::Error);
             assert_eq!(set.rules[0].name.as_deref(), Some("idiomatic/if-bool"));
+        }
+
+        // --- cadenza-lint I1 (level layer): allow/warn/deny per named lint. ---
+
+        #[test]
+        fn lint_level_parses_known_and_rejects_unknown() {
+            assert_eq!(LintLevel::parse("allow"), Some(LintLevel::Allow));
+            assert_eq!(LintLevel::parse("warn"), Some(LintLevel::Warn));
+            assert_eq!(LintLevel::parse("deny"), Some(LintLevel::Deny));
+            assert_eq!(LintLevel::parse("bogus"), None);
+        }
+
+        #[test]
+        fn allow_suppresses_a_named_lint_entirely() {
+            let set = LintSet::compile(
+                "(lint idiomatic/if-bool (if ,c true false) \"prefer the condition\")",
+            )
+            .unwrap();
+            let s = subj("(do (if a true false) (g b))");
+            // Without a level: fires.
+            assert_eq!(lint::run(&set, &s, None).len(), 1);
+            // Allowed: suppressed.
+            let mut levels = LintLevels::new();
+            levels.set("idiomatic/if-bool", LintLevel::Allow);
+            assert!(lint::run_with_levels(&set, &s, None, &levels).is_empty());
+        }
+
+        #[test]
+        fn deny_promotes_a_named_lint_to_error() {
+            let set = LintSet::compile(
+                "(lint idiomatic/if-bool (if ,c true false) \"prefer the condition\")",
+            )
+            .unwrap();
+            let s = subj("(do (if a true false))");
+            let mut levels = LintLevels::new();
+            levels.set("idiomatic/if-bool", LintLevel::Deny);
+            let diags = lint::run_with_levels(&set, &s, None, &levels);
+            assert_eq!(diags.len(), 1);
+            assert_eq!(diags[0].severity, Severity::Error);
+            assert!(lint::has_error(&diags), "deny fails the run");
+        }
+
+        #[test]
+        fn a_group_prefix_level_applies_to_every_lint_under_it() {
+            let set = LintSet::compile(
+                "(lint idiomatic/if-bool (if ,c true false) \"a\")\n\
+                 (lint naming/camel-case (camelCase ,@_) \"b\")",
+            )
+            .unwrap();
+            let s = subj("(do (if a true false) (camelCase x))");
+            // Allowing the whole `idiomatic` group suppresses if-bool but NOT naming/camel-case.
+            let mut levels = LintLevels::new();
+            levels.set("idiomatic", LintLevel::Allow);
+            let diags = lint::run_with_levels(&set, &s, None, &levels);
+            assert_eq!(diags.len(), 1, "{diags:?}");
+            assert_eq!(diags[0].message, "b");
+        }
+
+        #[test]
+        fn an_exact_name_override_beats_a_group_override() {
+            let set =
+                LintSet::compile("(lint idiomatic/if-bool (if ,c true false) \"a\")").unwrap();
+            let s = subj("(do (if a true false))");
+            // Group allows, but the exact name denies — the most-specific key wins → error.
+            let mut levels = LintLevels::new();
+            levels.set("idiomatic", LintLevel::Allow);
+            levels.set("idiomatic/if-bool", LintLevel::Deny);
+            let diags = lint::run_with_levels(&set, &s, None, &levels);
+            assert_eq!(diags.len(), 1);
+            assert_eq!(diags[0].severity, Severity::Error);
+        }
+
+        #[test]
+        fn a_cli_overlay_wins_over_a_module_level() {
+            // module layer denies; CLI layer allows on top → allowed (CLI > module).
+            let mut module = LintLevels::new();
+            module.set("idiomatic/if-bool", LintLevel::Deny);
+            let mut cli = LintLevels::new();
+            cli.set("idiomatic/if-bool", LintLevel::Allow);
+            module.overlay(&cli);
+            assert_eq!(
+                module.effective("idiomatic/if-bool"),
+                Some(LintLevel::Allow)
+            );
+        }
+
+        #[test]
+        fn a_bare_unnamed_rule_is_not_level_controlled() {
+            // A report-only rule has no name to key off, so a level override cannot touch it.
+            let set = LintSet::compile("(lint (todo ,@_) \"has a todo\")").unwrap();
+            let s = subj("(do (todo x))");
+            let mut levels = LintLevels::new();
+            levels.set("todo", LintLevel::Allow); // no effect — the rule is unnamed
+            assert_eq!(lint::run_with_levels(&set, &s, None, &levels).len(), 1);
+        }
+
+        #[test]
+        fn an_unoverridden_named_lint_keeps_its_default_severity() {
+            let set = LintSet::compile("(lint idiomatic/x (bad ,@_) \"m\" info)").unwrap();
+            let s = subj("(do (bad y))");
+            let levels = LintLevels::new(); // empty
+            let diags = lint::run_with_levels(&set, &s, None, &levels);
+            assert_eq!(
+                diags[0].severity,
+                Severity::Info,
+                "default severity preserved"
+            );
         }
     }
 

--- a/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/backend/rust/tests.rs
@@ -6733,8 +6733,8 @@ fn a_record_arg_closure_consumer_emits_a_param_shapes_note() {
     // correctly. Assert the consumer emits + carries the Record-shaped note.
     let m = compile_rust(
         "(module m \
-           (def (mkb (: k Int64)) (fn ((: r (Record (a Int64) (b Int64)))) (+ (* (. r a) (. r b)) k))) \
-           (def (appb (: h (-> (Record (a Int64) (b Int64)) Int64)) (: y Int64)) (h (record (a y) (b y)))) \
+           (def (mkb (: k Int64)) (fn ((: r (Record (: a Int64) (: b Int64)))) (+ (* (. r a) (. r b)) k))) \
+           (def (appb (: h (-> (Record (: a Int64) (: b Int64)) Int64)) (: y Int64)) (h (record (a y) (b y)))) \
            (export mkb) (export appb))",
     );
     assert!(
@@ -6742,7 +6742,7 @@ fn a_record_arg_closure_consumer_emits_a_param_shapes_note() {
         "the record-arg consumer emits (record erases to the (i64,i64) tuple):\n{m}"
     );
     assert!(
-        m.contains("// cdz-param-shapes[appb]: (-> (Record (a Int64) (b Int64)) Int64)"),
+        m.contains("// cdz-param-shapes[appb]: (-> (Record (: a Int64) (: b Int64)) Int64)"),
         "the consumer carries a cdz-param-shapes note with the pre-erasure Record arrow:\n{m}"
     );
 }

--- a/implementation/seed/crates/rcdzc/src/compile.rs
+++ b/implementation/seed/crates/rcdzc/src/compile.rs
@@ -2185,10 +2185,16 @@ fn collect_faults(db: &mut Db) -> Vec<Reject> {
         let field_entries = children[1..].to_vec();
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         for entry in field_entries {
-            // Each field entry is `(name Type)`; read the field name (the entry's first child).
-            let Some(name) = (match db.ast.get(entry) {
-                crate::ast::Struct::List(kv) if kv.len() == 2 => db.ast.as_name(kv[0]),
-                _ => None,
+            // Each field entry is the canonical `(: name Type)` ascription (RT3) or the legacy
+            // `(name Type)` head-app pair; read the field name from whichever form. (Without the
+            // ascription arm the duplicate-field check silently passed once the encoder/corpus moved to
+            // ascription — the field name went unread, so a repeated `x` slipped through.)
+            let Some(name) = (match db.ast.as_form(entry, ":") {
+                Some([name_occ, _ty]) => db.ast.as_name(*name_occ),
+                _ => match db.ast.get(entry) {
+                    crate::ast::Struct::List(kv) if kv.len() == 2 => db.ast.as_name(kv[0]),
+                    _ => None,
+                },
             })
             .map(str::to_string) else {
                 continue;

--- a/implementation/seed/crates/rcdzc/src/eval.rs
+++ b/implementation/seed/crates/rcdzc/src/eval.rs
@@ -3704,15 +3704,18 @@ fn encode_ty(db: &mut Db, ty: &crate::ty::Ty) -> StructId {
             }
             db.push_list(items)
         }
-        // A record type-value: `(Record (name T)…)` in canonical (sorted) field order — the capitalized
-        // `Record` head (the TYPE; the VALUE head is lowercase `record`), each field a `(name T)` pair.
-        // Round-trips with `decode_ty`'s `"Record"` arm; the `BTreeMap` iteration IS the canonical order.
+        // A record type-value: `(Record (: name T)…)` in canonical (sorted) field order — the capitalized
+        // `Record` head (the TYPE; the VALUE head is lowercase `record`), each field the canonical
+        // `(: name T)` ASCRIPTION node (RT3, DESIGN-record-type-syntax) — the shared binder node, not a
+        // bespoke pair. Round-trips with `decode_ty`'s `"Record"` arm (which reads the ascription); the
+        // `BTreeMap` iteration IS the canonical order.
         Ty::Record(fields) => {
             let mut items = vec![db.push_name("Record")];
             for (name, t) in fields.iter() {
+                let colon = db.push_name(":");
                 let fname = db.push_name(&name.name);
                 let fty = encode_ty(db, t);
-                items.push(db.push_list(vec![fname, fty]));
+                items.push(db.push_list(vec![colon, fname, fty]));
             }
             db.push_list(items)
         }

--- a/implementation/seed/crates/rcdzc/src/lower.rs
+++ b/implementation/seed/crates/rcdzc/src/lower.rs
@@ -15675,13 +15675,16 @@ fn type_ast(b: &mut crate::ast::Builder, ty: &crate::ty::Ty) -> Option<StructId>
         }
         Ty::Record(fields) => {
             // The TYPE head is capitalized `Record` (like `Tuple`); the VALUE head is lowercase `record`
-            // (see `const_value_ast`). The corpus writes `(Record (a Int64) …)` for the type.
+            // (see `const_value_ast`). Each field is the canonical `(: name T)` ASCRIPTION node (RT3,
+            // DESIGN-record-type-syntax) — the corpus writes `(Record (: a Int64) …)` for the type,
+            // matching `render_name`/`encode_ty`.
             let head = b.name("Record");
             let mut children = vec![head];
             for (name, t) in fields.iter() {
+                let colon = b.name(":");
                 let fname = b.name(name.name.clone());
                 let fty = type_ast(b, t)?;
-                children.push(b.list(vec![fname, fty]));
+                children.push(b.list(vec![colon, fname, fty]));
             }
             Some(b.list(children))
         }
@@ -26656,7 +26659,7 @@ mod tests {
         // Fields in canonical (sorted) order a, b → positional [a, b].
         assert_eq!(
             render(&ty, &V::Record(vec![V::Int(3), V::Int(1)])),
-            "(: (record (a 3) (b 1)) (Record (a Int64) (b Int64)))"
+            "(: (record (a 3) (b 1)) (Record (: a Int64) (: b Int64)))"
         );
     }
 

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -3039,7 +3039,7 @@ fn a_recursive_runtime_record_escapes_to_the_host() {
     };
     match cdz_run::run(&bytes, &opts).expect("run") {
         cdz_run::Outcome::Value(s) => assert_eq!(
-            s, "(: (record (a 0) (b 7)) (Record (a Int64) (b Int64)))",
+            s, "(: (record (a 0) (b 7)) (Record (: a Int64) (: b Int64)))",
             "R2 record escape value form"
         ),
         cdz_run::Outcome::Trap(t) => panic!("R2 record escape run trapped: {t}"),
@@ -3143,7 +3143,7 @@ fn a_record_with_a_runtime_tuple_field_escapes_to_the_host() {
     };
     match cdz_run::run(&bytes, &opts).expect("run") {
         cdz_run::Outcome::Value(s) => assert_eq!(
-            s, "(: (record (x 0) (y (tuple 0 1))) (Record (x Int64) (y (Tuple Int64 Int64))))",
+            s, "(: (record (x 0) (y (tuple 0 1))) (Record (: x Int64) (: y (Tuple Int64 Int64))))",
             "R2 nested record escape value form"
         ),
         cdz_run::Outcome::Trap(t) => panic!("R2 nested record escape run trapped: {t}"),
@@ -34477,13 +34477,13 @@ mod match_engine {
         // ("a list pattern does not match the payload type T"), which misleads for a top-level `match`/`let`
         // on a plain value that is not a variant payload.
         let rec = reject_full(
-            "(module m (def (g (: r (Record (x Int64)))) (match r ((list a) a))) (export g))",
+            "(module m (def (g (: r (Record (: x Int64)))) (match r ((list a) a))) (export g))",
         )
         .expect("a list pattern on a record rejects");
         assert_eq!(rec.code.as_deref(), Some("CDZ0201"), "got: {}", rec.message);
         assert!(
             rec.message.contains(
-                "this list pattern cannot destructure a value of type (Record (x Int64))"
+                "this list pattern cannot destructure a value of type (Record (: x Int64))"
             ) && !rec.message.contains("payload"),
             "names the type, no internal 'payload' term: {}",
             rec.message
@@ -53223,16 +53223,17 @@ mod diagnostics {
 
     #[test]
     fn a_record_type_renders_capitalized_matching_its_annotation_spelling() {
-        // `Ty::render_name` spells a RECORD type `(Record (a Int64))` — CAPITALIZED, the type-constructor
-        // head the author writes in an annotation (`(: r (Record (a Int64)))`), consistent with
-        // `Tuple`/`List`/`Map`/`Set`. It used to render lowercase `(record …)` — the VALUE constructor
+        // `Ty::render_name` spells a RECORD type `(Record (: a Int64))` — CAPITALIZED, the type-constructor
+        // head the author writes in an annotation (`(: r (Record (: a Int64)))`), consistent with
+        // `Tuple`/`List`/`Map`/`Set`; each field is the canonical `(: name T)` ASCRIPTION node (RT3,
+        // DESIGN-record-type-syntax). It used to render lowercase `(record …)` — the VALUE constructor
         // spelling, which a type annotation REJECTS ("not a type"), so a mismatch message named a type the
         // reader could not have written. The rendered type must round-trip as a valid annotation.
-        let d = first_error("(module m (def y (: (record (a 1)) (Record (a Bool)))) (export y))");
+        let d = first_error("(module m (def y (: (record (a 1)) (Record (: a Bool)))) (export y))");
         assert_eq!(d.code.as_deref(), Some("CDZ0203"), "got: {}", d.message);
         assert!(
-            d.message.contains("(Record (a Bool))") && d.message.contains("(Record (a Int64))"),
-            "record TYPE renders capitalized, matching the annotation spelling: {}",
+            d.message.contains("(Record (: a Bool))") && d.message.contains("(Record (: a Int64))"),
+            "record TYPE renders capitalized with ascription fields, matching the annotation spelling: {}",
             d.message
         );
         assert!(
@@ -53240,10 +53241,10 @@ mod diagnostics {
             "no lowercase value-constructor spelling in a TYPE message: {}",
             d.message
         );
-        // The rendered type is a VALID annotation (round-trips) — a reader can copy `(Record (a Bool))`
+        // The rendered type is a VALID annotation (round-trips) — a reader can copy `(Record (: a Bool))`
         // straight into an annotation; a compile of exactly that spelling never says "not a type".
         let round_trip = all_errors(
-            "(module m (def (f (: r (Record (a Bool)))) r) (def (main) 0) (export main))",
+            "(module m (def (f (: r (Record (: a Bool)))) r) (def (main) 0) (export main))",
         );
         assert!(
             !round_trip.iter().any(|e| e.message.contains("not a type")),
@@ -77889,7 +77890,7 @@ mod constant_resource_escape {
         let src = "(module m (def (main) (record (a 3) (b 1))) (export main))";
         assert_eq!(
             run_and_decode(src),
-            "(: (record (a 3) (b 1)) (Record (a Int64) (b Int64)))"
+            "(: (record (a 3) (b 1)) (Record (: a Int64) (: b Int64)))"
         );
     }
 }

--- a/implementation/seed/crates/rcdzc/src/ty.rs
+++ b/implementation/seed/crates/rcdzc/src/ty.rs
@@ -1719,16 +1719,18 @@ impl Ty {
             // width ({32, 64}) has an alias, so an observed float type is always a concrete `FloatN`
             // (an unresolved width grounds to `Float64`), mirroring the integer `IntN`/`UIntN` render.
             Ty::Float(ft) => format!("Float{}", ft.ground_width()),
-            // A record TYPE renders as `(Record (name Type) …)` in canonical (sorted) field order — the
-            // CAPITALIZED type-constructor head the author writes in an annotation (`(: r (Record (a
+            // A record TYPE renders as `(Record (: name Type) …)` in canonical (sorted) field order — the
+            // CAPITALIZED type-constructor head the author writes in an annotation (`(: r (Record (: a
             // Int64)))`), matching `Tuple`/`List`/`Map`/`Set` below (a lowercase `(record …)` in type
-            // position is rejected as "not a type" — it is the VALUE constructor). This is a TYPE renderer,
-            // so it must spell the type the way the surface accepts it: a mismatch message naming
-            // `(record (a Bool))` reads as a different thing than the `(Record (a Bool))` the author wrote.
+            // position is rejected as "not a type" — it is the VALUE constructor). Each field is the
+            // canonical `(: name T)` ASCRIPTION node (RT3, DESIGN-record-type-syntax) — the same node a
+            // param binder / `e: T` uses, not a bespoke pair. This is a TYPE renderer, so it must spell the
+            // type the way the surface accepts it: a mismatch message naming `(record (: a Bool))` reads as
+            // a different thing than the `(Record (: a Bool))` the author wrote.
             Ty::Record(fields) => {
                 let mut s = String::from("(Record");
                 for (k, t) in fields.iter() {
-                    s.push_str(&format!(" ({} {})", k.name, t.render_name()));
+                    s.push_str(&format!(" (: {} {})", k.name, t.render_name()));
                 }
                 s.push(')');
                 s
@@ -1818,7 +1820,8 @@ impl Ty {
             Ty::Record(fields) => {
                 let mut s = String::from("(Record");
                 for (k, t) in fields.iter() {
-                    s.push_str(&format!(" ({} {})", k.name, t.render_named_vars(names)));
+                    // Canonical `(: name T)` ascription field (RT3), matching `render_name`.
+                    s.push_str(&format!(" (: {} {})", k.name, t.render_named_vars(names)));
                 }
                 s.push(')');
                 s

--- a/spec/semantics/.gate-baseline
+++ b/spec/semantics/.gate-baseline
@@ -1,4 +1,5 @@
 # gate baseline — per-case verdicts (verdict\tdescription). Regenerate with `cargo xtask gate --save`.
+pass	200 recursive dispatches each crossing a heap LIST argument — the marshal at depth
 pass	@ensures / @requires predicate PROJECTS a TUPLE component (`(. ret N)` on the result, `(. p N)` on a param)
 pass	@ensures holds when the guarded def arrives through a runtime branch
 pass	@ensures on a RECURSIVE def whose body is a HANDLE is re-checked at every recursive exit (recursion x effects-fold seam)
@@ -56,6 +57,7 @@ pass	BigInt.of a signed Int32 is a positive BigInt (the narrow path breaks regar
 pass	Bytes.concat of two runtime SLICES splices window content in order
 pass	Bytes.concat of two sliced-view to-bytes is read twice and both reads see the concatenated bytes
 pass	Bytes.of of a computed (concatenated) runtime list builds a byte sequence of that length
+pass	Bytes.slice of a map-looked-up Bytes with perform-threaded start and len threads without a scratch collision
 pass	CATALAN numbers grow by convolving the table with itself and agree with the binomial closed form
 pass	CHUNK splits a list into fixed-size sublists with a short final chunk that reflattens intact
 pass	COIN CHANGE builds a min-coins table where greedy fails and unreachable targets report -1
@@ -65,7 +67,7 @@ pass	COMPOUND RESULT PAYLOAD: (Result (Tuple Int64 Int64) Int64) arg, drive Ok (
 pass	COMPOUND RESULT PAYLOAD: (Result Int64 (Tuple Int64 Int64)) — the ERR side is compound
 pass	COMPOUND RESULT PAYLOAD: a compound-Result closure beside a scalar closure (distinct-sig)
 pass	COMPOUND RESULT PAYLOAD: two same-sig closures share one call (multi-export)
-pass	COMPOUND SUM PAYLOAD: (Option (Record (x Int64) (y Int64))) — a RECORD payload
+pass	COMPOUND SUM PAYLOAD: (Option (Record (: x Int64) (: y Int64))) — a RECORD payload
 pass	COMPOUND SUM PAYLOAD: (Option (Tuple Int64 (Tuple Int64 Int64))) — a NESTED tuple payload
 pass	COMPOUND SUM PAYLOAD: (Option (Tuple Int64 Int64)) arg, drive None
 pass	COMPOUND SUM PAYLOAD: (Option (Tuple Int64 Int64)) arg, drive Some
@@ -132,6 +134,7 @@ pass	HORNER polynomial evaluation folds coefficients high-to-low and agrees with
 pass	IDIOMATIC HeadOp-sum encoding discharges no-overflow: for x<=100, (x+1)<=MAXINT (sum-typed head, not a magic-int Const tag)
 pass	INTERLEAVE alternates two spines and drains the longer tail after the shorter empties
 pass	INTERLEAVED pops and inserts keep the event queue min-ordered across live mutation
+pass	INVALID UTF-8 crosses as a Bytes op argument — the arm's decode declines with None
 pass	INVERSION COUNT pairs every element with its successors, zero when sorted and maximal when reversed
 pass	Int64 MAX threads the handler state intact (representation at the boundary)
 pass	Int64.min crosses the parameter boundary and back unchanged
@@ -272,6 +275,7 @@ pass	Qty.value recovers the underlying numeric value, discarding the unit
 pass	RANGE-SUM answers interval queries from a prefix table and agrees with a direct walk
 pass	RLE encode/decode round-trips a list — the runtime element merges or splits a run
 pass	ROTATE-90 composes row-reverse with transpose and four rotations restore the matrix
+pass	Rational.of over TWO perform results — ctor-arg order observable through the dispatches
 pass	Record.extend ADDS a closure field beside two existing ones and all three apply
 pass	Record.extend chained onto Record.without of a map-borne record computes, not traps
 pass	Record.extend widens a map-extracted record and the wide row enters a new map
@@ -283,6 +287,7 @@ pass	Record.with REPLACES one heap-list field while the sibling and the ORIGINAL
 pass	Record.with grows a LIST field by pushing onto the projected old value
 pass	Record.with on a map-extracted record leaves the stored original untouched
 pass	Record.with over a RUNTIME field leaves the original record readable (persistence)
+pass	Record.with over a perform result — the ORIGINAL record survives beside the update
 pass	Record.with replaces a nested-record field wholesale and the original keeps its inner
 pass	Record.without over runtime field values drops the named field and keeps the rest live
 pass	Record.without strips a field on a map-extracted record and both maps stay typed
@@ -320,6 +325,7 @@ pass	Set.to-list enumerates the FULL interior order, not just the smallest eleme
 pass	Set.to-list enumerates the elements as a List in canonical (sorted) order
 pass	Set.to-list length is the set's cardinality (deduped)
 pass	Set.to-list of a runtime-empty but element-typed set is the empty list
+pass	Set.to-list of the state crosses resume ORDERED — the body reads elements positionally
 pass	Set.to-list orders (Int,Bytes) tuples with the Bytes component as the tie-breaker
 pass	Set.to-list orders a multibyte string element AFTER ascii by unsigned byte order
 pass	Set.to-list orders a set of COMPOUND (tuple) elements lexicographically
@@ -410,6 +416,7 @@ pass	TWO modules' recursive performers interleave under ONE handler's shared sta
 pass	TWO outer op-results as SIBLING args of one inner perform evaluate left-to-right
 pass	TWO performs in an if condition both fold on the strict-first spine
 pass	TWO prefix scalars then a Tuple then a suffix scalar cross the direct-call boundary
+pass	TWO sequential handles of the same effect — the second starts fresh, no state bleed
 pass	TWO sequential inner handles seed from the outer's ADVANCING state
 pass	TWO sibling inner handlers observe through ONE outer counter
 pass	TWO stacked @ensures COMPOSE: BOTH postconditions are enforced — value-transparent when both hold
@@ -493,6 +500,9 @@ pass	a 3-arg effect op binds its operands POSITIONALLY — an argument-order swa
 pass	a 32-bit-float closure crosses the host boundary
 pass	a 32-bit-integer closure crosses the host boundary
 pass	a 33-VARIANT sum dispatches across the discriminant range with a payload variant last
+pass	a 40-element SET op result — a multi-node CHAMP payload crosses resume
+pass	a 40-element list as op ARGUMENT — the arm folds a multi-leaf RRB payload
+pass	a 40-element list op RESULT crosses resume — a multi-leaf RRB payload survives the marshal
 pass	a 40-entry trie of LIST values keeps each heap payload addressable at depth
 pass	a 500-iteration Bytes.concat loop measures exactly and indexes both extremes
 pass	a 5000-deep recursive-sum spine builds, walks, and compares — the eq walk survives depth
@@ -538,6 +548,7 @@ pass	a BOOL-result effect op threads state across two performs on a boolean conn
 pass	a BORROWED runtime Bytes rope map key is compacted at the key site and found by its flat twin
 pass	a BRANCHING tree walk performs once per leaf at 200-leaf scale
 pass	a BST built by comparison-driven inserts reads back sorted via in-order traversal
+pass	a BigInt arithmetic tower over one perform draw — cube then divide, narrowed once
 pass	a BigInt computed across the limb boundary keys a Map like its literal twin
 pass	a BigInt factorial accumulator computes 25! exactly
 pass	a BigInt is usable as a map key, matched by its arbitrary-precision value
@@ -564,6 +575,8 @@ pass	a Bytes-compact key and a flat rebuild both hit a rope-keyed map entry; a p
 pass	a Bytes-returning closure alongside a plain export — the closure runs
 pass	a Bytes-returning closure alongside a plain export — the plain runs
 pass	a Bytes-returning closure on a different argument
+pass	a Bytes-to-Bytes transformer op — the arm frames the payload it received and the body re-reads
+pass	a Bytes.slice VIEW crosses as op ARGUMENT — the arm reads through the window it was handed
 pass	a Bytes.slice into the to-bytes output decodes at a scalar boundary and rejects mid-scalar
 pass	a CAESAR cipher shifts alphabet positions modulo 26, involutes at ROT13, passes non-letters
 pass	a CALL-returned single-variant newtype with a literal-payload arm spills at the right width
@@ -585,6 +598,7 @@ pass	a CBOR skip steps over a tagged item to the value it wraps
 pass	a CBOR skip walks past a whole nested item to the next offset
 pass	a CLASSIFY-and-BUILD fold maps ints to letter pieces and the built rope equals the literal
 pass	a CLOSURE as the op ARGUMENT — the arm applies the caller's strategy to its own state
+pass	a CLOSURE handler state captures the enclosing function's parameter and applies per dispatch
 pass	a CLOSURE state whose body performs an OUTER effect when the arm applies it
 pass	a COMPOUND generated value is reproducible from its seed (a tuple draws identically twice)
 pass	a COMPOUND map key with a Rational leaf hashes+matches by the leaf's normalized form
@@ -607,12 +621,14 @@ pass	a CONSTANT signed nibble truncation of an all-ones nibble is -1
 pass	a CONSTANT signed nibble truncation sign-extends — the const-fold companion of the runtime .wrap
 pass	a CONSTANT signed truncation of an all-ones Int 12 is -1
 pass	a CONSTANT signed truncation sign-extends at a WIDER storage width (Int 12, i16 storage)
+pass	a CONSTANT-failure `?` inside the arm's helper — the cut stays in the helper, dispatch unharmed
 pass	a CONTINUED FRACTION evaluates bottom-up through recursive Rational division (a + 1/rest)
 pass	a CONTRACTED fn consumes perform results — @requires fires on a handler-produced value
 pass	a CROSS-handler op whose inline ARG performs an OUTER handler's op folds (op-arg let-lift)
 pass	a CURRIED closure capturing an inner-handled perform result closes over it through partial application
 pass	a Char-payload sum value escapes across the boundary in its canonical form
 pass	a DEFERRED resume-thunk escaping to another function re-installs the handler at apply, over a re-performing do-continuation
+pass	a DEPTH-3 nested-op chain WITHOUT a post-observer folds (the no-observer control for the observer-gated guard)
 pass	a DEPTH-3 op-arg chain threads across two handler layers
 pass	a DERIVED-dimension (velocity) quantity used as a Map key hits by content
 pass	a DIRECT-init branch perform in a let-init threads its state advance (adv-69 control, still computes)
@@ -633,8 +649,11 @@ pass	a FLOAT literal grounded to Float32 through an arith operand overflows to i
 pass	a FLOAT literal that fits its contextually-grounded narrow width through an arith op computes
 pass	a FLOAT-field Tuple closure ARG flattens + rebuilds (box-float imported)
 pass	a FLOAT-result effect op threads a float state and its resume folds under a float-dispatched operator
+pass	a FLOAT64 as op ARGUMENT — the arm accumulates fractional values into Float64 state
 pass	a FOUR-arg effect op binds positionally (place-value checksum)
+pass	a FRAMED-Bytes handler state decoded and re-encoded by the arm per dispatch
 pass	a FRESHLY-BUILT recursive-sum payload returns through a Result and unwraps in the caller
+pass	a FULL handle expression in the resume-value slot — the arm runs a nested handler per dispatch
 pass	a Fletcher-16 over a seam-spanning slice VIEW equals the checksum of its logical bytes
 pass	a Float KEY inserted into an empty (runtime) map boxes with box-float, not box-int
 pass	a Float VALUE inserted into an empty (runtime) map boxes with box-float, not box-int
@@ -674,21 +693,29 @@ pass	a HEX DECODER finds each digit's value by alphabet scan and rejects a bad d
 pass	a HEX ENCODER splits each byte into nibbles and indexes a digit alphabet string
 pass	a HOF callback matching a tuple argument computes through the nested reduction
 pass	a HOF callback matching its sum argument reaches the nullary arm
+pass	a HOST-delegated perform in a nested arm's NEXT-STATE slot is served (sequences at the boundary)
 pass	a KNOWN type's UNKNOWN variant constructed in an uncalled def is rejected
 pass	a LAZY comparator chain (Ordering + thunk) short-circuits on decisive and falls through on Equal
 pass	a LEB128 final byte is the shifted remainder masked to seven bits
 pass	a LEB128 non-final byte composes mask, continuation bit, and truncation
 pass	a LET shadow of a do-def heap binding closes its scope and the do-def survives
+pass	a LET-BOUND perform after a cross-function recursive helper observes the helper's out-state
 pass	a LET-bound escaping-effect closure returned from a host block cannot cross the host boundary
 pass	a LET-bound local (not a param) survives the multi-site continuation rebuild
 pass	a LET-bound outer perform under an inner handle threads its state advance
+pass	a LIST OF BIGINTS as op ARGUMENT — the arm folds heap-numeric elements it is handed
+pass	a LIST OF SETS as op ARGUMENT — the arm indexes into the nested payload it is handed
+pass	a LIST OF SETS op result — the body indexes, measures, and probes the nested elements
+pass	a LIST OF STRINGS op result — the body indexes and measures rope elements after the marshal
 pass	a LIST OF SUMS resumed from a handler feeds an event-sourcing fold in the body
+pass	a LIST built from three performs ESCAPES the handle — read intact outside the region
 pass	a LIST built in the handle body from perform results crosses the handle exit live
 pass	a LIST of Rationals as a map key normalizes EVERY element for the key hash
 pass	a LIST of closures as a set element is rejected (the collection-element face of the descent)
 pass	a LIST of closures rides one perform and the arm picks by state per call
 pass	a LIST of strategies is walked recursively, each applied to a fresh perform result
 pass	a LIST shrinker drops elements greedily and converges to a minimal failing sublist
+pass	a LIST-literal scrutinee with performing elements — draws fire once, bind by position
 pass	a LONGEST-COMMON-PREFIX walks two strings in scalar lockstep to the first mismatch
 pass	a List-returning closure alongside a plain export — the closure
 pass	a List-returning closure alongside a plain export — the plain
@@ -699,9 +726,12 @@ pass	a List.update at a second-RRB-node index on a large runtime list lands ther
 pass	a List.update at a third-level RRB index lands and preserves persistence and siblings
 pass	a List.update at depth-3 RRB path-copies one spine and shares the rest
 pass	a MAP MERGE folds one map's entries into another, summing values on key collision
+pass	a MAP OF LISTS op result — the body looks up a key and folds the inner list
 pass	a MAP argument to an effect op is looked up inside the arm at the handler's own state
 pass	a MAP built from generated pairs is equal regardless of insertion order (the Map analogue of set convergence)
 pass	a MAP keyed by perform results in the handle body crosses the exit and looks up by those keys
+pass	a MAP valued with perform results ESCAPES the handle — looked up outside the region
+pass	a MAP-OF-LISTS handler state accumulates per dispatch — the upsert idiom end to end
 pass	a MAP-valued key normalizes its Rational VALUES for the outer key hash
 pass	a MATCH as a NON-FINAL multi-binding let init selects the binding value per call
 pass	a MATCH-arm perform in a self-recursive performer threads the advance across recursion (rw-match)
@@ -722,6 +752,7 @@ pass	a MONOTONE BISECTION finds the least r with r*r >= n over answer space, cer
 pass	a MULTI-LEVEL concat-built list SET element (n>=33) is found by a push-built equal element
 pass	a MULTI-LEVEL concat-built list map key (n>=33) is found by a push-built equal key
 pass	a MULTI-PAYLOAD variant with a nested same-sum variant reads the right payload depth (known outer disc)
+pass	a MULTI-argument op mixing a heap list and two scalars — the arm consumes all three
 pass	a MULTI-guard chain on a perform-result scrutinee with a performing fallback folds
 pass	a MULTI-parameter user generic resolves by name in a type annotation applied with two arguments
 pass	a MULTI-payload struct newtype escapes as its payload tuple under the type header
@@ -807,8 +838,10 @@ pass	a NaN nested in a sum payload compares equal under the canonical byte form
 pass	a NaN nested in a tuple compares equal under the canonical byte form
 pass	a NaN operand makes every runtime float ordering relation false (unordered)
 pass	a NaN selected through a runtime if-join stays self-equal and unordered downstream
+pass	a ONE-shot ctl arm whose continuation reads an enclosing-fn param folds (mv single-splice control)
 pass	a PAIR shrinker coordinate-descends each component to a jointly 1-minimal failing pair
 pass	a PALINDROME two-pointer walk closes from both ends of a runtime rope
+pass	a PARAMETERIZED handler helper chained through itself — the step size is a function param
 pass	a PARSE-INT walks scalars, decodes digits by comparison, and handles a leading minus
 pass	a PARTIALLY-applied multi-payload constructor is a first-class function value
 pass	a PARTITION fold splits one spine into two lists by a runtime predicate
@@ -835,9 +868,11 @@ pass	a PRIORITY insert orders by key with FIFO tie-break carried as a sequence n
 pass	a PURE closure iterated by a recursive combinator composes with a perform in the same body
 pass	a PURE dead binding beside a perform is harmless (the eliminable control)
 pass	a QUICKSELECT finds the kth smallest by partitioning and recursing into ONE side
+pass	a Qty STATE threads via a def-bound arm computation — the workaround shape runs end to end
 pass	a Qty handler state advances via Qty.value / re-wrap in the next-state slot
 pass	a Qty payload with a GENERIC inner type rejects a bare use with no type argument
 pass	a Qty payload's INNER type stays a real type parameter — the unit-arg skip does not over-skip
+pass	a Qty state's next-state slot computes (+ s s) INLINE — the formerly-rejected shape runs
 pass	a Qty-keyed trie churned with differently-normalized magnitudes equals the direct build
 pass	a Qty-typed export carries its unit frame across the module boundary into caller algebra
 pass	a Qty-typed variant payload keeps its type non-generic and matches back
@@ -867,6 +902,7 @@ pass	a RECURSIVE user sum (Tree) crosses resume; the body folds it
 pass	a RECURSIVE-sum value of runtime depth rides a handler resume
 pass	a REFL tactic closes a reflexivity goal by driving the kernel, and cannot close a false goal
 pass	a RELATIONAL @requires over two parameters enforces their order at entry
+pass	a RESULT as op ARGUMENT — the arm branches on Ok/Err payloads it was handed
 pass	a RESULT handler state is matched per variant with one resume per arm (Ok accumulates, Err echoes)
 pass	a RESULT-returning effect op is matched on Ok / Err — the fallible-step idiom
 pass	a RESUMING handler around a contracted body still enforces @ensures on the resumed-through value
@@ -875,6 +911,7 @@ pass	a ROMAN NUMERAL renderer walks a value-symbol table greedily with subtracti
 pass	a ROPE Bytes arg (recursive concat, uncompacted) crosses the host boundary
 pass	a ROTATE-BY-K splits at the wrapped offset and swaps the halves, identity at multiples of len
 pass	a RUNTIME Ast structural equality compares by value (Ast.Int scalar leaf and Ast.List compound)
+pass	a RUNTIME Int64 argument to a narrow effect-op parameter is rejected as a type mismatch
 pass	a RUNTIME Result-of-Result from chained fallible helpers dispatches all three arms
 pass	a RUNTIME branch selects between an abortive perform and a plain value per call
 pass	a RUNTIME byte-slice torn mid-scalar is rejected by from-bytes at both tear points
@@ -896,6 +933,7 @@ pass	a RUNTIME-count generated batch insorts fully time-ordered, verified by a s
 pass	a RUNTIME-dependent hole threads through the tag application per call
 pass	a RUNTIME-selected combiner closure crosses a join and drives a fold
 pass	a Rational ARITHMETIC result probes a map key by its reduced canonical value
+pass	a Rational SQUARE over a perform draw — 1/5 squared stays exactly 1/25
 pass	a Rational accumulator threaded through recursion sums exactly
 pass	a Rational compare whose naive cross-multiply would OVERFLOW i64 still orders exactly
 pass	a Rational fanned into a compound then re-read survives (Perceus retain over a BigInt/Rational leaf)
@@ -932,10 +970,15 @@ pass	a SELF-RECURSIVE named def passed as a value is applied twice through the p
 pass	a SET as a Map key hits by ORDER-INDEPENDENT inner-set content
 pass	a SET as a Map key hits by canonical content and a different set misses
 pass	a SET as a set element hashes by content: three build orders, one element
+pass	a SET as op ARGUMENT — the arm measures and probes the set it is handed
 pass	a SET churned to empty equals a fresh empty set and re-accepts elements
 pass	a SET handler state grows per perform and dedupes a repeated event
 pass	a SET of BigInts as a map key matches its construction-order and arithmetic twin
 pass	a SET of SETS dedups elements by set CONTENT — insertion-order twins collapse
+pass	a SET of arm-interned symbols dedups across dispatches — warm appears twice, stored once
+pass	a SET of tuples as op ARGUMENT — the arm probes compound membership including order sensitivity
+pass	a SET op RESULT crosses resume — membership-probed and measured per dispatch
+pass	a SET state churns — inserts and removes interleave across dispatches, canonical at each read
 pass	a SET state dedup accumulator — the condition PROBES the state, the pass branch inserts
 pass	a SET-valued handler state accumulates uniques across resumes (the visited-set idiom)
 pass	a SINGLE-variant open sum still requires an open-tail arm
@@ -948,13 +991,17 @@ pass	a STACK-MACHINE interpreter dispatches instruction sums over a list operand
 pass	a STACKED @requires + @ensures contract on a performing def threads all three layers
 pass	a STALLED counter makes all Set.of perform results collide to a singleton
 pass	a STATS record threads min/max/sum/count as one fold accumulator with data-dependent field updates
+pass	a STD-SUM (Option) literal scrutinee — single eval, payload binds by position
 pass	a STRING run-length grouping counts adjacent equal scalars across a rope seam
 pass	a STRING-result effect op resumes with a string that folds through a concat
 pass	a SUM compound = has DISCRIMINATING power (a runtime-selected constructor separates two tagged values)
 pass	a SUM constructor payload that is a compound built from performs threads and destructures
 pass	a SUM is threaded as a handler's folded state across operations
 pass	a SYM tactic reduces a goal to a subgoal plus a kernel justification (backward proof)
+pass	a SYMBOL as op ARGUMENT — the arm compares interned identity against its own intern
 pass	a SYMBOL compound = has DISCRIMINATING power (two runtime-selected interned names separate)
+pass	a SYMBOL handler STATE threads dispatches — each resume reads the prior symbol's identity
+pass	a SYMBOL-keyed Map built from performs — interned keys look up across separate interns
 pass	a SYMBOL-keyed Map state routes hits to different keys (route-table accumulator)
 pass	a SYMBOL-returning effect op interns through the handler and results compare by content
 pass	a Set of (Int64, Bytes) tuples orders by int then Bytes lexicographically and dedups by content
@@ -982,6 +1029,7 @@ pass	a String built by folding String.concat over a runtime list of chunks has t
 pass	a String compound export under a non-main name crosses to the host
 pass	a String match with a BOUND default arm equals its (= s literal) if-chain with a bound else
 pass	a String match with disjoint literal arms is order-independent (reordering the arms preserves the result)
+pass	a String op RESULT selected by the op argument, composed via concat
 pass	a String param threaded through a self-recursive loop and concatenated each step is retained
 pass	a String slice OF a slice over a MULTIBYTE concat rope composes scalar offsets
 pass	a String slice VIEW keys a map by content in both directions, rope-backed included
@@ -989,6 +1037,8 @@ pass	a String-keyed map of MIXED-field records reads both leaves of a looked-up 
 pass	a String-returning closure alongside a parameterized plain export
 pass	a String-returning closure alongside a parameterized plain export — the plain runs
 pass	a String-to-String op transforms a rope arg in the arm and its RESULT feeds the next perform
+pass	a String-to-String transformer op — a rope argument crosses in, a wrapped rope crosses back
+pass	a String.slice VIEW built in the ARM crosses back through resume — the body measures it
 pass	a String.slice view returned from a helper OUTLIVES the helper's local parent
 pass	a Symbol interned from a rope-slice view keys maps and removes set elements
 pass	a Symbol leaf in a tuple orders content-lexicographically and decisively before later fields
@@ -1014,12 +1064,16 @@ pass	a TRANSPOSE of a 2x3 list-of-rows walks columns across row spines
 pass	a TRIPLY-nested Record ARG crosses the direct-call boundary
 pass	a TUPLE containing a closure as a map key is rejected (CDZ0216 descends into compound keys)
 pass	a TUPLE handler state — the arm destructures, branches, and rebuilds both slots
+pass	a TUPLE mixing Float64 and Int64 crosses as op ARGUMENT — the arm scales by the int
 pass	a TUPLE op argument with a HEAP leaf destructures inside the arm
+pass	a TUPLE-keyed Map op result — the body looks up by a reconstructed compound key
+pass	a TUPLE-literal scrutinee with performing fields — draws fire once, bind by position
 pass	a TUPLE-result perform's projected field feeds a SECOND perform's argument, threading state across both
 pass	a TUPLE-returning operation resumes a pair built from the handler state, then projected
 pass	a TUPLE-wrapped runtime slice as a Map key hits by content through the compound descent
 pass	a TWICE combinator stacks — a closure capturing a closure capturing a closure applies through the tower
 pass	a TWO-LIST FIFO queue reverses the back list exactly when the front drains
+pass	a TWO-argument capture closure through a fold-style HOF — the capture rides both applications
 pass	a TWO-field open-row projection instantiates at three widths with slot-shifting extras
 pass	a TWO-of-THREE partial application binds a prefix and the LET-BOUND residual completes
 pass	a TWO-resume-site arm branching on a CAPTURED Map folds — the branch reads heap, not state
@@ -1049,6 +1103,7 @@ pass	a UInt8 wrapping-add result feeds a CHECKED add — the MASKED value is wha
 pass	a USER sum as handler state — a countdown mode machine (Fast k -> Slow)
 pass	a USER-DEFINED multi-variant sum payload quantity renders scaled to its reference
 pass	a USER-SUM op result (Status) crosses resume; the body matches per variant
+pass	a USER-SUM-literal scrutinee with a performing payload — the ctor pattern binds once
 pass	a Unit element between two Int64s in a tuple, a later element read
 pass	a Unit element in a multi-payload sum variant compiles to valid wasm
 pass	a Unit payload MATCH-bound from a still-live sum at a dup-site drops the sentinel
@@ -1082,6 +1137,8 @@ pass	a `?` whose Result error type disagrees with the boundary's is rejected
 pass	a `?` with no fallible enclosing function boundary is rejected
 pass	a balanced-paren scan tracks depth over a runtime string and fails fast on early close
 pass	a bare (map) pattern with no keys matches a non-empty map, not just the empty one
+pass	a bare BIGINT as op ARGUMENT — the arm does exact wide arithmetic on the crossed box
+pass	a bare RATIONAL as op ARGUMENT — the arm reads exact numerator/denominator off the crossed value
 pass	a bare TUPLE of quantities renders each element scaled to its reference (mixed inner types)
 pass	a bare UInt8 literal-match (no newtype) is the width template
 pass	a bare arithmetic keyword is rejected, not a crash
@@ -1207,6 +1264,7 @@ pass	a byte sequence written as a literal renders back to the same literal
 pass	a byte-decode loop advancing by a tuple projection while accumulating sum nodes compiles and runs
 pass	a byte-string literal equals the explicit byte sequence it desugars to
 pass	a byte-string literal with escapes equals its explicit byte sequence
+pass	a byte-walk lexer performing per byte — Bytes.at pairs with an advancing draw per position
 pass	a byte-wise reversal over a seamed rope is an involution and lands bytes at mirrored offsets
 pass	a bytes segment sized by a CONSTANT LITERAL binds a fixed number of bytes then composes
 pass	a bytes value chosen by a runtime if is length-measured with valid wasm
@@ -1308,6 +1366,7 @@ pass	a closure export alongside a plain scalar export — the closure runs
 pass	a closure export alongside a plain scalar export — the plain export runs
 pass	a closure exported to the host is called by the host
 pass	a closure factory's returned capturing closure is applied at the call site
+pass	a closure looked up from a map by a perform result, applied to a perform result, threads through call_indirect
 pass	a closure performing a HANDLED (non-delegated) effect does NOT trip the escape reject
 pass	a closure returned from a match arm carries the arm's HEAP payload binding
 pass	a closure returned from a recursive function is applied through a recursive HOF
@@ -1368,6 +1427,7 @@ pass	a compile-time Char comparison folds beside performs (the runtime-Char boun
 pass	a compile-time expansion residual combines with a runtime param per call
 pass	a compile-time type branch reads a runtime parameter's static type
 pass	a complementary comparison pair nested past a third operand still folds via reassociation
+pass	a complete handler inside a CLOSURE body — each application instantiates fresh
 pass	a component's manifest is the union of two entrypoints' distinct rows
 pass	a compose combinator captures TWO function values and applies them in declared order
 pass	a compose combinator over HEAP-typed functions pipelines list transformers
@@ -1498,9 +1558,12 @@ pass	a cross-handler op-arg performing an outer effect runs EXACTLY ONCE though 
 pass	a cross-type constructor pattern NESTED in a matching outer payload is rejected
 pass	a cross-type variant pattern of the SAME payload width and colliding tag is rejected
 pass	a cross-type variant pattern whose payload width differs is rejected, not miscompiled
+pass	a crossed rope String compares EQUAL to an arm-local flat literal — content equality over the marshal
 pass	a crossing text-literal arm is rejected even beside a same-kind sibling arm
 pass	a ctl-style arm applying its continuation inside a match scrutinee resolves and folds
+pass	a ctl-style arm that LET-BINDS its continuation result then reads the state binder folds
 pass	a ctl-style arm that applies its continuation lexically folds through the delimited context
+pass	a ctl-style arm that reads the STATE binder AROUND its continuation application folds
 pass	a ctl-style arm whose continuation ESCAPES to another function reifies it as a closure and applies it there
 pass	a ctor-in-tuple-slot match is expressible by binding the tuple then re-matching
 pass	a cube dimension renders as Unit.^ with exponent 3
@@ -1621,6 +1684,7 @@ pass	a do-local function declaration is recursive
 pass	a do-local generic function is instantiated per type
 pass	a do-sequence of unit-returning performs runs each for effect, then yields the tail value
 pass	a do-sequenced perform train under its OWN inner handle threads state
+pass	a do-spine item abort ABANDONS its enclosing operator, not splicing the value (do-item abort-abandon)
 pass	a dotted nullary arm whose body nests a same-type sum match dispatches correctly
 pass	a double fused match chain through a shared callee computes both calls
 pass	a double same-dimension annotation preserves the original scale
@@ -1652,6 +1716,7 @@ pass	a failure `?` short-circuits BEFORE later computation runs
 pass	a failure `?` short-circuits a RUNTIME error payload (static Err ctor, per-call value)
 pass	a failure `?` short-circuits the enclosing LAMBDA, not the outer function
 pass	a fall-through arm body performs and reads the post-scrutinee state
+pass	a fallible helper with a `?` called from INSIDE a handler ARM (success path)
 pass	a fallible helper with a runtime-payload `?` is called from INSIDE a handle body
 pass	a fallible parser threads a Result((value,cursor),String) through mutual recursion, short-circuiting on Err
 pass	a false first operand falls through — the OR's second perform fires (same program)
@@ -1817,6 +1882,7 @@ pass	a guard compares two distinct sum payloads from one tuple
 pass	a guard composes with a string-literal arm
 pass	a guard condition applies a let-bound closure
 pass	a guard condition reads a heap list bound outside the match
+pass	a guard destructures a perform-result TUPLE and its condition reads both binders
 pass	a guard expression calling a recursive helper inside a self-tail-loop match compiles
 pass	a guard on a ctor list element reads the constructor's payload binder
 pass	a guard on a literal-element list pattern reads an enclosing let binding through inlining
@@ -1893,6 +1959,8 @@ pass	a handler arm that resumes NON-tail folds when the perform is the whole bod
 pass	a handler folds a counter across the operations it discharges
 pass	a handler mixing arms of two different effects is rejected
 pass	a handler resumes its continuation at most once by default
+pass	a handler state GROWS a list across 100 dispatches — the accumulated spine reads back intact
+pass	a handler state SHRINKS per dispatch — Map.remove down to empty across resume cycles
 pass	a handler state of TWO tries (tuple) updates each side independently across resumes
 pass	a handler that does not discharge every operation of its effect is rejected
 pass	a handler threads a MAP as its state — a key-value store deduping keys across performs
@@ -1910,6 +1978,7 @@ pass	a heap arg threaded UNCHANGED to a self-recursive call while a sibling arg 
 pass	a heap capture persists across two applications of a curried closure
 pass	a heap list conditionally escaping into a Some in one branch is still usable after the join
 pass	a heap list consumed in only one if-branch stays live for a use after the if
+pass	a heap result of effect A pipes directly into effect B's argument — cross-effect heap flow
 pass	a helper RETURNS a derived-dimension (m squared) quantity and same-dimension results add
 pass	a helper called TWICE threads its first write so the second call HITS the memoized value
 pass	a helper decodes bytes to a string and consumes the fallible result
@@ -1918,6 +1987,7 @@ pass	a helper projects a tuple parameter constrained by its argument
 pass	a helper returning a partial constructor is over-applied to complete the variant
 pass	a helper returns the shorter of two borrowed ropes and both caller handles stay live
 pass	a helper sums two fields of a record parameter
+pass	a heterogeneous TUPLE as op ARGUMENT — the arm destructures both components
 pass	a heterogeneous TUPLE op result (String, Int64) crosses resume and destructures
 pass	a hexadecimal integer literal
 pass	a hexadecimal literal is case-insensitive
@@ -1933,6 +2003,7 @@ pass	a higher-order left fold over a built-in list with an annotated fn paramete
 pass	a hoisted division traps by the selected divisor only
 pass	a hoisted trapping invariant loop-bound still traps when it overflows, even at zero iterations
 pass	a homogeneous nested Option distinguishes its outer and inner None
+pass	a host call SANDWICHED between two in-program dispatches — state survives the boundary crossing
 pass	a host call's response is an ordinary value that feeds a LATER host call
 pass	a host delegating a value definition rather than an effect is rejected
 pass	a host delegating the same effect twice is rejected
@@ -1943,6 +2014,7 @@ pass	a host op whose result is a QUANTITY crosses the boundary as its inner scal
 pass	a host op with a Bytes arg AND a scalar arg crosses both parameters (list<u8> beside a scalar)
 pass	a host op with a String parameter composes with the value-heap runtime
 pass	a host response SIZES a guest-built collection which is then folded and keyed
+pass	a host response captured BEFORE a multi-shot region is shared by both branches — one host call
 pass	a host result captured by closures in a NESTED tuple fires the host op once (adv-62 nested face)
 pass	a host result captured by two closures stored in a RECORD fires the host op once (adv-62b)
 pass	a host-block scrutinee folding to a multi-arm sum switch fires the host op once (adv-62 switch face)
@@ -1975,6 +2047,7 @@ pass	a later declaration in a do block sees an earlier one
 pass	a later let binding sees an earlier one in the same let
 pass	a later let binding sees an earlier pattern's binders
 pass	a later let binding sees an earlier record pattern's field binders
+pass	a later let-binding abort preserves an EARLIER binding's committed advance (multi-binding prefix)
 pass	a le pattern segment reads a fixed-width integer little-endian
 pass	a leading nested-list element dispatches on the inner list's length
 pass	a leading-element list rest pattern in a def parameter is refutable and rejected
@@ -2052,6 +2125,7 @@ pass	a list match pattern with a malformed rest names the shape, not an unbound 
 pass	a list mixing integer and boolean elements is a type error
 pass	a list mixing integer and float elements is a type error
 pass	a list of Options orders its elements by the declared Some-below-None
+pass	a list of RATIONALS op result — exact fractions cross resume and fold to a canonical sum
 pass	a list of a nullary sum written in the bare-member form is exhaustive across every variant
 pass	a list of a sum is exhaustive when the empty and every variant's first-element arm are covered
 pass	a list of bools is exhaustive when the empty and both first-element values are covered
@@ -2083,6 +2157,7 @@ pass	a list-of-quantities used as a Map key canonicalizes and hits
 pass	a list-payload split missing the empty arm is non-exhaustive
 pass	a list-payload split missing the non-empty arm is non-exhaustive
 pass	a list-scrutinee match arm whose head is an unbound name is rejected in a recursive body (CDZ0101)
+pass	a list-to-list TRANSFORMER op — heap payloads cross BOTH slots of one dispatch
 pass	a literal MAP KEY that overflows the annotated key width is rejected
 pass	a literal MAP VALUE that overflows the annotated value width is rejected
 pass	a literal arm wins over a later guard arm that also matches
@@ -2181,6 +2256,8 @@ pass	a map with tuple values of different arities is a type error
 pass	a map with values of two different types is a type error
 pass	a map-over-map rebuild transforms every retrieved value into a NEW trie in one walk
 pass	a map-scrutinee match arm whose head is an unbound name is rejected in a recursive body (CDZ0101)
+pass	a map-to-map transformer op CHAINED — the second dispatch receives the first's result
+pass	a map-via-effects walk — each element transformed by a dispatch, output order preserved
 pass	a masked-divisor signed division still traps on a zero divisor (zero guard never elided)
 pass	a match arm binds a nested tuple inside a sum payload
 pass	a match arm building a fresh runtime compound infers its shape
@@ -2235,6 +2312,7 @@ pass	a matched arm body performs and reads the state the scrutinee advanced
 pass	a max-FOLD over a list containing a computed NaN keeps the ordered maximum
 pass	a member access with no field operand is rejected, not a crash
 pass	a memoizing fold caches computed results in a Map and counts its hits
+pass	a mid-scalar byte window crosses to the arm and String.from-bytes declines it
 pass	a middle curry STAGE is reused — one s1 residual yields an s2 applied twice
 pass	a middle module re-exports a base function and also uses it in its own exported function
 pass	a missed literal tag falls to a BINDER bin arm that decodes the scrutinee
@@ -2277,6 +2355,7 @@ pass	a multi-argument closure returning a COMPOUND round-trips — flat arrow sp
 pass	a multi-argument closure round-trips through a consumer
 pass	a multi-argument closure round-trips through a consumer — FLAT arrow spelling
 pass	a multi-argument closure with COMPOUND args round-trips — flat arrow spelling
+pass	a multi-argument op with TWO heap arguments — a String key and a Map to search
 pass	a multi-byte runtime bit-field takes the matching wide unsigned type
 pass	a multi-export compound-result shared call is a repeatable (borrow<t>) callback
 pass	a multi-export set of parameterized capturing closures is driven per export
@@ -2299,7 +2378,12 @@ pass	a multi-payload variant with MIXED-width, MIXED-type payloads deconstructs 
 pass	a multi-payload variant with a scalar AND two recursive payloads escapes flat
 pass	a multi-payload variant with an EMPTY-Map first payload compiles + deconstructs (function[27] regression pin)
 pass	a multi-segment bin concatenates mixed-width signed and unsigned segments in order
+pass	a multi-shot arm with an enclosing-param resume value and a MATCH-binder consumer folds
+pass	a multi-shot arm's resume VALUE reads the enclosing param — the let-bound body folds correctly
 pass	a multi-shot continuation contains a NESTED handler — each re-reduction re-enters it fresh
+pass	a multi-shot ctl arm reading an enclosing param with NO let frame folds (mv no-let control)
+pass	a multi-shot ctl arm whose continuation reads an ENCLOSING-fn param folds
+pass	a multi-shot handle SEEDED by the enclosing param folds with a let-bound body
 pass	a multi-site arm folds while the handle BODY reads an enclosing binding (the re-anchored free var)
 pass	a multi-site arm's resume value routes through a pure helper call
 pass	a multi-step kernel derivation composes several primitive rules into one theorem
@@ -2475,9 +2559,12 @@ pass	a nested unquote pattern matches a Bool sub-AST by shape
 pass	a nested unquote pattern matches a Float sub-AST by shape
 pass	a nested unquote pattern matches a Str sub-AST by shape
 pass	a nested unquote pattern matches a sub-AST by shape
+pass	a nested-handler ctl arm whose continuation-consuming body ALSO performs an OUTER effect folds
 pass	a nested-let chain that reuses each binding folds to one value
+pass	a nested-list DAG — one perform-derived inner list aliased TWICE in the outer
 pass	a nested-list-rest arm reads BOTH the inner rest and the outer rest binders
 pass	a nested-map BUMP (lookup-inner, insert-inner, reinsert-outer) builds a multimap
+pass	a nested-operand abort preserves a HEAP-state advance across a mid-mutation frame drop
 pass	a nested-record parameter projects its inner fields through two dot levels
 pass	a neutral and-true keeps both the trap and the value of its left operand
 pass	a newtype match-arm destructure reads the erased scalar back
@@ -2598,7 +2685,15 @@ pass	a perform in the scrutinee fires exactly ONCE whichever of three arms is se
 pass	a perform result LET-bound then fed to a bin segment builds Bytes under a handler
 pass	a perform under NOT in a condition (the negated dispatch gate)
 pass	a perform's result flowing as the ARGUMENT of an enclosing perform threads state inner-to-outer
+pass	a perform-capture through a TUPLE-returning HOF — both results carry the capture
+pass	a perform-capturing closure passed to a HIGHER-ORDER helper applies twice under the handler
+pass	a perform-derived byte-rope SELF-concatenated — both halves read the same draw
+pass	a perform-derived list SHARED by two tuples — both readers see one allocation's content
+pass	a perform-derived rope SELF-concatenated — the shared subtree measures correctly
+pass	a perform-drawn quantity DIVIDES across dimensions — the meter/second quotient value
+pass	a perform-drawn quantity MULTIPLIES across dimensions — meter·second product value
 pass	a perform-free do-def feeding a bin-construction operand under a handler stays bound (F2)
+pass	a perform-seeded inner handle composed with a SECOND same-effect instantiation after it
 pass	a performed operation composes as a RECORD field value that is then projected
 pass	a performed operation composes under a projection and a negation
 pass	a performed operation is the scrutinee of a match that dispatches on its result
@@ -2611,10 +2706,16 @@ pass	a performing closure homed TRANSITIVELY through a pass-through function is 
 pass	a performing closure passed to a function that applies it UNDER a handler is homed at the apply site
 pass	a performing closure stored in a TUPLE and applied IN-GUEST fires normally
 pass	a performing do-def feeding a bin-construction operand under a handler stays bound (F2)
+pass	a performing guard on a TUPLE-destructuring pattern folds
+pass	a performing guard on a refutable pattern whose guard FAILS falls to the catch-all
+pass	a performing guard with a WILDCARD fallback is ALSO a COMPILE ERROR (finding #9 sibling, CDZ0407)
 pass	a performing helper called from TWO sites — each call site is its own dispatch
 pass	a performing helper whose body BINDS the result and BRANCHES on it, called from two sites, folds
 pass	a performing match SCRUTINEE threads its state into a performing arm body
 pass	a performing match-arm guard folds with WILDCARD patterns (no binder to let-bind)
+pass	a performing match-arm guard on a REFUTABLE pattern folds (keeps the match, hoists the guard)
+pass	a performing record nested in a TUPLE scrutinee — bound by position, record-matched after
+pass	a performing scrutinee matched by a PERFORMING GUARD is a COMPILE ERROR (breaker finding #9, now CDZ0407)
 pass	a pipeline chain applies its stages left to right
 pass	a pipeline chain threads handler STATE left-to-right through effectful stages
 pass	a plain number def is unaffected by a following statement (the `as` sugar stays in its statement)
@@ -2627,6 +2728,7 @@ pass	a positional tuple access out of the tuple's static arity is a type error
 pass	a possibly-out-of-range runtime integer conversion still declines (checked emit pending)
 pass	a post-order effectful walk draws each node's id AFTER both children (SSA reg-alloc shape)
 pass	a post-order labeling walk returns a labeled tree (heap result, id drawn after children)
+pass	a pre-abort HOST call inside a NESTED strict operand is ISSUED before the abort abandons
 pass	a predicate closure returning Bool drives an early-exit recursive HOF
 pass	a prefix literal does not shadow a longer string arm
 pass	a prefixed quantity displays scaled to its reference over BigInt (exact, no truncation)
@@ -2658,6 +2760,7 @@ pass	a projection chain rooted at a parameter retains the consumed child in the 
 pass	a projection chain through a record inside a tuple retains the consumed child
 pass	a projection chain through a tuple inside a record retains the consumed child
 pass	a proper fraction truncates to zero from both signs and an exact integer to itself
+pass	a pure HELPER's arguments evaluate left-to-right when each performs
 pass	a pure closure-driver call beside a perform in one handle body
 pass	a pure lambda passed as an argument to a performing callee folds
 pass	a pure let-bound lambda and a performing one are both applied in the handle body
@@ -2731,10 +2834,12 @@ pass	a re-declared same-name theorem type in another module is a distinct type a
 pass	a read result destructures through nested Ast patterns — the analyze path computes
 pass	a read-modify-write of a List value in a Map grows the entry and leaves the original map unchanged
 pass	a reader literal carries a qualified name with a dot
+pass	a reader→writer PUMP then a LET-bound flush reads the FULL accumulation (breaker tk3d class)
 pass	a reciprocal dimension renders as Unit.one over the unit
 pass	a recognized pragma with a malformed argument list is rejected
 pass	a recognized string escape denotes its one scalar value
 pass	a record MATCH pattern with a LITERAL field sub-pattern dispatches on the field value
+pass	a record STATE with a Set field rebuilt per dispatch — dedup observed through the field
 pass	a record TYPE with a duplicate field name is a type error
 pass	a record annotated with the wrong field type is rejected
 pass	a record binding pattern binds fields by name, out of order and partial
@@ -2770,6 +2875,8 @@ pass	a record whose field is a List projects the list handle and indexes it, alo
 pass	a record whose field is a runtime tuple nests across the boundary
 pass	a record whose field is a tuple with a Float64 leaf is a Map key found by content
 pass	a record whose field is misnamed is both missing and extra
+pass	a record with a LIST field crosses resume — the body projects and folds the collection field
+pass	a record with a SET field as op ARGUMENT — the arm probes the collection beside the scalar
 pass	a record with a duplicate field name is a type error
 pass	a record with a non-adjacent duplicate field name is a type error
 pass	a record with a runtime field is returned as a program result
@@ -2791,6 +2898,7 @@ pass	a recursive NEWTYPE traversal recurses on its projected recursive field
 pass	a recursive NEWTYPE-wrapped linked list folds to a scalar
 pass	a recursive RENAME pass rewrites every matching Name leaf at any depth and counts them
 pass	a recursive TLV frame walk over sliced runtime bytes decodes LE payloads per frame
+pass	a recursive TREE as a transformer op — crosses IN, the arm wraps it, crosses back OUT
 pass	a recursive builder PERFORMS per step and a recursive pure fold consumes the built list
 pass	a recursive byte fold calling two helpers emits valid wasm (disjoint scratch slots)
 pass	a recursive byte walk sums a runtime sequence via Bytes.at and match
@@ -2841,6 +2949,7 @@ pass	a recursive loop performs to TWO handlers per iteration with independent st
 pass	a recursive loop whose CONDITION performs — each iteration RE-dispatches (never hoisted)
 pass	a recursive lower from a sum to Bytes assembles its output in match arms
 pass	a recursive map rebuilding a sum list infers its unannotated callback
+pass	a recursive nested-op performer whose per-iteration outer advance is read by a POST-loop observer threads it
 pass	a recursive parameter used only as a call argument infers from the callee's parameter type
 pass	a recursive parser drains a STREAM of length-prefixed frames to the empty base case
 pass	a recursive performer of a nested-handler op whose resume performs the outer effect threads the advance
@@ -2898,6 +3007,7 @@ pass	a reflected quantity type rejects a value of a different dimension
 pass	a reframed packet with a TRANSFORMED header compares byte-equal to its independent twin
 pass	a refutable constructor pattern in a let binder is rejected
 pass	a refutable map value sub-pattern dispatches by the value's constructor
+pass	a region's RESULT seeds a second same-effect region with a DIFFERENT arm shape
 pass	a reified (sum-of-step-shapes) lazy pull-iterator compiles, runs, and is lazy
 pass	a rename pass DERIVES each new Name from the old payload (concat suffix), quote-verified deep
 pass	a repeated condition inside a branch propagates the known truth value
@@ -3319,6 +3429,7 @@ pass	a schema decode's Err result is handled as data on its own branch
 pass	a schema decode's Ok result is matched to recover the decoded payload
 pass	a scientific-notation float literal denotes the scaled value
 pass	a scientific-notation literal annotated Rational scales the numerator
+pass	a scrutinee FAILING the pattern reaches the catch-all WITHOUT running the guard's perform
 pass	a scrutinee of two to the sixty-fourth-adjacent magnitude misses a zero-based jump table
 pass	a second same-signature closure export shares the one call method
 pass	a seconds quantity is rejected by a meter-typed import at the call site
@@ -3397,6 +3508,7 @@ pass	a signed zero survives a TUPLE round-trip and its sign still steers arithme
 pass	a signed-byte entrypoint returns its runtime argument
 pass	a signed-zero tuple-key leaf MISSES the opposite-signed-zero entry on lookup
 pass	a simplifier pass applied TWICE equals one application (idempotence at the fixpoint)
+pass	a single MUTUAL-recursion chain performs at its base — the cross-function fold serves it
 pass	a single Map.swap reports the OLD prior value WHILE the new map holds the NEW value (combined atomicity)
 pass	a single handler with both a resuming and an abortive arm dispatches each op to its own arm kind
 pass	a single mixed handler uses only its resuming arm when the abortive op is never performed
@@ -3519,6 +3631,7 @@ pass	a symbol compared to a string is a type error
 pass	a symbol converts back to its content string
 pass	a symbol is constructed from a string
 pass	a symbol literal list element dispatches a runtime list by its content
+pass	a symbol round-trip between TWO ops of one effect — interned by one, judged by the other
 pass	a symbol's identity is its content, not how the content was derived
 pass	a symbol-literal match agrees with its if-(= s lit) chain on the DEFAULT fall-through arm
 pass	a symbol-literal match agrees with the equivalent if-(= s lit) chain
@@ -3667,6 +3780,7 @@ pass	a tuple payload at a late variant projects both fields by its own layout
 pass	a tuple payload consumed INLINE in the sum arm projects and re-matches
 pass	a tuple payload extracted through a helper return must not be rejected as a type error
 pass	a tuple payload returned through a helper from a built-in Option must not trap
+pass	a tuple scrutinee built from TWO performs — the guard relates both dispatch results
 pass	a tuple with a Char leaf declines compound ordering — Char has no blessed order
 pass	a tuple with a Float64 element MISSES a Map key with a different float leaf
 pass	a tuple with a Float64 element is a Map key found by a separately-built equal key
@@ -3702,6 +3816,7 @@ pass	a two-arm match whose wildcard binds the scrutinee — the zero-probe arm
 pass	a two-constructor-element list arm falls through when the second tag differs
 pass	a two-level UPDATE of a map-of-maps rebuilds the inner and leaves the old outer intact
 pass	a two-level index reads an inner element of a list of lists
+pass	a two-op composition where the second op's String argument is BUILT from the first's result
 pass	a two-parameter closure is applied at full arity through a recursive HOF
 pass	a two-parameter sum whose variants use the parameters in different orders instantiates correctly
 pass	a two-payload constructor applied in curried form builds the variant
@@ -3712,10 +3827,13 @@ pass	a two-site arm branching on the OP ARGUMENT with a hit-count state folds (t
 pass	a two-site arm branching on the STATE folds (the refold re-anchor serves state-reading conditions)
 pass	a two-site arm gates on a PROJECTED field of the record state (rate limiter)
 pass	a two-site arm over a BYTES state (bin-built seed, concat growth) with a trailing size reader
-pass	a two-site arm whose condition reads the ARG AND the STATE together folds
 pass	a two-site arm over a HEAP STATE with a body free-var and a second state-reading op folds
 pass	a two-site arm over a STRING state (concat on pass, hold on fail) with a trailing length reader
+pass	a two-site arm whose condition reads the ARG AND the STATE together folds
 pass	a two-site arm with HEAP resume values (empty vs two-element list) folds
+pass	a two-site resume arm reading the enclosing SEED param in its resume value folds
+pass	a two-site resume arm whose resume VALUE reads an enclosing-fn param folds
+pass	a two-site resume arm whose resume value is a heap LIST reading an enclosing param folds
 pass	a two-step seed sequence advances (successive draws differ)
 pass	a two-variant enum match with constant arms dispatches branchlessly — first variant
 pass	a two-variant enum match with constant arms dispatches branchlessly — second variant
@@ -3827,6 +3945,16 @@ pass	a zero-arm match on an inhabited sum is non-exhaustive
 pass	a zero-bit integer width is rejected
 pass	a zero-leading list rest pattern binds the whole list in a def parameter
 pass	a zero-length slice is the empty byte sequence
+pass	aa1 the resume VALUE is a deep pure expression over the op arg AND state — (v+s)^2 - v*s per dispatch
+pass	aa2 a QUADRATIC next-state (s^2+1) — three dispatches, the state squaring away from the seed
+pass	aa3 REMAINDER arithmetic in the resume value — (% s 7) cycles as the +5 stride wraps the modulus
+pass	aa4 a THREE-WAY comparison arm — the resume value encodes gt/eq/lt as 1/10/100 against the advancing state
+pass	aa5 DIVISION in the resume value with a subtracting stride — quotients shrink as the state walks down
+pass	ab1d the scalar twin — a conditional abort under a SCALAR-state outer, pre-abort advance committed
+pass	ab1e a branch-conditional abort under a STRING-state outer handler — the taken abort skips the post-abort emit, the untaken row grows the rope
+pass	ab2 a conditional abort under a MAP-state outer — the pre-abort insert is committed either way
+pass	ab3 the abort VALUE is itself a draw from the outer STRING-state handler — the pre-abort dispatch commits before the unwind
+pass	ab4 TWO sequential abort regions under one STRING-state outer — an aborted region leaves the rope where it was
 pass	abstract theorems stored in a MAP stay unforgeable and usable — lookup returns a real Thm
 pass	abstract-type values live in an importer's map and round-trip through module ops
 pass	accessing through an empty-side split-at is usable, like the equivalent literal
@@ -3854,10 +3982,28 @@ pass	addition of two sets is rejected — a set is not a number
 pass	addition of two strings is rejected — text is not a number
 pass	addition of two symbols is rejected — a symbol is not a number
 pass	advancing the clock past the UInt64 nanosecond range traps rather than silently wrapping
+pass	ae1 SUBTRACTION of two same-op draws as a 2-ary op's args — the antisymmetry pins left-to-right order exactly
+pass	ae10 TUPLE literal of three draws matched immediately as scrutinee — positions survive the construct-then-destructure round trip
+pass	ae11 a DO-block as an argument — its DISCARDED interior draw still advances the state before the block's value draw
+pass	ae12 an IF-expression as an argument whose CONDITION draws — the taken branch decides whether a second draw fires before the next arg
+pass	ae2 draw-PURE-draw argument positions to a pure 3-ary fn — the middle constant sits between two advancing draws
+pass	ae3 THREE same-op draws as a 3-ary OP's own args — order pinned inside the op's argument list itself
+pass	ae4 draw / performing-HELPER / draw argument positions — the middle arg performs through a def boundary
+pass	ae5 short-circuit AND with DRAWS on both sides — the skipped right draw leaves the state thread untouched
+pass	ae6 short-circuit OR with DRAWS on both sides — the right draw fires only when the left is false
+pass	ae7 draw NESTED under a pure unary call in the first arg slot, second slot a bare draw — nesting must not reorder
+pass	ae8 LIST literal of three draws — element positions carry the draw order into the structure
+pass	ae9 RECORD literal of two draws read back by PROJECTION — field-init order in the literal drives the state thread
+pass	al1 chained LET locals inside the arm — intermediate names feed both the resume value and the next-state
+pass	al2 a PURE helper called from the arm for BOTH slots — the arm delegates its computation to a def
+pass	al3 a two-site resume where EACH branch has its own LET local — gap/overshoot named per path, different strides
+pass	al4 ONE arm-local feeds BOTH slots — the score accumulates into the base while the count rides beside
+pass	al5 an arm-LOCAL named the same as a body-side binder — hygiene keeps the two w's separate across dispatches
 pass	all four leaf kinds in one quoted form dispatch their own tags
 pass	all-nullary enum equality compares discriminants
 pass	alternating prepend and push keep both list ends straight
 pass	an 8-bit-integer closure crosses the host boundary
+pass	an @ensures on a PERFORMING def called TWICE under one handler — both effectful results checked
 pass	an @ensures on a recursive def is re-checked at every EXIT including self-call returns (not only the outermost)
 pass	an @ensures over a MATCH-bodied def wraps the whole match — the postcondition checks the match's result
 pass	an @ensures predicate reading a top-level GLOBAL alongside ret resolves and enforces (resolution seam)
@@ -3870,6 +4016,7 @@ pass	an @param of a Bool type generates a Bool-typed accessor
 pass	an @param of a Float64 type generates a Float64-typed accessor
 pass	an @param site generates a Param accessor a host delegation reads at run time
 pass	an @param with no widget config still generates its typed accessor
+pass	an ABORT in the first handle leaves the SECOND handle's dispatch untouched
 pass	an ABORTING arm applies the CLOSURE STATE for its final answer
 pass	an ABORTING arm derives its answer from an Ast op-arg and discards the continuation
 pass	an ABORTIVE arm whose value is a COMPOUND matches the handle body type and folds
@@ -3898,6 +4045,8 @@ pass	an IEC binary prefix converts exactly over Int64
 pass	an IEC binary prefix scales a unit by a power of two
 pass	an IEC-prefixed quantity displays scaled to its reference over Int64
 pass	an IF nested in a match arm re-tests the binder with a MAP lookup (the unguarded twin)
+pass	an IF-join with an unsolved-Var arm and an empty-list sibling grounds like a match join
+pass	an IN-PROGRAM arm resumes a Qty built in the arm — the erased-scalar crossing without a host
 pass	an IN-RANGE Map.insert value via a sibling-inferred width computes
 pass	an IN-RANGE Set.of element via a sibling-inferred width computes
 pass	an IN-RANGE literal through a Map.insert builder chain compiles (the CDZ0302 control)
@@ -3916,9 +4065,11 @@ pass	an N suffix lets a huge literal need no annotation
 pass	an N-suffixed integer literal is a BigInt
 pass	an OPEN-ROW helper projects from the record state INSIDE the arm
 pass	an OPEN-sum value stored as a MAP VALUE matches back out with its open-tail arm
+pass	an OPTION as op ARGUMENT — the arm matches Some/None it was handed, per dispatch
 pass	an OPTION handler state TOGGLES its variant per perform
 pass	an OPTION payload quantity renders scaled to its reference in the value form
 pass	an ORDER-PRESERVING dedup threads a seen-Set and an out-List as twin accumulators
+pass	an OVERFLOWING literal to a narrow effect-op parameter is rejected
 pass	an Ok and an Err decode compose through one shared handler
 pass	an Ok carrying a bare None type-checks under a whole-expression annotation
 pass	an Option built by an if with the nullary branch first type-checks
@@ -3947,6 +4098,10 @@ pass	an `and` whose first RESUMING perform is true evaluates the second: both ad
 pass	an `or` short-circuit SKIPS a resuming perform, and the skip is observable through the state
 pass	an abort abandons a pending borrowed map lookup and the map survives
 pass	an abort abandons a pending consuming op and the shared binding survives
+pass	an abortive arm READS the heap LIST op argument it was handed — the payload survives the abort
+pass	an abortive arm returns a MAP built FROM its heap op argument as the handle's value
+pass	an abortive arm that READS a heap-typed (List) handler state folds — the List face
+pass	an abortive arm that READS a heap-typed (Map) handler state folds — seed-let-lift on the abort path
 pass	an abortive arm yields a RECURSIVE-SUM spine as the handle's value
 pass	an abortive arm yields a heap LIST built in the arm as the handle's value
 pass	an abortive handler ISSUES a host call sequenced BEFORE the abort in its discarded body
@@ -4048,6 +4203,8 @@ pass	an arm binder SHADOWS an outer heap list and the outer survives the shadow'
 pass	an arm chooses its resume value by an if on the handler state
 pass	an arm performs the outer effect TWICE and the results feed the resume value
 pass	an arm re-performing its own effect with no outer handler has no home
+pass	an arm re-performs its OWN effect to a SAME-EFFECT outer handler — the true self-shadow forward
+pass	an arm resuming an OVERFLOWING literal into a narrow op RESULT is rejected
 pass	an arm resuming with a re-perform of its OWN effect forwards to an outer handler of that effect
 pass	an arm that binds its resume in a lambda and applies it immediately folds
 pass	an arm's NEXT-STATE expression saturates via a conditional on the current state
@@ -4098,7 +4255,11 @@ pass	an element is projected from a tuple returned by a function
 pass	an element is projected from a tuple returned by a nullary function
 pass	an element pattern matches a list by its length and elements
 pass	an element read across a concatenation boundary is the right value
+pass	an emit/flush byte-writer seeded EMPTY — three emits accumulate, flush reads the frame back
+pass	an empty (list) match-fallback beside an unsolved-Var arm grounds to the join's list type
 pass	an empty Ast.Bytes round-trips through encode and decode
+pass	an empty MAP fallback beside an unsolved-Var arm grounds — the Map-of-Maps face
+pass	an empty SET literal in a match-Option fallback grounds through the join
 pass	an empty binary form is the empty byte sequence
 pass	an empty byte-string literal is the empty byte sequence
 pass	an empty list escaping to the host is rejected as undetermined, like a bare None
@@ -4210,7 +4371,9 @@ pass	an in-program handler OVERRIDES an effect's peer binding (the test-mock, no
 pass	an in-program two-site handler runs INSIDE a host block beside a host call
 pass	an in-range constant argument to a narrow parameter computes at the parameter width
 pass	an in-range left shift on an unusual signed width computes at the declared width
+pass	an in-range literal to a narrow effect-op parameter crosses and the arm observes it
 pass	an in-range unusual-width division computes at the declared width
+pass	an indexed list walk performing per element — element × advancing draw, summed
 pass	an indexed read is not shared across a shadowing rebinding
 pass	an indexed read of an updated list is not shared with the original's
 pass	an init after the failing `?` never evaluates — even a provably-trapping one
@@ -4219,14 +4382,19 @@ pass	an inline-never definition is emitted once and called
 pass	an inline-never definition with a const dictionary still monomorphizes the dictionary
 pass	an inlined helper matching a sum built FROM the fused binder plus an enclosing capture
 pass	an inlined multi-use checked-arith argument is shared and computed directly into its slot
+pass	an inner ABORT handle inside a MULTI-SHOT region — each forked branch runs its own abort
 pass	an inner abort ELIDES an outer perform sequenced AFTER it (dead-path control)
+pass	an inner abort in a LET-INIT preserves the outer advance committed before it (let-init collapse)
 pass	an inner abort in a NON-FINAL do-statement elides the DEAD suffix after it (pre-abort advance kept)
+pass	an inner abort preserves BOTH a PERFORMING-CONDITION advance AND an if-branch advance before it (ao10)
 pass	an inner abort preserves TWO outer advances committed before it (multi-step outer trace)
 pass	an inner abort preserves an OUTER advance committed in a MATCH-ARM body before it (arm do-shape)
 pass	an inner abort preserves an OUTER advance committed in a MATCH-SCRUTINEE before it (scrutinee collapse)
 pass	an inner abort preserves an OUTER advance committed in a STRICT OPERAND before it (operand-lift)
 pass	an inner abort preserves an OUTER advance committed in an IF-BRANCH before it (branch do-shape)
+pass	an inner abort preserves an outer advance committed in a NESTED strict operand (deeper-operand-lift)
 pass	an inner abortive handler preserves an OUTER effect's advance committed before the abort (do-shape)
+pass	an inner arm performs TWO DISTINCT outer effects in one resume value — both thread per dispatch
 pass	an inner arm resumes with the OUTER handler's result while both states advance
 pass	an inner binding shadows an outer one only within its scope
 pass	an inner handle of the SAME delegated effect discharges in-program inside the host block
@@ -4297,7 +4465,11 @@ pass	an out-of-range literal argument caught transitively through a two-call cha
 pass	an outer Int64 let binder survives an inner String shadow of the same name
 pass	an outer definition references a sibling nested module by bare name
 pass	an over-ceiling integer width in an unused parameter is rejected, like a used one
+pass	an overflowing literal in a RECORD op argument's narrow field is rejected
 pass	an overwrite-churn runtime map holds one entry with the last value winning
+pass	an s-around-k ctl arm that ALSO performs an outer effect in the arm body folds — the two E5 fixes compose
+pass	an s-around-k ctl arm whose K-ARGUMENT performs an outer effect folds
+pass	an s-around-k ctl arm whose handle BODY performs an outer effect after the inner perform folds
 pass	an un-annotated negative list element in an unsigned sibling-inferred list is CDZ0302
 pass	an un-annotated over-max list element takes the sibling-inferred narrow width and is CDZ0302
 pass	an un-projected tuple element is not evaluated, so its trap does not occur
@@ -4410,7 +4582,11 @@ pass	arithmetic right shift
 pass	arithmetic right shift of negative one is negative one
 pass	arithmetic right shift preserves the sign bit for a negative operand
 pass	arithmetic within one integer type
+pass	arm-interned symbols keep content identity ACROSS dispatches — same content = same symbol
 pass	at min times -1 the three overflow families diverge: checked None, wrapping min
+pass	av1 the inner arm ABORTS with an OUTER draw as the abort value — the escaping value performs on the way out
+pass	av2 the abort value SUBTRACTS two outer draws under a DOUBLING outer state — antisymmetry pins order inside the aborting arm
+pass	av3 in a THREE-stack the innermost arm aborts with a MIDDLE draw — the escaping value advances the middle thread, later draws see it
 pass	b(mul): a no-overflow obligation is DISCHARGED for x <= 100, (x * 2) <= MAXINT via positive-multiplier monotonicity
 pass	b(sub): a no-underflow obligation is DISCHARGED — for x >= 0, (x - 1) >= MININT via monotonicity + a CHECKED numeral fact
 pass	b4b denotation: a predicate Ast (<= x 100) denotes to the bounds obligation term le (Var 0) (Num 100)
@@ -4420,6 +4596,12 @@ pass	b4c(conjunctive): two stacked @requires give a 2-hyp proof; licenses requir
 pass	b4c(proven): @requires(<= x 100)/@ensures(<= ret MAXINT) on (f x)=x+1 discharges — P denoted as hyp, Q[ret:=body] as goal
 pass	b4c(unprovable): @ensures(<= ret MAXINT) on unbounded (f x)=x+1 is NOT dischargeable — the proof tier correctly MISSES (CDZ-VERIFY)
 pass	bare patterns on a CONCRETELY-exported type stay legal for importers
+pass	bc1 a comparison of a draw feeds a BOOL-taking op whose arm NEGATES the state — the bool crosses the dispatch boundary
+pass	bc1 short-circuit AND over two draws — the false-first row skips the second draw, observed by the branch draw
+pass	bc2 monotonicity of THREE draws under a parity-dependent step — the and of two comparisons decides, the final state rides along
+pass	bc2 short-circuit OR over two draws — the true-first row skips the second draw
+pass	bc3 a nested and-of-or short-circuit tree over draws — each row exercises a distinct skip pattern
+pass	bc3 an op RETURNS Bool consumed by a two-flag if ladder — a mod-3-dependent step makes all four paths reachable
 pass	bin-encode segment ORDER holds for runtime-swapped operand values
 pass	binary operator operands are evaluated left to right
 pass	binding the same effect to a peer twice is rejected
@@ -4441,6 +4623,7 @@ pass	bitwise XOR toggles bits
 pass	bitwise XOR with negative one is the bitwise complement
 pass	bitwise XOR with zero is the operand (identity)
 pass	both elements of a runtime-content fn-return tuple are projected directly and combined
+pass	both same-effect handlers STATEFUL — the outer's advance survives the inner's forwards
 pass	both sibling args consume the same binding independently
 pass	boxed closures of two fn types in one sum: the unbuilt variant's dispatch is dead
 pass	branches performing DIFFERENT counts each thread their own post-state to the continuation
@@ -4454,12 +4637,29 @@ pass	breaker holsubst: a free occurrence beside a shadow substitutes selectively
 pass	breaker holsubst: a shadowing binder blocks substitution
 pass	breaker holsubst: the naive subst's documented capture hazard
 pass	breaker specsubst: GEN of refl then SPEC substitutes the bound var throughout the body
+pass	bs1 a BOOL toggle state — four draws alternate true/false from an input-dependent seed
+pass	bs2 a LATCH — once an op arg is false, the state stays false and every later check answers false
+pass	by1 a BYTES handler state grows two bytes per dispatch — each arm returns the pre-growth length
+pass	by1 bytes built from THREE draws then read at a draw-picked index — Bytes.at follows the thread into the buffer
+pass	by2 a SLICE view (start,LEN) of the Bytes state read per dispatch — in-range bytes returned, out-of-range answers -1
+pass	by3 op-arg values WRAPPED to bytes at runtime accumulate in the state — the fourth emit sees three prior
+pass	by4 nested SAME-effect handlers with independent BYTES states — the outer buffer self-doubles, the inner appends
 pass	byte length agrees with the length of the encoded bytes
 pass	byte length counts the normalized form, not the source spelling
 pass	byte length is the UTF-8 byte count
 pass	byte sequences are equal by their bytes in order
 pass	capture-avoiding substitution renames a Forall binder to avoid capture (logical-form subst)
 pass	capture-avoiding substitution renames a binder so the substituted term's free variable is not captured
+pass	cc1 a closure over the fn PARAM built before the handle, applied twice inside with draws — capture stable, draws advance
+pass	cc2 a closure escaping handle A is applied inside handle B — the A-capture is stable while B's draws feed the args
+pass	cc4 TWO closures over SEQUENTIAL draws inside one region — each captures its own read, applied after both bind
+pass	cc5 composed closures over three draws — g(f(draw)) where f and g each captured an earlier read
+pass	cc6b a closure bound OUTSIDE the outer handle applied inside a nested SHADOW region and after it — capture crosses both boundaries
+pass	cc7 a draw-capturing closure threaded through a RECURSIVE helper — applied per frame, the leaf applies it to a fresh draw
+pass	cc8 a closure carried in a TUPLE beside a scalar — destructured in one match and applied around advancing draws
+pass	ch1 a FOUR-op result chain in one nested expression — each op transforms the last result while bumping the shared state differently
+pass	ch2 the same FOUR-op chain flattened through LETs — one binding per hop must equal the nested form exactly
+pass	ch3 the chain hops CROSS two effects — F.b of G.p of F.a, each thread advancing only on its own hops
 pass	chained Record.with at TWO DIFFERENT fields holds both updates
 pass	chained Record.with updates on one field compose with the last write winning
 pass	chained `?`s unwrap three List.at reads over a sufficient list
@@ -4480,6 +4680,8 @@ pass	closures built one per iteration each capture their OWN loop value
 pass	closures capture successive SNAPSHOTS of a growing heap list
 pass	closures extracted from a list by RUNTIME index and applied dispatch correctly
 pass	closures stored as MAP VALUES dispatch by key with distinct captures
+pass	cn1 a THREE-deep seed RELAY — each nested shadow's seed is a draw from its parent, strides differ per depth
+pass	cn2 the inner shadow's RESULT flows up into the outer computation — a let-bound region value scaled beside an outer draw
 pass	combining a named rate with a length is a dimensional error
 pass	compacting a byte sequence built at run time preserves its bytes
 pass	compacting a runtime CONCAT ROPE materializes it, preserving the value and staying usable
@@ -4560,6 +4762,7 @@ pass	conjunction is true exactly when both operands are true
 pass	conjunction of two theorems sharing a hypothesis concatenates without dedup
 pass	conjunction shields a trapping right operand when the left is false
 pass	const u32 and u16 bin bindings with their top bits set fold unsigned
+pass	constant conditions simplify around performs — kept branches dispatch, dropped ones do not
 pass	constant-succeeding tries as LIST-literal elements unwrap in place and the list builds
 pass	constructing a bit-field from a value wider than its width is rejected
 pass	constructing a byte sequence with a negative value is a type error
@@ -4583,6 +4786,18 @@ pass	converting an out-of-range integer to a char yields None
 pass	converting zero to a char yields Some — U+0000 (NUL) is a valid scalar
 pass	cross-unit Qty host results reject at the guest-side add
 pass	cross-width widening a runtime narrow int with .of (UInt16.of a UInt8) emits (total)
+pass	cv1 an inner arm resumes with a CHAIN of two outer ops — O.b of O.a evaluated inside the arm, probe pins the double advance
+pass	cv2 TWO asks each running the in-arm chain — the second chain starts where the first left the outer thread
+pass	cv3 the in-arm chain routes through a PURE fn mid-hop — O.b of dbl of O.a, the pure call must not detach the thread
+pass	da1 THREE draws inside one list literal passed to a helper — left-to-right element order, the post-call draw sees all three
+pass	da2 draws as MAP-literal keys and values — two entries built from three sequential draws
+pass	da3 draws as SET-literal elements — n=7 collides the first draw with the fixed element, n=6 collides the second
+pass	dc1 a THREE-hop def relay under ONE handler — each def draws then calls the next, weights pin the depth order
+pass	dc2 the relay call's ARGUMENT is a draw — the callee draws again and combines, argument-before-body order pinned
+pass	dc3 the MIDDLE relay hop is chosen by a draw — the branch decides between a two-draw and a one-draw callee, a tail draw pins the total
+pass	dd1b consecutive do-DEF draws — both binders hold their reads, the tail draw sees the doubled-twice state
+pass	dd1d a bare DISCARDED draw before a let-bound draw — the discard advances the state the binder reads
+pass	dd2 a do-DEF bound to a whole nested SHADOW handle — the def holds the inner region's value, the tail draw reads outer
 pass	declaring a unit with a conversion conflicting with a built-in is an error
 pass	decode of a Float tag with a non-finite (NaN) bit pattern yields the error case
 pass	decode of a List tag whose element count exceeds the bytes present yields the error case
@@ -4687,6 +4902,11 @@ pass	division by one keeps a boundary-crossing runtime operand
 pass	division by zero traps
 pass	division of an integer and a float does not silently promote
 pass	division of the minimum integer by -1 overflows and traps
+pass	dn1 a FIVE-deep same-effect shadow tower — one draw per level plus a doubled draw at the innermost
+pass	dn2b an abort under FOUR resumptive frames — the unwind abandons all four pending sums (extends the three-frame pin)
+pass	dn3 an ALTERNATING A/B/A/B tower where both effects share the op NAME next — each perform homes to its effect's innermost handler
+pass	dn4 SKIP-LEVEL performs from the innermost region — A's draws cross the B and C frames to the outermost handler twice
+pass	dn5 a tuple built INSIDE the inner region from BOTH effects' draws, destructured OUTSIDE — data crosses the region boundary
 pass	double negation of a runtime boolean is the identity
 pass	doubling a subnormal crosses UP into the minimum normal exactly
 pass	draining the event queue yields entries in time-order with FIFO same-time ties
@@ -4696,11 +4916,23 @@ pass	dropping a rope built OVER a survivor must not free the shared child node
 pass	dropping a set derived by insert must not free members shared with the survivor
 pass	dropping an absent field from a record is rejected
 pass	dropping fields from a record leaves the remaining fields
+pass	ds1 FOUR discarded draws in a do-chain before the kept one — every discarded dispatch still advances the thread
+pass	ds2 the DISCARDED statement is itself an op-result chain — both hops advance the thread even though the value dies
+pass	ds3 a DISCARDED handle expression whose interior draws from the outer thread — the frame opens, draws, closes, and the value dies
+pass	ds4 a DISCARDED if whose arms draw DIFFERENT counts — the taken branch's advances survive the discard
+pass	dv1 truncated division and dividend-sign modulo over DRAWS — negative dividends exercise the toward-zero rule through dispatch
+pass	dv2 the DIVISOR comes from the arm with a state-dependent sign — quotient and remainder track the alternating divisor exactly
+pass	dv3 division by -1 of a RUNTIME draw — negation across the full non-MIN range, the MIN draw guarded to its own branch
+pass	dw1 a list literal mixing an Int32-annotated element with a wider-inferred literal unifies to (List Int32) — every element renders at the unified element width, uniform across backends (fuzzer cdz-smith differential: rust once emitted a heterogeneous vec![i32,i64])
 pass	each definition in a module registers a reachable export field
 pass	each literal kind quotes to its own single Ast leaf that escapes and renders
 pass	each multi-shot branch OBSERVES its own divergent state via a trailing peek
 pass	each multi-shot branch observes its own heap-lineage length
 pass	each recursion level installs its own handle around a def-bound perform
+pass	ed1 TWO defs each install their OWN handler for one effect — main calls both, seeds and arms fully independent
+pass	ed2 a handled def CALLED from inside another def's handle — the callee's region shadows the caller's mid-body
+pass	ed3 a RECURSIVE def that handles per frame, called from a handled main — the base case draws from the deepest frame's handler
+pass	ed4 one shared performing helper called under TWO different live handlers — each call homes to its caller's region
 pass	effect state threads across a successful `?`
 pass	encoding a decoded string round-trips to the same bytes
 pass	encoding and decoding a constructor-built AST round-trips to an equal value
@@ -4748,6 +4980,7 @@ pass	eval of a quasiquote with TWO unquotes splices a bound and a computed value
 pass	eval of a quasiquote-built form with a byte-string unquote folds
 pass	eval of a quasiquote-built form with a float unquote folds
 pass	eval of a quote carrying a symbol literal is rejected CDZ0101 — the reify bail as a perf-bound tripwire
+pass	eval of a quoted HUGE integer literal declines CDZ0201 — BigInt storage does not widen eval
 pass	eval of a quoted List.at folds the indexing operation to its Option result
 pass	eval of a quoted RECURSIVE call folds through the compile-time evaluator
 pass	eval of a quoted RECURSIVE-sum construction builds the heap spine
@@ -4800,7 +5033,17 @@ pass	extending a record then dropping the added field returns the original
 pass	extending a record with a non-#label (bare identifier) field-name operand is rejected
 pass	extending a record with an already-present field is rejected
 pass	extracting a high byte composes shift and mask
+pass	fa1 a FOLD-style accumulator threads through a performing recursion — acc doubles then absorbs each level's draw
+pass	fa2 TWO accumulators through one performing recursion — running sum and prefix-sum-of-prefix-sums stay in step with the draws
+pass	fa3 each fold level draws TWICE and mixes them asymmetrically — 10*first + second pins the intra-level draw order
+pass	fa4 the accumulator IS a sum — each level's draw moves it around an A->B->C->A cycle capturing payloads on the way
+pass	fa5 a TWO-effect fold — each level's step multiplies a draw from each thread, both threads advancing independently
 pass	false is less than true
+pass	fe1 a Float64 handler state HALVING per dispatch — three draws sum to exactly 1.75x the seed (exact binary fractions)
+pass	fe2 a CLAMP-style Float64 arm (single-site resume) — below-state args are lifted to the rising floor
+pass	fe3 an Int64 handler and a Float64 handler INTERLEAVED — integer ticks and exact float halving thread independently
+pass	fe4 float comparisons route an integer match — the sign of the second draw picks the arm, exact identities verify inside
+pass	filter-via-effects — a STATEFUL predicate dispatch decides each element's survival
 pass	first-match-wins holds with a duplicate string-literal arm
 pass	float <= is NOT (< or =): they diverge on NaN because canonical-byte equality says nan = nan
 pass	float >= is NOT (> or =): the same NaN divergence mirrors on the greater-or-equal side
@@ -4814,12 +5057,20 @@ pass	four nested frames dispatched OUTERMOST-first — every outer perform escap
 pass	four same-signature closure exports share one resource
 pass	from-bytes decodes a 3-byte scalar split across BOTH seams of a 3-leaf rope
 pass	from-bytes rejects a torn sequence whose invalid continuation sits in the NEXT leaf
+pass	fs1 the SAME handle expression re-entered per recursion round — a FRESH region each iteration, seeds keyed by depth
+pass	fs2 two SEQUENTIAL handles where the second's SEED is computed from the first's RESULT — regions chained by value
+pass	fs3 THREE value-chained regions — each seed is the previous region's result, arms +1 / x2 / -5
 pass	function arguments are evaluated left to right
 pass	functions are single-arity and curried
 pass	generated FLOAT values are totally ordered (a trichotomy property over two generated floats)
 pass	generated small-alphabet strings dedup in a Set by content across per-draw construction
 pass	generated string keys OVERWRITE by content and the first word's final value is observable
 pass	generic user-sum values dedupe as set elements and key a map by rope-payload content
+pass	gl1 the let-lifted pure-guard equivalent of the gp1 dispatch shape — the pre-bound guard draw advances the state the arms read
+pass	gl2 the let-lifted pure-guard equivalent of the gp2 cascade — both guard draws pre-bound, all three arms reachable
+pass	gp1 a PERFORMING guard on a wildcard pattern is a COMPILE ERROR (guards-side-effect-free, CDZ0407)
+pass	gp2 TWO guard arms where a guard PERFORMS — declines (multi-guard performing-condition fold gap)
+pass	gp2e TWO pure guards cascade over a draw, the fallback re-performs — guard misses leave dispatch serviceable
 pass	grafting through a DAG-shared user-sum subtree rebuilds one path and leaves the shared original intact
 pass	graph REACHABILITY drains a worklist against a visited-set over a Map adjacency list
 pass	greater-than at the integer extremes is signed
@@ -4828,21 +5079,51 @@ pass	greater-than of an integer and a float is rejected
 pass	greater-than on an unusual signed width orders a positive above the negative minimum
 pass	greater-than-or-equal
 pass	greater-than-or-equal of an integer and a float is rejected
+pass	ha1 an INNER op's arguments draw from the OUTER handler — two outer draws cross the inner dispatch boundary in order
+pass	ha2 outer-draw feeds the INNER op, whose result feeds an OUTER op again — a three-hop cross-handler value chain
+pass	ha3 INTERLEAVED outer-inner-outer draws in ONE argument list — each draw dispatches to its own handler in sequence
+pass	ha4 an inner op's arguments dispatch to the SAME inner handler — same-effect draws inside the op's own arg list, then an outer draw
 pass	halving the minimum subnormal flushes to zero while a double-min stays subnormal
 pass	handler op-param and state binders stay hygienic when colliding with perform-site names
 pass	handler-arm bindings and perform-site bindings stay in their own scopes across the fold
 pass	hash-only set ops keep working on float-leaf tuples that have no blessed order
+pass	hc1 a THREE-deep pure helper chain whose LEAF performs — two top-level calls thread the state through the depth
+pass	hc2 helpers at TWO depths both perform — the call-site draw, mid's draw, and leaf's draw arrive in order
+pass	hc3 the SAME performing helper under two SEQUENTIAL handlers — each handle interprets its draws with its own arm and seed
+pass	hc4 a performing helper COMPOSED with itself — probe(probe(draw)), three dispatches through two call frames
+pass	hc5 a helper RETURNS a tuple of two draws — the caller destructures it and re-performs
 pass	heap string elements of a hoisted list if select by branch
 pass	heap-valued handler state above an inner abort keeps threading
 pass	heterogeneous constructions take ONE malformed-collection code across list, map, and set
 pass	hex and binary literals drive a runtime mask-extract across radix notations
 pass	hexadecimal, binary, and decimal spellings of one value are equal
+pass	hi1 an arm INSTALLS a fresh handle and resumes with its result — a whole handler lifecycle inside one dispatch
+pass	hi2 the arm-installed handle's body draws from the arm's ENCLOSING frame — fresh inner frame and outer dispatch in one arm
+pass	hi3 the arm-installed handle's OWN arm resumes with an OUTER draw — the rv face nested inside another handler's dispatch
+pass	hi4 the arm-installed handle ABORTS with an outer draw — the av face nested inside another handler's dispatch
 pass	host calls are observed in the order they were made
+pass	host calls in the seed AND the next-state slot — the FINAL dispatch's state call is elided
 pass	host calls issue only from the TAKEN arm of a fused match and in arm order
+pass	hp1 a RECURSIVE fn installs a fresh same-effect handler per frame — the base case draws from the deepest, each frame from its own
+pass	hp2 per-frame handlers with a POST-ORDER draw — each frame draws its own state AFTER the recursive call returns
+pass	hp3 the recursive call sits in the SEED — each frame's handler is seeded by the whole subtree below it
+pass	hr1 a HANDLE expression as a record-literal FIELD value — the region's result sits beside a pure field
+pass	hr2 a HANDLE expression as a middle LIST element — the region's result sits between pure elements
+pass	hr3 a HANDLE expression as a map-literal VALUE — the region's result is stored under a key and looked up after
+pass	hr4 a whole HANDLE region as another effect's op ARGUMENT — B's region computes the value A's dispatch consumes
+pass	hs1 an inner SAME-effect handle's result is the match SCRUTINEE — the selected arm and the trailing draw hit the OUTER state
+pass	hs2 an OUTER-seeded inner handle builds a tuple scrutinee — the destructured arm re-performs against the outer
+pass	hs3 an inner SAME-effect handle's result is the IF condition — the taken branch re-performs against the outer
 pass	hygiene fix does not over-reach: a different-named template binder needs no rename
 pass	hygiene: a spliced unquote sits beside the template's own use of the renamed binder
 pass	hygiene: an unquote is uncaptured through two nested same-named template binders
 pass	hygiene: two distinct unquotes each colliding with a different template binder are both renamed
+pass	ic2 an INLINE performing if-condition — the taken branch's draw reads the condition-advanced state
+pass	ic3 CHAINED if-else-if where each condition draws — three rows land in three different arms
+pass	ic4 a helper with a performing IF-condition called twice — each call re-evaluates the condition against the advanced state
+pass	ic5 a recursive LOOP whose exit condition draws per iteration — the iteration count is state-determined
+pass	ic6 a draw-conditioned branch selects BETWEEN two effects — the untaken effect's state is untouched by that row
+pass	identical PURE reads of a perform-built list — safe to share, values agree
 pass	identical PURE subterms around distinct performs — pure sharing must not merge dispatches
 pass	identical negative zeros nested in a tuple compare equal
 pass	identically-built ropes on both sides of a nested compare are equal (control)
@@ -4886,6 +5167,9 @@ pass	intersection is commutative over runtime-element sets
 pass	intersection of a set with itself is the set (idempotent)
 pass	intersection of a trie with its churned-back subset is the subset itself
 pass	intersection with the empty set is the empty set
+pass	is1 a draw-SELECTED match arm installs a nested same-effect shadow — outer state resumes after the branch-local region
+pass	is2 the ARM's resume-value is a nested SAME-effect handle — a fresh shadow instantiated per dispatch from the live state
+pass	is3 the ARM's NEXT-STATE is computed by a nested SAME-effect handle — the shadow feeds the outer state thread
 pass	jointly-total guards over one variant are still non-exhaustive (guards are opaque to the checker)
 pass	keyed lookups at different keys are not shared
 pass	large-set algebra over a multi-level CHAMP trie computes correct union/intersection/difference
@@ -4898,13 +5182,26 @@ pass	less-than-or-equal
 pass	less-than-or-equal of an integer and a float is rejected
 pass	let bindings' initializers are evaluated in binding order
 pass	let-bound perform results stored into record fields
+pass	lf1 a recursive index-walk over a DRAW-BUILT list, scaled by an earlier draw — the walk itself is pure
+pass	lf2 a PERFORMING recursive walk — each element visit draws, pairing element order with state order
+pass	lf3 the arm pushes TWO elements per dispatch (both lengths read from the PRE-push list) — the third draw reads length 5
+pass	lf4 a per-element dispatch comparing each element against the RISING state — amplify-or-pass per visit
+pass	lf5 TWO lists walked in LOCKSTEP with a per-pair 2-arg dispatch — length-guarded via projection helpers
+pass	li1 draws choose BOTH the List.update target and the List.at read index — the collection edit follows the thread
+pass	li2 a list BUILT from pushed draws then read at a draw-picked index — construction and consumption share one thread
+pass	li3 draw PARITY picks prepend vs push while building — the final shape encodes the whole draw sequence
 pass	list concatenation is associative by content
 pass	list ordering recurses into string elements by content across mixed reps
 pass	lists are equal by elements in order
 pass	lists built by PUSH and by CONCAT compare equal by content, and order stays decisive
 pass	literal payload refinement works in a non-head element position
 pass	literal refinement on two elements of one list pattern
+pass	lo1 THIRTY dispatches in one region — the fold scales past the corpus's usual handful, arithmetic sum exact
+pass	lo2 a NINE-level shadow tower (outer + eight) — one draw per level, the deepest doubling, strides 1-8
+pass	lo3 EIGHT ops in one effect, called in shuffled order — dispatch-table width, one op advancing mid-sequence
 pass	looking up an absent key yields None
+pass	lt1 the arm SWAPS its list state's ends per dispatch — the head alternates between the original ends
+pass	lt2 the arm DOUBLES every list element per dispatch (via a projection helper) — the sum geometrically grows
 pass	map THEN filter compose — one combinator's output list is the next's input
 pass	map equality is independent of insertion order
 pass	maps reached via Map.swap and Map.take equal their directly-built twins
@@ -4948,6 +5245,12 @@ pass	merging two empty records is the empty record
 pass	merging two records with disjoint fields unions their fields
 pass	merging with the empty record on the left is the identity
 pass	merging with the empty record on the right is the identity
+pass	mf1 a helper performing TWO different effects — both handlers discharge it, both states advance per call
+pass	mf2 the SAME two-effect helper under the OPPOSITE handler nesting order — distinct effects commute
+pass	mf3 one performing helper called from an ARM's resume-value AND the body — three calls, one advancing thread
+pass	mi1 enumeration DELTA across dispatches — dumps before and after keyed inserts, collision rows shrink the delta
+pass	mi2 SORTED Set enumeration survives a draw-keyed insert — positional reads, the collision row exposes the missing third slot
+pass	mi3 the arm AGGREGATES map values via a to-list walk — the n=1 row OVERWRITES the seed value, shrinking the total
 pass	mixed bool and int splices evaluate in one template
 pass	mixed comparison operators across if arms keep their own arms
 pass	mixed operators across the if arms keep their own arms
@@ -4963,12 +5266,26 @@ pass	mixing two float widths without a conversion does not silently promote
 pass	mixing two integer widths without a conversion does not silently promote
 pass	mixing two numeric types without an explicit conversion does not silently promote
 pass	mixing units of DIFFERENT dimensions is still a compile-time error
+pass	mk1 a MAP handler state keyed by the op ARGUMENT — per-key counters, lookup-or-default then insert per dispatch
+pass	mk2 map keys DERIVED from prior draws — n=1 collides the derived key with the first insert, shrinking the map
+pass	mk3 the arm SHRINKS the map state via remove — re-removing the same key is idempotent, a missing key is a no-op
+pass	mo1 a TWO-op effect fully shadowed — the inner handler re-interprets BOTH ops with different arms
+pass	mo2 THREE-deep same-effect shadowing — each depth's draws thread its own state, interleaved before/inside/after
+pass	mo4 a SAME-effect draw in the inner handle's SEED homes to the OUTER handler — the shadow starts at the body, not the seed
+pass	mo5 LIST-state shadowing — inner and outer thread independent heap lists, growth interleaved
 pass	modular exponentiation by SQUARING halves the exponent and branches on parity
 pass	modulo by -1 is zero even at the minimum integer
 pass	modulo by zero traps
 pass	modulo gives the remainder
 pass	modulo of an integer and a float does not silently promote
 pass	modulo of two floats rejects — the operator is integer-only, not merely promotion-free
+pass	mp1 draws pick the Map INSERT key and the LOOKUP key — hit-old, hit-updated, and miss all reachable by input
+pass	mp2 map VALUES are draws inserted in key order — weighted lookups replay the draw sequence through the map
+pass	mp3 a draw picks the Map.remove key — lookups of all three keys show exactly one hole where the thread pointed
+pass	ms1 an op returns a THREE-variant sum built from state parity — two sequential performing scrutinees, the second sees the advanced state
+pass	ms2 match ARMS themselves draw after the performing scrutinee advanced the state — arm-selected continuation of the same thread
+pass	ms3 parity-sum dispatch inside a RECURSIVE walk — each level draws a Mode and accumulates by variant as the thread advances
+pass	ms4 the C arm RE-MATCHES its own payload's parity — a nested pure match inside an arm of the performing-scrutinee match
 pass	multi-argument application is curried application
 pass	multi-export Set-result closures — the singleton one
 pass	multi-export Set-result closures — three sharing one call
@@ -4993,6 +5310,9 @@ pass	multiply-by-zero is NOT an annihilator for FLOAT — nan * 0.0 is nan, not 
 pass	multiplying a compound (tuple) by a number is a cross-kind type error, not invalid wasm
 pass	multiplying a scaled-unit quantity by the literal one keeps its dimension and displays scaled
 pass	multiplying quantities multiplies their dimensions
+pass	mx1 a THREE-arg op mixing Int64/String/Bool — one arm consumes all three kinds beside the live state
+pass	mx2 mixed-arg op with BOTH args draw-derived — the int arg is a draw, the string arg branches on a second draw
+pass	mx3 a TUPLE-arg op chained through a tuple RESULT — the second dispatch consumes the first's destructured output
 pass	narrow unsigned comparison division and remainder compose unsigned over a high-bit operand
 pass	narrowing a BigInt-valued if back to Int64 works over both branches
 pass	narrowing a constant BigInt out of the target range is rejected at compile time
@@ -5024,8 +5344,20 @@ pass	nested quasiquote: a level-2 deferred unquote is INDEPENDENT of the enclosi
 pass	nested quasiquote: an inner unquote at level 2 is deferred, not spliced (exact structure)
 pass	nested same-direction shifts by constants combine into one shift by the sum, keeping the left-shift overflow trap
 pass	nested-Option equality observes the OUTER variant and matches identical nesting
+pass	nm1 NEGATIVE remainder is TRUNCATED (sign of the dividend) uniformly — bare and through a handler arm
+pass	nm2 NEGATIVE division TRUNCATES toward zero uniformly — bare and through a handler arm
+pass	nm3 the only overflowing DIVISION (Int64.min / -1) is a CONSTANT-fold reject — the runtime-divisor form runs for every other divisor
+pass	nm4 Int64.min divided by RUNTIME divisors — every non-(-1) divisor has an exact Int64 quotient
 pass	nullary constructor patterns are uniform with unary
 pass	nullary variants of a payload-carrying sum order by discriminant
+pass	nx1 a SUBTRACTING stride crosses zero — negative states thread and sum correctly
+pass	nx2 a 2^62 seed threads exactly — the difference of consecutive draws recovers the stride
+pass	nx3 the arm branches on the op arg's SIGN — negation on the negative path, n and -n both exercised
+pass	nx4 an alternating-sign GEOMETRIC stride (*-2) — the sign flips per dispatch and the sum telescopes
+pass	nx5 i64::MIN-adjacent op arguments — the arm's subtraction stays in range and the two dispatches differ by exactly the state stride
+pass	oc1 an Option-of-TUPLE accumulator — None seeds on first step, Some carries (total,count) advancing both
+pass	oc2 an Option FLOWS between two ops of one effect — find produces Some/None, use consumes it as an op ARG
+pass	oc3 a DOUBLE-wrapped Option resume value — None vs Some(None) vs Some(Some v) all distinguished by the body
 pass	odd-width CHECKED arithmetic traps at the odd boundary, not the machine slot (Int24 max + 1)
 pass	odd-width values as Set keys dedupe at their own width (UInt4: wrap 3 = wrap 19)
 pass	odd-width wrap lands exactly at its own boundary (UInt4 16->0, Int24 2^23 -> -2^23)
@@ -5041,10 +5373,13 @@ pass	one host effect with TWO ops interleaves its calls in program order
 pass	one module's export clause does not affect a same-named member of another module
 pass	one of several same-signature closure exports is made and called by the host
 pass	one of two DIFFERENT-signature closure exports is made and called
+pass	one perform result flows through let, record, projection, tuple, destructure, and match
 pass	one performing closure applied twice observes the handler state stepping between calls
 pass	one staged partial application fans out to TWO second stages sharing the first capture
 pass	one string content hashes identically from flat, rope, and view reps in one program
 pass	one type parameter used at several depths in one multi-payload variant
+pass	op1 the STD Option as handler state — None seeds to Some on first feed, the payload accumulates thereafter
+pass	op2 an Option RESUME value from a single-site arm — Some carries the excess, None answers the shortfall row
 pass	or evaluates the right operand when the left is false
 pass	or performs the right operand's effect when the left is false
 pass	or short-circuit does not perform the right operand's effect
@@ -5063,6 +5398,9 @@ pass	over-applying a lambda by an extra argument is a type error
 pass	over-applying a named function by an extra argument is a type error
 pass	overflow of the default integer traps deterministically
 pass	overwriting ONE deep list value leaves the neighbors AND the original map live
+pass	pa1 a SAME-effect perform as another op's ARGUMENT — the arg dispatch advances the state the outer dispatch reads
+pass	pa2 TWO same-effect draws as the TWO arguments of one op — left-to-right arg order, the arm reads the post-args state
+pass	pa3 THREE-deep nested same-effect arg-feed — scale(scale(next)) with a state-advancing scale arm
 pass	parsing a length-framed message and rebuilding it yields the original bytes
 pass	partial application captures a let-bound value in the residual lambda
 pass	partial application captures a runtime parameter in the residual lambda
@@ -5102,6 +5440,7 @@ pass	print of an Ast.Float renders a re-readable decimal and read inverts it
 pass	print of an Ast.Str renders a quoted literal with escapes and read inverts it
 pass	print of an exponent-scale Ast.Float round-trips through read
 pass	print of an integer-valued Ast.Float keeps its float form through read
+pass	print renders a HUGE Ast.Int losslessly — the full 26-digit decimal, no truncation
 pass	print renders a bare Ast.Bool as its exact keyword text
 pass	print renders a bare Ast.Bytes as its exact b"…" byte-literal text
 pass	print renders a bare Ast.Int as its exact decimal text
@@ -5147,6 +5486,7 @@ pass	promoting a Float32 to Float64 is exact
 pass	pure guards on fused-match arms read the payload binder and an enclosing capture
 pass	pushing an element of a different type onto a list is a type error
 pass	pushing an element onto a list appends it
+pass	pushing onto a SHARED perform-built list — the original stays len 2 beside the grown copy
 pass	pushing through ONE alias of a doubly-held list leaves the sibling field intact
 pass	quasiquote constructs AST with selective evaluation
 pass	quasiquote makes AST construction readable
@@ -5202,6 +5542,7 @@ pass	recursive repeated-squaring modpow over BigInt computes a Mersenne-modulus 
 pass	recursive-sum equality discriminates a difference at the DEEPEST node
 pass	recursive-sum equality is decided by RUNTIME parameters, both regimes in one export
 pass	recursive-sum equality over FLOAT payloads compares by canonical float bytes along the walk
+pass	recursively STACKED same-effect handlers — the perform resolves to the DEEPEST frame
 pass	redeclaring a built-in unit with its own conversion is admissible
 pass	redeclaring a user-declared unit with the same conversion is admissible
 pass	reifying a constant NaN into an Ast.Float declines (no canonical value form)
@@ -5268,6 +5609,14 @@ pass	round-trip: a scalar consumer + a compound consumer of the same closure —
 pass	round-trip: a scalar consumer and a byte-rope consumer of the same closure — the byte-rope one
 pass	round-trip: a scalar consumer and a byte-rope consumer of the same closure — the scalar one
 pass	round-trip: an UNANNOTATED inner closure with a List param via the context arrow
+pass	rr1 one draw consumed THREE times (squared, scaled, summed) — a single dispatch, the binder multiply-read
+pass	rr2 the SQUARE of a difference of two draws — composite arithmetic over one advancing thread, zero row included
+pass	rs1 a RECORD state where each op owns a FIELD — bump advances a, scale multiplies b, interleaved
+pass	rs2 the arm updates the record state via Record.with — field b is held by the functional update across dispatches
+pass	rs3 a NESTED record state — the arm functionally updates the inner record's x by y and bumps the outer counter
+pass	rt1 Ok/Err resume values with a DEPENDENT second dispatch — the sign of the falling state flips Ok to Err
+pass	rt2 an Err SHORT-CIRCUITS a recursive Result walk — Ok accumulates, the first Err multiplies out and stops
+pass	rt3 the Err VALUE seeds a RECOVERY region — a fallback same-effect handle runs inside the Err arm
 pass	run-length encode/decode round-trips a runtime list of tuples
 pass	runtime < on a self operand is false for finite AND NaN (irreflexive, stays false)
 pass	runtime <= on a self operand is true for finite but FALSE for NaN (no reflexivity fold)
@@ -5304,6 +5653,14 @@ pass	runtime tuple concatenation preserves element order across the seam
 pass	runtime-packed nibbles MATCH back out through bits patterns - the pack-unpack identity
 pass	runtime-payload `?`s in BOTH arms of a RUNTIME-scrutinee match each resolve the boundary
 pass	runtime-payload `?`s in BOTH branches of a runtime if take their own continuations
+pass	rv1 the inner handler ARM resumes with an OUTER draw — the resume VALUE expression performs against the enclosing handler
+pass	rv2 the inner arm's resume value SUBTRACTS two outer draws — cross-handler order inside the arm, with a doubling outer state
+pass	rw1 two sequential Record.with updates each take a DRAW — the second write sees the advanced state, projections read both back
+pass	rw2 draw PARITY picks WHICH field Record.with updates — projections of both fields show exactly one write landed
+pass	rw3 each Record.with value PROJECTS from the record it updates plus a draw — self-referential functional updates chain through the thread
+pass	sa1 STRING op arguments measured into a scalar state — the empty string is a real zero-length argument
+pass	sa2 a string BUILT from a prior draw's branch becomes the next op's argument — the tag arm reads the post-pick state
+pass	sa3 STRING resume values — the arm builds a rope per dispatch branching op-arg vs live state, body concatenates two
 pass	same-Instant queue entries resume in FIFO insertion order (§3.4 tie-break)
 pass	same-arity tuple match arms share an equal element and sink the differing one
 pass	same-effect shadowing with ADVANCING states — the outer state survives the inner handle and resumes advanced
@@ -5312,6 +5669,11 @@ pass	same-key-set record match arms share an equal field and sink the differing 
 pass	same-length list match arms share an equal element and sink the differing one
 pass	same-payload different-variant sum keys are DISTINCT map keys
 pass	same-variant sums order by PAYLOAD when the discriminant ties
+pass	sb1 an op ARG drawn at a shadow boundary — both the arg draw and the consuming dispatch home to the INNER handler
+pass	sb3 the op ARG draws from effect B while the dispatch homes to effect A — two paired dispatches, both states advance
+pass	sb4 the innermost seed is a COMPOSITE of two effects' dispatches — B's draw feeds A's add, the result seeds a fresh B shadow
+pass	sc1 STRING literal-arm dispatch on a draw — the hi arm re-performs and measures, the lo arm is constant
+pass	sc2 EQUALITY of two string draws routes the branch — the n=3 row crosses the threshold between draws
 pass	scalar length counts Unicode scalar values, not bytes
 pass	scalar length of a supplementary-plane character is one scalar value
 pass	scaling a Float64 quantity by a bare integer is a numeric-type mismatch
@@ -5322,6 +5684,15 @@ pass	scan emits the seed plus one accumulator per element (n+1 outputs)
 pass	scan over an empty iterator emits just the seed
 pass	scan threads its accumulator left-to-right (an order-sensitive folder)
 pass	scan's kth emitted accumulator is the running fold of the first k elements
+pass	sd1 a draw COUNT drives string repetition through a recursion — String.byte-len pins how many times the thread said to concat
+pass	sd2 draw parity picks WHICH string each op returns — the concat order of two draws is visible in content equality
+pass	sd3 a draw-bounded String.slice window — start and end both come from the thread, byte-len pins the window width
+pass	se1 a SET handler state with dedup dynamics — re-adding an existing element leaves the size fixed
+pass	se1 five draws collected into a Set under a cycling state — duplicates collapse, len and membership pin the distinct draws
+pass	se2 MEMBERSHIP of a draw decides a branch that draws again — the set gates the thread's continuation
+pass	se2 a membership-GATED arm — first visit admits and records, a revisit answers negated without growing
+pass	se3 a DRAIN-style arm removes on hit — the second take of the same key routes to the miss path
+pass	se3 a set BUILT from cycling draws probed by a LATER state read — the in-cycle probe hits, the off-cycle probe misses
 pass	self-difference of a 100-element trie IS the canonical empty set by equality
 pass	self-operand division is NOT folded to one — it still traps at zero
 pass	self-operand subtraction and xor are zero, and-or are the operand, on a runtime value
@@ -5334,6 +5705,16 @@ pass	set union is associative on generated inputs (the order merges are grouped 
 pass	set union is commutative on generated inputs (a grow-only-set CRDT merge converges)
 pass	set union is idempotent on generated inputs (re-delivering a set changes nothing)
 pass	sets reached via DIFFERENCE and INTERSECTION equal the directly-built set
+pass	sg1 a string BUILT by a recursive walk of draws — one H/L character per dispatch, exact content compared
+pass	sg2 a stable PREFIX slice of a growing rope — String.slice (start,END) of the state per dispatch, prefix identical across growth
+pass	sg3 a ONE-SHOT string lock — the arm string-compares op arg vs state, consuming the key on the first match
+pass	sg4 TWO-SIDED rope growth — the op arg's sign picks append-right vs prepend-left, exact content across three sign patterns
+pass	sg5 the GROWING string state is a MAP KEY per dispatch — each draw looks up the current rope in a literal map
+pass	sg6 the rope's LENGTH PARITY routes its own growth — odd appends two, even appends one; four draws read 1,3,4,5
+pass	sg7 byte-len vs scalar-len DIVERGE on a growing multi-byte rope — each dispatch reads the difference (one per accent)
+pass	sh1 a NESTED handler for the SAME effect shadows the outer — inner draws hit the inner state, the draw after hits the outer
+pass	sh2d a let bound in a handle body, read by a NESTED handle's seed — declines (let-crossing scope gap)
+pass	sh2n the config-fetch idiom with its perform LET-LIFTED — declines (let-crossing scope gap)
 pass	shift-by-zero is a no-op on a runtime operand for both directions
 pass	shrinking an @invariant newtype to EMPTY traps at the rebuild — the invariant catches the crossing
 pass	shrinking reports the minimal failing input
@@ -5365,6 +5746,14 @@ pass	splitting a tuple at its full arity yields an empty suffix
 pass	splitting a tuple at zero yields an empty prefix
 pass	splitting a tuple beyond its arity is rejected
 pass	splitting a tuple with a runtime element addresses the prefix and suffix
+pass	ss1 a STRING handler state grows per dispatch — each arm returns the pre-growth length, growth is op-arg-branchy
+pass	ss2 string state grows across a DO sequence — discarded draws still advance the rope
+pass	ss3 nested SAME-effect handlers with independent STRING states — inner self-doubles, outer appends
+pass	st1 a handle expression as ONE operand of an enclosing pure sum — the pure operand and the handled region compose
+pass	st1 the SAME effect handled at THREE depths — each draw resolves to the innermost open frame, outer frames resume as inner ones close
+pass	st2 TWO sibling handle expressions as operands of one sum — independent regions with different arms and seeds
+pass	st2 draws BETWEEN the installs of a three-deep tower — each thread advances only while it is the innermost, sum pins the interleave
+pass	st3 the SHADOWING frame's arm draws the SAME effect — its dispatch escapes its own extent and lands on the frame it shadows
 pass	stacked line comments on a top-level form are all seen through
 pass	straight-line add-then-subtract keeps the value but is not cancelled to the operand
 pass	string REVERSE walks scalars back-to-front and anti-commutes with concatenation
@@ -5388,6 +5777,14 @@ pass	structural equality holds component-wise
 pass	structural equality of two Ast.Int wider than Int64 compares by full value
 pass	structural equality on an Ast.List is element-COUNT sensitive
 pass	structural equality on an Ast.List is element-ORDER sensitive
+pass	su1 a SUM-typed state machine — Idle transitions to Run on first dispatch, Run accumulates thereafter
+pass	su2 a THREE-variant cyclic machine — the op arg selects the transition, both Mid exits exercised
+pass	su3 a RECURSIVE sum state — the arm grows a Peano tower by two per dispatch, a recursive fn measures it
+pass	su4 a sum variant carrying a HEAP list — Empty seeds on first put, Full grows the payload thereafter
+pass	su5 the sum STATE escapes as the handle's value via a dump op — matched OUTSIDE the handler
+pass	su6d BOTH handlers sum-state, same effect, TWO inner dispatches — declines (2nd arm copy's variant match hits the scalar-probe path)
+pass	su6f a SCALAR-state outer shadowed by a SUM-state inner cycler — the inner machine transitions twice
+pass	su6g a SUM-state outer shadowed by a SCALAR-state inner — mixed state kinds across the shadow boundary
 pass	subset record comparison is explicit projection, not an overloaded equality
 pass	substitution fires inside an implication (subst recurses into Imp)
 pass	subtracting quantities of incompatible dimension is a compile-time error
@@ -5398,6 +5795,11 @@ pass	subtraction of two strings is rejected
 pass	subtraction of two symbols is rejected
 pass	sum type constructors are in scope after declaration
 pass	swapped-operand complements do not fold — less-than or flipped greater-equal is not a tautology
+pass	sy2 a SYMBOL toggle state — equality routes the resume value while the arm flips fast/slow per dispatch
+pass	sy3 the SYMBOL state is a MAP KEY per dispatch — the a→b→c walk ends at a missing key
+pass	sy4 sequential draws written into record FIELDS via Record.with symbol selectors — chained functional updates
+pass	sy5 SYMBOL op args as COMMANDS — inc/dbl/nop route both the answer and the state transition
+pass	syd1 an op returns a SYMBOL picked by state parity — symbol equality gates a branch that draws again
 pass	symbol identity follows String normalization
 pass	symbol ordering is reflexive at the boundary — less-than-or-equal on equal content
 pass	symbol ordering — greater-than agrees with the byte order
@@ -5413,12 +5815,15 @@ pass	t1(oob) NEGATIVE: with only the LOWER bound (>= i 0), the out-of-bounds obl
 pass	t1(oob): the out-of-bounds obligation (0<=i) AND (i<len) is DISCHARGED from the two bound preconditions
 pass	t1(trap) NEGATIVE: a trap guard NOT contradicted by the precondition is NOT unreachable — the trap STAYS
 pass	t1(trap): an explicit trap under guard (lt x 0) is UNREACHABLE when @requires(>= x 0) — the trap is dead
+pass	ta2 an abort INSIDE the inner frame of a same-effect tower — Bail innermost, both E threads keep their positions
 pass	take-while and drop-while split a leading run and reassemble to the original
 pass	take-while composed after a map threads both transformers' closures
 pass	take-while excludes the failing element and everything after it (content, not just count)
 pass	take-while where every element satisfies the predicate keeps the whole run
 pass	take-while where the first element fails the predicate returns the empty run
 pass	textually-identical performs are DISTINCT state-advancing reads, not a common subexpression
+pass	the ARM ENCODES its scalar op argument into framed Bytes and resumes them — body decodes
+pass	the ARM decodes a Bytes op argument with a bin pattern and resumes a parsed field
 pass	the AST is a sum type deconstructible by pattern matching
 pass	the Bool generator covers both values across seeds (it is not a constant)
 pass	the CHECKED ground axiom le-ax cannot forge a FALSE order fact (5 <= 3) — the axiom base is consistent
@@ -5440,6 +5845,7 @@ pass	the OLD 2-operand `Record.extend (name value)` pair form is rejected (migra
 pass	the OLD 2-operand `Record.with (name value)` pair form is rejected (migrated to 3 operands)
 pass	the OR short-circuits on a true first operand — the second perform must NOT fire
 pass	the RUNTIME division identity a=(a/b)*b+(a%b) holds across all four sign quadrants
+pass	the SAME op name on two DIFFERENT effects — each qualified perform routes to its own handler
 pass	the SAME runtime set as both operands of union intersection and difference computes each law live
 pass	the SELECT (choice) axiom is minted via new_axiom as a hypothesis-free theorem
 pass	the Sign sum orders Neg below Pos per its declaration
@@ -5449,6 +5855,10 @@ pass	the additive-zero identity preserves a boundary-crossing runtime operand
 pass	the and SHORT-CIRCUITS: the second operand's perform must NOT fire (state proves it)
 pass	the and-complement folds to zero on an unsigned type but the or-complement is the width all-ones not -1
 pass	the arithmetic operator rejects a float-first mixed operand pair
+pass	the arm DECODES a Bytes op argument to a String — multibyte UTF-8 survives the crossing
+pass	the arm ENUMERATES its Map state to a list of tuples and resumes the enumeration
+pass	the arm slices a crossed multibyte String at a scalar boundary — the slice window respects UTF-8
+pass	the arm's nested handler is instantiated FRESH per dispatch — independent inner state
 pass	the arm-shape rule is FRAME-RELATIVE: a nested single-site handler dispatching mid-sequence is invisible
 pass	the b2 match predicate LICENSES the elision: the discharged no-overflow proof matches the obligation and its hyps are covered by the node precondition
 pass	the b2 match predicate REJECTS a proof discharged under a FOREIGN hypothesis not in the node precondition (soundness — no elision under wrong assumptions)
@@ -5475,6 +5885,8 @@ pass	the byte length of a run-time-selected string reads the actual handle
 pass	the byte length of a runtime string equals the length of its encoded bytes
 pass	the byte-len of a multi-byte String.slice exceeds its scalar-len (the two measures diverge)
 pass	the churned-to-empty map REGROWS with correct structure (no residue corrupts re-insertion)
+pass	the closure state is REPLACED per dispatch by one capturing the arm's OWN binder
+pass	the closure's inner arm performs an OUTER effect through the closure boundary
 pass	the compare walk recurses list-of-sums-of-lists with discriminant-first at depth
 pass	the complement laws fold x-and-not-x to zero and x-or-not-x to all-ones on a signed runtime value
 pass	the composed multibyte slice view equals its literal twin and keys a Map
@@ -5526,11 +5938,13 @@ pass	the filtered rebuild EQUALS the direct selection build (selection is canoni
 pass	the first failing `?` short-circuits; a later `?` never runs
 pass	the float ordering-versus-equality split on the zero pair
 pass	the four rational-to-Int64 projections of one runtime rational store in a list and read back distinct
+pass	the gcd face: a reducible num/den pair from performs canonicalizes (4/8 → 1/2)
 pass	the generated Param accessor carries the @param's declared type into arithmetic
 pass	the generated-set convergence property has discriminating power — two different generated sets are NOT equal
 pass	the generator is a deterministic function of its seed (same seed, same value) — folds
 pass	the generator reproduces its stream from a runtime seed (same seed, same value) — runs
 pass	the greater-than operator on chars follows scalar order
+pass	the guard-MISS path re-performs in the fallback arm — dispatch continues past a failed guard
 pass	the guard-TRUE path of the perform-scrutinee match (no fallback entry)
 pass	the guarded-let conditional takes its else-branch when the conjunction is false
 pass	the handler STATE is a CLOSURE the arm replaces with one capturing the perform-time op argument
@@ -5574,6 +5988,7 @@ pass	the length of a list looked up from a map by a runtime key
 pass	the length of a prepended-onto list grows by one
 pass	the length of a runtime byte sequence is its byte count
 pass	the length of a slice is the slice's byte count
+pass	the let-bound-after-helper observation is state-type-general (scalar counter)
 pass	the let-form of the dual-resume-slot arm computes (the always-worked oracle twin)
 pass	the logical-shift-drops-all-bits fold does not discard a trapping runtime operand
 pass	the magnitude of a bare-scaled quantity reads back
@@ -5595,6 +6010,7 @@ pass	the multiplicative-one and subtractive-zero identities preserve a boundary-
 pass	the multiply-by-zero annihilator does not discard a trapping runtime operand
 pass	the multiply-by-zero annihilator does not swallow a COMPILE-PROVABLE overflow in the discarded operand
 pass	the multiply-by-zero annihilator folds to zero when the discarded constant operand is total
+pass	the natural invariant construction over a VIOLATING perform result traps through the handler
 pass	the negative power agrees with dividing into the dimensionless one
 pass	the new map from a runtime-key swap holds the new value at that key
 pass	the new map from a runtime-key take has the key removed
@@ -5650,12 +6066,14 @@ pass	the selected operand decides a hoisted comparison
 pass	the selected operand decides a hoisted float equality
 pass	the sequent-shaped kernel Thm is unforgeable — building Thm.Seq outside the kernel is CDZ0214
 pass	the set De Morgan law relates difference-over-union to intersection-of-differences on runtime sets
+pass	the shadow stack UNWINDS — each level's post-region perform reaches ITS enclosing frame
 pass	the shift-by-zero identities preserve a runtime narrow UInt8 (x << 0 = x, x >> 0 = x)
 pass	the shrinking search terminates via its fuel bound rather than searching unboundedly
 pass	the sign of ZERO propagates through multiply and add per IEEE at runtime
 pass	the slice overflow guard holds on a chained slice-of-a-slice
 pass	the span between two equal Instants is zero — the inclusive lower boundary of `since`
 pass	the stacked contract's PRE fires through the @ensures layer BEFORE the perform (abortive observer)
+pass	the state-SWAP idiom — the op argument becomes the state and the OLD state returns
 pass	the swap and take value-yielding forms agree with insert and remove on the resulting map
 pass	the taken arm's checked add still overflows under the operator hoist
 pass	the tautology fold keeps a trapping shared operand
@@ -5715,13 +6133,34 @@ pass	three leaf variants in one quoted form each dispatch their own tag
 pass	three same-variant literal arms fall through in order
 pass	three sums in a tuple bind three distinct payloads
 pass	three-way compare orders (Some 3) below None per the declared discriminant order
+pass	ti1 A-B-A-B interleaved draws in ONE expression — each effect threads its own state independently
+pass	ti2b the inner arm's resume-VALUE performs the outer effect on EVERY dispatch — three dispatches, both states advancing
+pass	ti3 cross-effect resume-value feed PLUS direct body interleave — B's arm and the body both advance A
+pass	ti4 THREE-effect chained cross-feed — C's arm performs B, B's arm performs A, two C dispatches walk the whole chain twice
+pass	ti5 a FOREIGN outer perform inside the inner region — A advances inside B's body, the post-region draw sees it
+pass	tl1 THREE live handlers, each drawn in one expression — every draw dispatches past the two inner frames to its own
+pass	tl2 a THREE-frame value pipeline — innermost pick feeds middle dbl feeds outermost send, then an outer draw stamps the hundreds
+pass	tl3 the MIDDLE frame's arm resumes with an OUTERMOST draw — rv-face at depth, dispatched from under a third live frame
+pass	tl4 SAME effect handled at two depths — the inner handle shadows for its extent, the outer thread resumes after it closes
 pass	to-bytes of a sliced multibyte string is read twice and both reads see the right bytes
+pass	tp1 TWO ops each own a tuple-state SLOT — lo advances field 0, hi doubles field 1, interleaved
+pass	tp2 a SWAP op exchanges the tuple-state slots — interleaved readers observe the exchange
+pass	tp3 a NESTED tuple state ((a b) c) — the arm rebuilds the inner Fibonacci pair and bumps the outer counter per dispatch
+pass	tq1 a Q-shadow inside a TWO-effect region — P draws thread THROUGH the shadow while Q is locally rebound
+pass	tq2 the Q-shadow's SEED mixes P and Q draws — both outer threads advance before the shadow opens, and resume after
+pass	tq3 a Q-shadow wraps only the MIDDLE argument of a pure call — its neighbors dispatch to the outer P and Q frames
+pass	tr1 a TUPLE snapshot resume value — each dispatch returns (state, state*10), two snapshots differ by the stride
 pass	tree HEIGHT and BALANCE derive from insertion order over the same BST shape
 pass	triple negation of a runtime boolean is a single negation
 pass	triple-nested same-op performs — each argument is the inner perform's result
 pass	true is greater than false
 pass	true is not less than false
 pass	truncating a rational whose integer part exceeds Int64 traps rather than wrapping
+pass	tt1 a NESTED-tuple op ARG destructured two levels inside the arm — both dispatches read the live state
+pass	tt2 NESTED-tuple resume values across two dispatches — outer destructured by match, inner read by PROJECTION
+pass	tt3 a tuple ROTATED through two chained dispatches — each rotation folds the state into the moved slot
+pass	tt4 a MIXED String+Int tuple state — the arm grows the rope and folds the op arg into the counter per dispatch
+pass	tt5 an inner PAIR swapped on counter parity — a nested-tuple state machine, both slots and the counter observed
 pass	tuple access on a non-tuple is a type error
 pass	tuple access on a record is a type error
 pass	tuple access on a tuple chosen by a conditional projects the element
@@ -5758,6 +6197,7 @@ pass	two closures from one factory capture distinct values
 pass	two composed times-minus-one strength reductions round-trip a normal operand but still trap at Int64.min
 pass	two constant records with the same fields in different written order are equal
 pass	two constant sums with the same payload but different variants are not equal
+pass	two crossed LISTS compare structurally in the arm — same content from different builders
 pass	two deep ropes built in OPPOSITE orders compare equal by content
 pass	two definitions imported under the same name are rejected
 pass	two dependent utf8 bin segments each sized by its own preceding length byte
@@ -5787,6 +6227,7 @@ pass	two functions with the same body-solved arrow but different bodies reflect 
 pass	two heap-list accumulators swap slots through every tail call
 pass	two host calls consume their responses in order
 pass	two host responses combine in call order through a non-commutative operator
+pass	two host-seeded SIBLING handlers — each region's seed consumes its response in evaluation order
 pass	two keys sharing a full 32-bit hash occupy one CHAMP collision node as distinct Set elements
 pass	two lists are concatenated into one flat list
 pass	two lists of different length are unequal, not a type error
@@ -5801,6 +6242,7 @@ pass	two narrow tuple elements are projected and compared
 pass	two nested recursive const-closure drivers (filter under fold) emit valid wasm and compute correctly
 pass	two newtypes over the SAME inner type do not cross-assign
 pass	two pattern keys match with one satisfied by the runtime-keyed entry
+pass	two perform-drawn quantities of one dimension ADD — same-unit combine over two crossings
 pass	two performs as the two ARGUMENTS of a pure USER function thread the state left-to-right
 pass	two performs bound by nested lets thread the handler state in order
 pass	two performs of a MULTI-parameter op each combine both args with the state advancing between them
@@ -5892,7 +6334,13 @@ pass	updating a record field changes its type to the new value's
 pass	updating a record field preserves the other fields' values
 pass	updating a record field replaces its value
 pass	updating an absent record field is rejected
+pass	uv2 a @requires-guarded fn fed by DRAWS — the contract checks effectful argument values at each call
+pass	uv3 the handler ARM calls a @requires-guarded helper — the contract checks the live state per dispatch
+pass	uv4 a RELATIONAL @ensures (ret > x) over a TWO-draw body — the postcondition compares the effectful result to the arg, twice
 pass	value-eq CONTROL: a runtime slice compares equal to a flat Bytes of the same content
+pass	wa1 wrapping-add as the next-state — a near-MAX seed wraps to a concrete near-MIN value on the second draw
+pass	wa2 wrapping-add of the op ARG and state in the resume value — wrap, exact-MAX, and identity rows
+pass	wa3 the wrap WALK — three draws from a MAX seed step MAX, MIN, MIN+1 through wrapping-add(+1), checked '+' beside
 pass	when two abortive performs sit on one spine the FIRST (leftmost) abort wins
 pass	widening a runtime narrow-width unsigned integer to Int64 zero-extends (total, emits)
 pass	widening a runtime signed narrow integer to Int64 sign-extends (total, emits)
@@ -5918,6 +6366,15 @@ pass	wrapping-sub of the minimum integer from zero wraps back to the minimum
 pass	wrapping-sub on a runtime Int8 wraps at its signed min boundary
 pass	wrapping-sub on a runtime UInt8 wraps modulo 256
 pass	wrapping-sub wraps a boundary-crossing runtime Int64 at the min boundary
+pass	wx1 the state thread WRAPS at Int64.max — three draws straddle the wraparound and the comparisons see the seam
+pass	wx2 Int64.min and Int64.max cross the dispatch as OP ARGUMENTS and come back exact — a count arm tallies the trips
+pass	wx3 Int64.min and Int64.max ride as SUM payloads through dispatch — variant chosen by state parity, payloads verified exact
+pass	wx4 the ARM doubles its argument with wrapping-mul — MAX wraps to -2, MIN to 0, a small value stays exact, count rides along
+pass	wx5 the state STEPS by wrapping-sub of MAX each draw — two hops cross the seam in opposite directions
+pass	wx6 wrapping increments CHAINED hop-to-hop — MAX-1 crosses the seam inside a nested three-op chain, count pins the trips
+pass	za1 literal-arm dispatch on a draw — the MATCHED arm performs again, both calls exercised
+pass	za2 a COMPUTED scrutinee (difference of two draws) selects the performing arm at one input only
+pass	za3 NESTED literal-arm dispatch — each level matches a let-bound draw, the innermost arm reads a third
 pass	zero divided by a runtime value folds to zero but keeps the zero-divisor guard
 pass	α-equivalence (aconv) recognizes (λx.x) and (λy.y) as the same term up to bound-variable renaming
 pass	α-equivalence handles nesting and distinguishes a bound variable from a same-numbered free variable
@@ -5954,7 +6411,6 @@ todo	a closed literal closure forwarded through const-wrapper hops is not a fals
 todo	a constant-try helper that fails feeds the None arm's fallback into resume
 todo	a cross-handler foreign-perform op-arg into a MATCH-shaped-resume arm declines cleanly (completeness gap)
 todo	a mutually-recursive group with a BRANCH-PERFORM sharing a strict expr with the mutual call declines cleanly (adv-69 rw4 sub-face)
-pass	a performing scrutinee matched by a PERFORMING GUARD is a COMPILE ERROR (breaker finding #9, now CDZ0407)
 todo	a recursive nested-op performer whose resume-VALUE reads the inner state around the outer perform declines cleanly
 todo	a recursive scalar-walk classifies characters across a multibyte String entry arg
 todo	a runtime bin match decodes a FINAL constant-size utf8 segment

--- a/spec/semantics/02-binding-and-control.sexp
+++ b/spec/semantics/02-binding-and-control.sexp
@@ -4114,7 +4114,7 @@
 (case "a record binding pattern naming an absent field is rejected"
   (doc    "The contrast: a record binding pattern that names a field the bound value's record type does NOT
            have is a type mismatch (CDZ0203), not a silent miss. `(let (((record (nope a)) (record (x 3) (y
-           4)))) a)` names `nope`, absent from `(Record (x Int64) (y Int64))`. Pins that a record binding
+           4)))) a)` names `nope`, absent from `(Record (: x Int64) (: y Int64))`. Pins that a record binding
            pattern's fields must exist on the value — the record analogue of a tuple pattern's arity check.")
   (input  (let (((record (nope a)) (record (x 3) (y 4)))) a))
   (error  CDZ0203))

--- a/spec/semantics/05-compound-types.sexp
+++ b/spec/semantics/05-compound-types.sexp
@@ -110,29 +110,28 @@
   (input      (record (a 1) (b 2) (a 3)))
   (error      CDZ0201))
 
-; The same fixed-field-set rule governs a record TYPE, not only a record VALUE. `(Record (x Int64) (x
-; Bool))` — the capital-`R` TYPE form (distinct from the lowercase `record` value alias) — names field
+; The same fixed-field-set rule governs a record TYPE, not only a record VALUE. `(Record (: x Int64) (: x ; Bool))` — the capital-`R` TYPE form (distinct from the lowercase `record` value alias) — names field
 ; `x` twice, so it is ill-formed (CDZ0201, #A Record Has A Fixed Set Of Named Fields), the type-form twin
 ; of the `(record (a 1) (a 2))` value reject above. The duplicate is not silently deduplicated to a
-; last-wins single field (which would compile `(Record (x Int64) (x Bool))` as `(Record (x Bool))`) — a
+; last-wins single field (which would compile `(Record (: x Int64) (: x Bool))` as `(Record (: x Bool))`) — a
 ; repeated field name is almost always an author error, so it is rejected wherever a record type is
 ; written: an annotation's type position and a variant payload's type both catch it.
 
 (case "a record TYPE with a duplicate field name is a type error"
-  (doc    "`(Record (x Int64) (x Bool))` names field `x` twice in a record TYPE (the capital-`R` type
+  (doc    "`(Record (: x Int64) (: x Bool))` names field `x` twice in a record TYPE (the capital-`R` type
            form) — a record's field names are a fixed SET whether written as a value or a type, so this is
            ill-formed and rejected (CDZ0201), the type-form twin of the value-form `(record (a 1) (a 2))`
-           reject. Not silently deduplicated to `(Record (x Bool))` by a last-wins insert. Here the type is
+           reject. Not silently deduplicated to `(Record (: x Bool))` by a last-wins insert. Here the type is
            written in an annotation's type position.")
-  (input      (: (record (x 1)) (Record (x Int64) (x Bool))))
+  (input      (: (record (x 1)) (Record (: x Int64) (: x Bool))))
   (error      CDZ0201))
 
 (case "a duplicate field in a variant's record-type payload is a type error"
   (doc    "The duplicate-field record TYPE is caught wherever a record type is written, not only in an
-           annotation: a sum variant whose payload type is `(Record (x Int64) (x Bool))` names `x` twice
+           annotation: a sum variant whose payload type is `(Record (: x Int64) (: x Bool))` names `x` twice
            and is rejected (CDZ0201). Pins that the fixed-field-set check reaches a record type nested in a
            type declaration, the variant-payload companion of the annotation case above.")
-  (input      (do (type T (V (Record (x Int64) (x Bool)))) (def (main) 1) (export main)))
+  (input      (do (type T (V (Record (: x Int64) (: x Bool)))) (def (main) 1) (export main)))
   (error      CDZ0201))
 
 ; A SUM's variant names are a set too, exactly as a record's field names are — type-system.md #The
@@ -1489,7 +1488,7 @@
   (input  (do
             (def (f n) (if (= n 0) (record (a n) (b 7)) (f (- n 1))))
             (def (main) (f 3)) (export main)))
-  (output (: (record (a 0) (b 7)) (Record (a Int64) (b Int64)))))
+  (output (: (record (a 0) (b 7)) (Record (: a Int64) (: b Int64)))))
 
 (case "a nested runtime tuple built behind a recursive call escapes to the host"
   (doc    "`(tuple n (tuple n n))` with n=0 (reached via recursion so it does NOT constant-fold) →
@@ -1511,7 +1510,7 @@
   (input  (do
             (def (f n) (if (= n 0) (record (x n) (y (tuple n 1))) (f (- n 1))))
             (def (main) (f 2)) (export main)))
-  (output (: (record (x 0) (y (tuple 0 1))) (Record (x Int64) (y (Tuple Int64 Int64))))))
+  (output (: (record (x 0) (y (tuple 0 1))) (Record (: x Int64) (: y (Tuple Int64 Int64))))))
 
 (case "a recursive sum constructor with a CHECKED-ARITH payload and a recursive-call sibling payload"
   (doc    "A recursive `map` over a linked list `(type ILst (INil) (ICons Int64 ILst))` whose `ICons`
@@ -1649,7 +1648,7 @@
   (input  (do
             (def (f n) (record (a n) (b 1)))
             (def (main) (f 3)) (export main)))
-  (output (: (record (a 3) (b 1)) (Record (a Int64) (b Int64)))))
+  (output (: (record (a 3) (b 1)) (Record (: a Int64) (: b Int64)))))
 
 (case "record fields render in canonical (key-sorted) order regardless of source order"
   (doc    "`(record (b n) (a 1))` with n=2 renders `(record (a 1) (b 2))` — fields in sorted key
@@ -1659,7 +1658,7 @@
   (input  (do
             (def (f n) (record (b n) (a 1)))
             (def (main) (f 2)) (export main)))
-  (output (: (record (a 1) (b 2)) (Record (a Int64) (b Int64)))))
+  (output (: (record (a 1) (b 2)) (Record (: a Int64) (: b Int64)))))
 
 (case "a list with a runtime element is returned as a program result"
   (doc    "`(list n 2 3)` with n=1 produces `(list 1 2 3)` — a list one of whose elements is a runtime
@@ -3995,7 +3994,7 @@
   (input  (do
             (def (f n) (record (x n) (y (tuple n 1))))
             (def (main) (f 5)) (export main)))
-  (output (: (record (x 5) (y (tuple 5 1))) (Record (x Int64) (y (Tuple Int64 Int64))))))
+  (output (: (record (x 5) (y (tuple 5 1))) (Record (: x Int64) (: y (Tuple Int64 Int64))))))
 
 ; --- A constructor whose payload is itself a constructor keeps its own variant tag -------
 ; A Sum value is (variant-tag, payload); its canonical form is `(Variant payload)`
@@ -9815,8 +9814,7 @@
   (error     CDZ0201))
 
 (case "a variant carrying a RECORD payload constructs and matches"
-  (doc    "The Record-payload companion of the Tuple-payload cases: `(type P (Pt (Record (x Int64) (y
-           Int64))) O)` declares `P.Pt` carrying a two-field record. `(P.Pt (record (x 3) (y 4)))`
+  (doc    "The Record-payload companion of the Tuple-payload cases: `(type P (Pt (Record (: x Int64) (: y Int64))) O)` declares `P.Pt` carrying a two-field record. `(P.Pt (record (x 3) (y 4)))`
            constructs it, and a `((P.Pt r) …)` arm binds the whole record payload as `r`, projected
            `(+ (. r x) (. r y))` → 7. Pins that a RECORD payload type is a real single payload (the
            record companion of the Tuple payload). A record field name is a LABEL, not a type parameter:
@@ -9825,7 +9823,7 @@
            `P.Pt` would look NULLARY and reject the construction (CDZ0201 'a nullary variant takes the
            unit value'). Must construct and fold to 7.")
   (input  (do
-            (type P (Pt (Record (x Int64) (y Int64))) O)
+            (type P (Pt (Record (: x Int64) (: y Int64))) O)
             (def (sum r) (+ (. r x) (. r y)))
             (def (main) (match (P.Pt (record (x 3) (y 4))) ((P.Pt r) (sum r)) (P.O 0)))
             (export main)))
@@ -9878,7 +9876,7 @@
            resource path, its lowercase field names carried through as labels (not misread as type
            parameters).")
   (input  (do
-            (type P (Pt (Record (x Int64) (y Int64))) O)
+            (type P (Pt (Record (: x Int64) (: y Int64))) O)
             (def (main) (P.Pt (record (x 1) (y 2)))) (export main)))
   (output (: (Pt (record (x 1) (y 2))) P)))
 
@@ -10101,13 +10099,13 @@
   (output (: 15 Int64)))
 
 (case "a generic sum with a type parameter inside a record payload constructs and projects"
-  (doc    "The record companion: `(type Box (B (Record (val a))) N)` — a generic sum whose variant carries
+  (doc    "The record companion: `(type Box (B (Record (: val a))) N)` — a generic sum whose variant carries
            a RECORD payload whose field type is the parameter. `(Box.B (record (val 7)))` instantiates `a =
            Int64`; the `(Box.B r)` arm binds the record payload and `(. r val)` projects 7. Pins that a
            type parameter inside a RECORD field type is threaded through the constructor scheme (the field
            NAME `val` stays a label), the record sibling of the tuple-payload case above.")
   (input  (do
-            (type Box (B (Record (val a))) N)
+            (type Box (B (Record (: val a))) N)
             (def (main) (match (Box.B (record (val 7))) ((Box.B r) (. r val)) (Box.N 0)))
             (export main)))
   (output (: 7 Int64)))
@@ -12244,14 +12242,14 @@
 
 (case "a recursive sum recurses THROUGH a record-typed payload"
   (doc    "The recursion runs through a RECORD field rather than a tuple element: `(type Tree (Leaf Int64)
-           (Br (Record (l Tree) (r Tree) (w Int64))))` — the `Br` variant's payload is a record whose `l`
+           (Br (Record (: l Tree) (: r Tree) (: w Int64))))` — the `Br` variant's payload is a record whose `l`
            and `r` fields are the recursive `Tree` (indirection sits inside the record). A fold reads the
            record fields (`(. rec l)`, `(. rec w)`) and recurses. `(sum (Br {l=Leaf 7, r=Leaf 2, w=1}))`
            = 1 + 7 + 2 = 10. Pins that the Box/heap indirection decision reaches THROUGH a record-typed
            payload the same way it reaches through a tuple payload — the record companion of the existing
            `(Cons (Tuple … Tree))` recursive-list shape.")
   (input  (do
-            (type Tree (Leaf Int64) (Br (Record (l Tree) (r Tree) (w Int64))))
+            (type Tree (Leaf Int64) (Br (Record (: l Tree) (: r Tree) (: w Int64))))
             (def (sum (: t Tree))
               (match t
                 ((Tree.Leaf n)  n)
@@ -13262,15 +13260,15 @@
 
 (case "comparing same-shape nominal types is a type error"
   (doc    "Witnesses type-system.md #User Types Are Declarable As Nominal Or Structural. `Point` and
-           `Vector` are nominal types over the SAME underlying record shape `(Record (x Int64) (y Int64))`
+           `Vector` are nominal types over the SAME underlying record shape `(Record (: x Int64) (: y Int64))`
            — but a nominal type's identity is its declaration, not its shape, so they are distinct. The
            compiler tracks nominal identity and rejects comparing `(Point.Mk …)` with `(Vector.Mk …)`
            across the nominal boundary (CDZ0202). The record sibling of the nominal-SUM case below; a
            nominal type is a name tagging any structural type (§Nominal Is An Orthogonal Modifier Over Any
            Structural Type — record, tuple, or sum).")
   (input    (do
-              (type Point  (Mk (Record (x Int64) (y Int64))))
-              (type Vector (Mk (Record (x Int64) (y Int64))))
+              (type Point  (Mk (Record (: x Int64) (: y Int64))))
+              (type Vector (Mk (Record (: x Int64) (: y Int64))))
               (= (Point.Mk (record (x 0) (y 0))) (Vector.Mk (record (x 0) (y 0))))))
   (error    CDZ0202))
 
@@ -13290,7 +13288,7 @@
            to the untagged shape it was declared distinct from (unwrap the nominal to compare the
            underlying value).")
   (input    (do
-              (type Point (Mk (Record (x Int64) (y Int64))))
+              (type Point (Mk (Record (: x Int64) (: y Int64))))
               (= (Point.Mk (record (x 0) (y 0))) (record (x 0) (y 0)))))
   (error    CDZ0202))
 
@@ -13299,7 +13297,7 @@
            violation regardless of which operand carries the tag — CDZ0202. Pins that the nominal tag
            is checked on either side of the comparison, not only the left.")
   (input    (do
-              (type Point (Mk (Record (x Int64) (y Int64))))
+              (type Point (Mk (Record (: x Int64) (: y Int64))))
               (= (record (x 0) (y 0)) (Point.Mk (record (x 0) (y 0))))))
   (error    CDZ0202))
 
@@ -14373,7 +14371,7 @@
            hash walks fields in the descriptor's canonical order at every slot; a first-field-only hash
            would collide the 6-7 keys sharing each x residue and misroute the descent.")
   (input  (do
-            (def (fill (: i Int64) (: m (Map (Record (x Int64) (y Int64)) Int64)))
+            (def (fill (: i Int64) (: m (Map (Record (: x Int64) (: y Int64)) Int64)))
               (if (= i 0) m (fill (- i 1) (Map.insert m (record (x (% i 6)) (y (/ i 6))) i))))
             (def (main (: n Int64))
               (do
@@ -14390,9 +14388,9 @@
            exactly as the scalar churn pins require — the two-field key layout leaves no residue in the
            canonical form.")
   (input  (do
-            (def (grow (: i Int64) (: n Int64) (: m (Map (Record (x Int64) (y Int64)) Int64)))
+            (def (grow (: i Int64) (: n Int64) (: m (Map (Record (: x Int64) (: y Int64)) Int64)))
               (if (= i n) m (grow (+ i 1) n (Map.insert m (record (x (+ i 100)) (y i)) i))))
-            (def (shrink (: i Int64) (: n Int64) (: m (Map (Record (x Int64) (y Int64)) Int64)))
+            (def (shrink (: i Int64) (: n Int64) (: m (Map (Record (: x Int64) (: y Int64)) Int64)))
               (if (= i n) m (shrink (+ i 1) n (Map.remove m (record (x (+ i 100)) (y i))))))
             (def (main (: n Int64))
               (do
@@ -15082,8 +15080,8 @@
            (sorted) field order `(record (hi 15) (lo 5))`. Two calls pin that both fields track the
            argument, not a constant.")
   (input  (do (def (main (: a Int64)) (record (lo a) (hi (+ a 10)))) (export main)))
-  (call   main (: 5 Int64)) (output (: (record (hi 15) (lo 5)) (Record (hi Int64) (lo Int64))))
-  (call   main (: 0 Int64)) (output (: (record (hi 10) (lo 0)) (Record (hi Int64) (lo Int64)))))
+  (call   main (: 5 Int64)) (output (: (record (hi 15) (lo 5)) (Record (: hi Int64) (: lo Int64))))
+  (call   main (: 0 Int64)) (output (: (record (hi 10) (lo 0)) (Record (: hi Int64) (: lo Int64)))))
 
 (case "a parameterized export returns a built-in Option computed from its argument"
   (doc    "The built-in `Option` companion (the sum case above used a user `(type Option …)`): `main(a)`
@@ -15199,8 +15197,8 @@
 (case "a record-parameter export returns a tuple computed from its fields"
   (doc    "A RECORD parameter crosses as a `tuple<…>` in canonical sorted-key order; `main((record (x 3)
            (y 8))) = (tuple 8 3)` swaps the fields. Proves the record-param + tuple-result compound path.")
-  (input  (do (def (main (: p (Record (x Int64) (y Int64)))) (tuple (. p y) (. p x))) (export main)))
-  (call   main (: (record (x 3) (y 8)) (Record (x Int64) (y Int64))))
+  (input  (do (def (main (: p (Record (: x Int64) (: y Int64)))) (tuple (. p y) (. p x))) (export main)))
+  (call   main (: (record (x 3) (y 8)) (Record (: x Int64) (: y Int64))))
   (output (: (tuple 8 3) (Tuple Int64 Int64))))
 
 (case "an export mixing a scalar and a tuple parameter returns a list from both"
@@ -15246,8 +15244,8 @@
 (case "an export with a record-with-a-tuple-field parameter returns a list from its leaves"
   (doc    "A record whose field is a tuple is likewise a nested fixed-shape compound; its fields cross in
            canonical sorted-key order. `main((record (pt (tuple 10 20)) (n 30))) = (list 10 20 30)`.")
-  (input  (do (def (main (: p (Record (pt (Tuple Int64 Int64)) (n Int64)))) (list (. (. p pt) 0) (. (. p pt) 1) (. p n))) (export main)))
-  (call   main (: (record (pt (tuple 10 20)) (n 30)) (Record (pt (Tuple Int64 Int64)) (n Int64))))
+  (input  (do (def (main (: p (Record (: pt (Tuple Int64 Int64)) (: n Int64)))) (list (. (. p pt) 0) (. (. p pt) 1) (. p n))) (export main)))
+  (call   main (: (record (pt (tuple 10 20)) (n 30)) (Record (: pt (Tuple Int64 Int64)) (: n Int64))))
   (output (: (list 10 20 30) (List Int64))))
 
 (case "an export mixing a scalar and a nested-tuple parameter returns a list from both"
@@ -15258,7 +15256,7 @@
   (output (: (list 9 5 7) (List Int64))))
 
 (case "a composed call over a record-transforming function with an arithmetic field compiles"
-  (doc    "`(f (f (record (a 0) (b 5))))` where `f : (Record (a Int64) (b Int64)) -> (Record …)`
+  (doc    "`(f (f (record (a 0) (b 5))))` where `f : (Record (: a Int64) (: b Int64)) -> (Record …)`
            increments field `a` via `(+ (. r a) 1)` and copies `b`. `f` applied twice gives {a:2, b:5},
            so `.a` = 2. The record is BOTH the inner call's result and the outer call's argument. Each
            field of a `Core::Record` is materialized into the value-heap array; a checked-arith field
@@ -15270,7 +15268,7 @@
            call. The fix advances each field's scratch base past the running high-water (the disjoint-slot
            discipline tuples/lists already use). Expected: 2.")
   (input  (do
-            (def (f (: r (Record (a Int64) (b Int64))))
+            (def (f (: r (Record (: a Int64) (: b Int64))))
               (record (a (+ (. r a) 1)) (b (. r b))))
             (def (main) (. (f (f (record (a 0) (b 5)))) a))
             (export main)))
@@ -16795,7 +16793,7 @@
            parameter `r` — `(f (record (x 3) (y 4)))` binds `a`=3, `b`=4 → 7 (a real heap read, not a const
            fold). Earlier the record-match arm was a not-yet-implemented decline (CDZ0201) and a field
            reference leaked a misleading 'unbound name' — this case now pins the working destructure.")
-  (input  (do (def (f (: r (Record (x Int64) (y Int64))))
+  (input  (do (def (f (: r (Record (: x Int64) (: y Int64))))
                 (match r ((record (x a) (y b)) (+ a b))))
               (def (main) (f (record (x 3) (y 4))))
               (export main)))
@@ -16804,10 +16802,10 @@
 (case "a record match pattern binds fields by name — partial and out of order"
   (doc    "A record match projects each field by NAME, not position: a PARTIAL pattern names a subset of
            the fields, and the pattern MAY name them in a different order than the record's type. Here
-           `(record (z b) (a c))` over a `(Record (a Int64) (z Int64))` binds `c` to field `a` and `b` to
+           `(record (z b) (a c))` over a `(Record (: a Int64) (: z Int64))` binds `c` to field `a` and `b` to
            field `z` regardless of written order → `100*c + b` = 100*10 + 20 = 1020. The match twin of the
            record BINDING pattern's field-order independence — a flexibility a positional tuple pattern lacks.")
-  (input  (do (def (f (: r (Record (a Int64) (z Int64))))
+  (input  (do (def (f (: r (Record (: a Int64) (: z Int64))))
                 (match r ((record (z b) (a c)) (+ (* 100 c) b))))
               (def (main) (f (record (a 10) (z 20))))
               (export main)))
@@ -16842,7 +16840,7 @@
            (_ 99))` — the record arm binds field `x` and the `_` covers the rest. Over `(record (x 3))` the
            record arm is taken → 3. (An UNGUARDED record arm; a GUARDED record arm is a later increment —
            it currently declines cleanly rather than lowering, pending the guard×record leaf gating.)")
-  (input  (do (def (f (: r (Record (x Int64))))
+  (input  (do (def (f (: r (Record (: x Int64))))
                 (match r ((record (x a)) a) (_ 99)))
               (def (main) (f (record (x 3))))
               (export main)))
@@ -16855,7 +16853,7 @@
            `(record (x 9) (y 4))` it does not → falls through to the catch-all → -1. Pins that a record
            match arm supports a refutable field probe (not only bare-binder fields), the record analogue of
            `(tuple 3 b)` / `(Some 0)`. Two `(call …)` values drive the runtime scrutinee through `f`.")
-  (input  (do (def (f (: r (Record (x Int64) (y Int64))))
+  (input  (do (def (f (: r (Record (: x Int64) (: y Int64))))
                 (match r ((record (x 3) (y b)) b) (_ -1)))
               (def (main (: k Int64)) (f (record (x k) (y 4))))
               (export main)))
@@ -16877,7 +16875,7 @@
            scrutinee a genuinely-runtime materialized value (a constant record would fold the fields away and
            never exercise the projection). x=5 → guard holds → 5+6 = 11; x=-5 → guard fails → -1; x=0 →
            guard `(> 0 0)` fails → -1.")
-  (input  (do (def (f (: r (Record (x Int64) (y Int64))))
+  (input  (do (def (f (: r (Record (: x Int64) (: y Int64))))
                 (match r ((guard (record (x a) (y b)) (> a 0)) (+ a b)) (_ -1)))
               (def (main (: k Int64)) (f (record (x k) (y (+ k 1)))))
               (export main)))
@@ -16944,7 +16942,7 @@
            compiles — so the fault is reference-specific; the coded decline surfaces it in `cdz check` on a
            parameterized body, not only the emit walk. The nested-in-compound twin of the top-level
            record-match + the record-BINDING nested-compound declines.")
-  (input  (do (def (f (: t (Tuple (Record (x Int64)) Int64)))
+  (input  (do (def (f (: t (Tuple (Record (: x Int64)) Int64)))
                 (match t ((tuple (record (x a)) c) (+ a c))))
               (export f)))
   (error  CDZ0201))
@@ -17023,7 +17021,7 @@
            4 × 3 = 12. A hoist guard or child retain keyed to positional projections misses the
            field-keyed extraction.")
   (input  (do
-            (def (go (: r (Record (f (List Int64)))) (: n Int64) (: acc Int64))
+            (def (go (: r (Record (: f (List Int64)))) (: n Int64) (: acc Int64))
               (if (= n 0) acc
                   (go r (- n 1) (+ acc (List.len (List.push (. r f) 9))))))
             (def (main (: d Int64))
@@ -17363,7 +17361,7 @@
 ; type)` annotation triple, `(type DbBox (DbBox (Record (: a Int64) (: b Int64))))` — must register the
 ; payload so the variant is NON-nullary and its record field is readable. The ML record-type surface `{a:
 ; Int64, b: Int64}` lowers each field to a 3-element `(: a Int64)` node (vs the 2-element `(a Int64)` pair
-; the s-expr `(Record (a Int64) …)` spelling uses). `typeval_of`'s RecordCtor decode originally accepted only
+; the s-expr `(Record (: a Int64) …)` spelling uses). `typeval_of`'s RecordCtor decode originally accepted only
 ; the 2-element pair, so the ML-surfaced structural-record payload decoded to `None` → the variant read
 ; NULLARY (CDZ0201 "the variant DbBox is nullary … carries no payload" at construction, "not a variant of the
 ; matched type" at the pattern). Building `(DbBox (record (a 1) (b 2)))`, matching it, and reading field `a`

--- a/spec/semantics/07-type-system.sexp
+++ b/spec/semantics/07-type-system.sexp
@@ -594,29 +594,29 @@
   (error  CDZ0203))
 
 ; The parameter check applies to a RECORD's field type too, not only a sum's payload or a list's
-; element. `(record (a 1))` has type `(Record (a Int64))`; annotated `(Record (a Bool))`, the head
+; element. `(record (a 1))` has type `(Record (: a Int64))`; annotated `(Record (: a Bool))`, the head
 ; `Record` and the field name `a` agree but the field's type `Int64` cannot unify with `Bool` — a
 ; contradiction (CDZ0203), the record analogue of the list-element and option-payload cases above. A
 ; record's fields are the third structural type (type-system.md #The Structural Types Are Record, Tuple,
 ; And Sum) beside the tuple's positions and the sum's payload; the annotation-parameter check the cases
 ; above pin for a tuple position, a sum payload, and a list element MUST also cover a record field, or a
 ; checker that verifies only the head `Record` and the field NAMES silently accepts the ill-typed
-; program and runs it, returning `(record (a 1))` under a declared `(Record (a Bool))` — the same
+; program and runs it, returning `(record (a 1))` under a declared `(Record (: a Bool))` — the same
 ; annotation-replaces-inference the section forbids. A generation that does not yet check a record
 ; field's type parameter declines rather than accepting (reject-don't-miscompile).
 
 (case "a record annotated with the wrong field type is rejected"
-  (doc    "`(: (record (a 1)) (Record (a Bool)))` annotates a `(Record (a Int64))` as `(Record (a Bool))`:
+  (doc    "`(: (record (a 1)) (Record (: a Bool)))` annotates a `(Record (: a Int64))` as `(Record (: a Bool))`:
            the head `Record` and the field name `a` match but the field's type `Int64` cannot unify with
            `Bool`, a contradiction (CDZ0203), the record companion of the list-element and option-payload
            cases above. Pins that the annotation's parameter check covers a record's field type — the
            third structural type beside a tuple's positions and a sum's payload — not only a sum's payload
            or a list's element. A checker that stops at the head `Record` and the field names silently
            accepts the ill-typed program and runs it, returning `(record (a 1))` under a declared
-           `(Record (a Bool))` (type-system.md #Annotations Constrain, Never Contradict). A generation
+           `(Record (: a Bool))` (type-system.md #Annotations Constrain, Never Contradict). A generation
            that does not yet check a record field's type declines rather than accepting
            (reject-don't-miscompile).")
-  (input  (: (record (a 1)) (Record (a Bool))))
+  (input  (: (record (a 1)) (Record (: a Bool))))
   (error  CDZ0203))
 
 ; --- A record's field SET must match the annotation, not only each field's type ------------
@@ -624,37 +624,36 @@
 ; mismatch: the value's set of field names differs from the annotation's — a MISSING field (the value
 ; lacks one the annotation names) or an EXTRA field (the value carries one the annotation does not). A
 ; record's shape is its fixed set of named fields (type-system.md #A Record Has A Fixed Set Of Named
-; Fields), so `(Record (a Int64))` and `(Record (a Int64) (b Int64))` are DIFFERENT types — the check is
+; Fields), so `(Record (: a Int64))` and `(Record (: a Int64) (: b Int64))` are DIFFERENT types — the check is
 ; over the whole field set, not a subset/superset relaxation (that widening is row polymorphism, a
 ; separate opt-in — 15-rows-and-open-sums). Each mismatch is CDZ0203 and the diagnostic names the
 ; offending field (missing `b` / no such field `c`), the actionable add-missing / delete-extra repair.
 
 (case "a record missing a field the annotation names is rejected"
-  (doc    "`(: (record (a 1)) (Record (a Int64) (b Int64)))` annotates a one-field record as a two-field
-           type — the value is MISSING field `b`. The field sets differ, so the value's type `(Record (a
-           Int64))` does not match the annotation `(Record (a Int64) (b Int64))` (CDZ0203, naming the
+  (doc    "`(: (record (a 1)) (Record (: a Int64) (: b Int64)))` annotates a one-field record as a two-field
+           type — the value is MISSING field `b`. The field sets differ, so the value's type `(Record (: a Int64))` does not match the annotation `(Record (: a Int64) (: b Int64))` (CDZ0203, naming the
            missing `b`). A record type is not satisfied by a value carrying a subset of its fields — field
            presence is static (the row-poly widening that would accept this is a separate opt-in). The
            field-SET companion of the wrong-field-TYPE case above.")
-  (input  (: (record (a 1)) (Record (a Int64) (b Int64))))
+  (input  (: (record (a 1)) (Record (: a Int64) (: b Int64))))
   (error  CDZ0203))
 
 (case "a record carrying a field the annotation does not name is rejected"
-  (doc    "The dual: `(: (record (a 1) (b 2) (c 3)) (Record (a Int64) (b Int64)))` carries an EXTRA field
+  (doc    "The dual: `(: (record (a 1) (b 2) (c 3)) (Record (: a Int64) (: b Int64)))` carries an EXTRA field
            `c` the annotation does not name. The field sets differ, so it is rejected (CDZ0203, 'no such
            field `c` on the expected record'). A record value is not accepted against a type with FEWER
            fields — the extra field is not silently dropped. Pins the superset direction of the field-set
            check (the value has more fields than the type).")
-  (input  (: (record (a 1) (b 2) (c 3)) (Record (a Int64) (b Int64))))
+  (input  (: (record (a 1) (b 2) (c 3)) (Record (: a Int64) (: b Int64))))
   (error  CDZ0203))
 
 (case "a record whose field is misnamed is both missing and extra"
-  (doc    "`(: (record (a 1) (x 2)) (Record (a Int64) (b Int64)))` names its second field `x` where the
+  (doc    "`(: (record (a 1) (x 2)) (Record (: a Int64) (: b Int64)))` names its second field `x` where the
            annotation expects `b` — so relative to the annotation the value is simultaneously MISSING `b`
            and carrying an EXTRA `x`. Rejected (CDZ0203) with both faults named ('missing field `b`; no
            such field `x`'). Pins that a single misnamed field surfaces as the combined field-set
            mismatch, the shape a field-name typo takes.")
-  (input  (: (record (a 1) (x 2)) (Record (a Int64) (b Int64))))
+  (input  (: (record (a 1) (x 2)) (Record (: a Int64) (: b Int64))))
   (error  CDZ0203))
 
 ; The variant-payload TYPE check must fire wherever the constructor appears — including as the direct
@@ -778,12 +777,12 @@
 
 (case "addition of two records is rejected — a record is not a number"
   (doc    "`(+ r q)` on two same-typed Records is rejected (CDZ0201, 'arithmetic is not defined on
-           (Record (a Int64))'). A Record has no concatenation, so — unlike String/List — no fix is
+           (Record (: a Int64))'). A Record has no concatenation, so — unlike String/List — no fix is
            offered, only the honest message. Pins that the numeric-operand requirement rejects a compound
            record, the companion of the list case with no concat rewrite. Runtime operands (parameters),
            so the fault is the operator's, not a fold.")
   (input  (do
-            (def (f (: r (Record (a Int64))) (: q (Record (a Int64)))) (+ r q))
+            (def (f (: r (Record (: a Int64))) (: q (Record (: a Int64)))) (+ r q))
             (def (main) (f (record (a 1)) (record (a 2)))) (export main)))
   (error  CDZ0201))
 
@@ -926,7 +925,7 @@
 ; typing, the companion of the cross-kind cases above.
 
 (case "equality of two records with different field sets is a type error"
-  (doc    "`(= (record (x 1)) (record (y 2)))` compares a `(Record (x Int64))` with a `(Record (y Int64))`
+  (doc    "`(= (record (x 1)) (record (y 2)))` compares a `(Record (: x Int64))` with a `(Record (: y Int64))`
            — same KIND (both records) but different field SETS, so different types (a record's shape is its
            field set). Rejected CDZ0203, the diagnostic naming the delta (missing `x`; no such field `y`).
            Pins that `=` requires matching field sets, not merely that both operands are records — the
@@ -1662,7 +1661,7 @@
 
 (case "Type.eq compares a RECORD type-value structurally, by field types"
   (doc    "`Type.of` on a record value reflects its structural `Ty::Record` type, compared by field name +
-           type. `(Type.of (record (x 1) (y \"a\")))` is `(Record (x Int64) (y String))`: equal to another
+           type. `(Type.of (record (x 1) (y \"a\")))` is `(Record (: x Int64) (: y String))`: equal to another
            record of the same field-name-and-type set regardless of values (→ true), but distinct when a
            field's TYPE differs — `(y String)` vs `(y Int64)` → false. `1 + 0 = 1`. Pins that a record
            type-value's equality carries each field's type (the record analogue of the tuple case above).")
@@ -1856,8 +1855,8 @@
   (doc    "The record-field position of the function-domain reflection family (coverage companion to the
            reflected_ty domain-grounding fixes). A function in a record field `(record (fld f))` is grounded
            from its body like a tuple/list element: `f x = x + 1` is `(-> Int64 Int64)` and `g b = if b 0 1`
-           is `(-> Bool Int64)`, so `(record (fld f))` reflects `(Record (fld (-> Int64 Int64)))` and
-           `(record (fld g))` reflects `(Record (fld (-> Bool Int64)))` — distinct → `Type.eq` false; but
+           is `(-> Bool Int64)`, so `(record (fld f))` reflects `(Record (: fld (-> Int64 Int64)))` and
+           `(record (fld g))` reflects `(Record (: fld (-> Bool Int64)))` — distinct → `Type.eq` false; but
            `(record (fld f))` vs `(record (fld f2))` (both `(-> Int64 Int64)`) is true. `0 + 100 = 100`.")
   (input  (do
             (def (f x) (+ x 1))

--- a/spec/semantics/09-functions.sexp
+++ b/spec/semantics/09-functions.sexp
@@ -1358,14 +1358,14 @@
 ; both also member projections — keep their own paths.
 
 (case "a function stored in a record field of a sum payload is called after a match"
-  (doc    "`(type H (M (Record (f (-> Int64 Int64)) (n Int64))))` carries a record with a FUNCTION field
+  (doc    "`(type H (M (Record (: f (-> Int64 Int64)) (: n Int64))))` carries a record with a FUNCTION field
            `f` and a data field `n`. Matching binds the whole record to `rec`; `((. rec f) rec.n)` projects
            the fn field off the runtime payload record and applies it to the data field — `(fn (x) (+ x 1))`
            applied to 41 → 42. Pins that a fn projected from a record that is a sum payload dispatches via
            call_indirect (it cannot fold — the record is a runtime heap value behind the match), while the
            sibling `rec.n` data read folds as usual.")
   (input  (do
-            (type H (M (Record (f (-> Int64 Int64)) (n Int64))))
+            (type H (M (Record (: f (-> Int64 Int64)) (: n Int64))))
             (def (run (: h H)) (match h ((H.M rec) ((. rec f) rec.n))))
             (def (main) (run (H.M (record (f (fn ((: x Int64)) (+ x 1))) (n 41)))))
             (export main)))
@@ -5455,14 +5455,14 @@
            a `(: g (-> t …))` arrow annotation previously collapsed `t` to `Unit` (the `encode_ty`/`decode_ty`
            round-trip for a built arrow type-value had no `Ty::Var` arm, so the def scheme read `(-> (-> Unit
            Int64) …)` and a real closure argument mismatched). Now the scheme is `(-> Type (-> (Record
-           (describe (-> a Int64))) (-> a Int64)))`, and `show-with` dispatches over BOTH an Int64 instance
+           (: describe (-> a Int64))) (-> a Int64)))`, and `show-with` dispatches over BOTH an Int64 instance
            (`describe-int`) AND a Bool instance (`describe-bool`) through the dict in one program:
            `describe-int(5)=5` + `describe-bool(true)=1` = 6. Pins the type-valued-parameter-under-an-arrow
            substitution the ad-hoc-polymorphism chapter (traits = records of functions) depends on.")
   (input  (do
             (def (describe-int (: n Int64)) n)
             (def (describe-bool (: b Bool)) (if b 1 0))
-            (def (show-with (: t Type) (: dict (Record (describe (-> t Int64)))) (: x t))
+            (def (show-with (: t Type) (: dict (Record (: describe (-> t Int64)))) (: x t))
               ((. dict describe) x))
             (def (main)
               (+ (show-with Int64 (record (describe describe-int)) 5)
@@ -5807,13 +5807,13 @@
 ; same "inline a compile-time-known argument, drop the param" rule that erases a type-valued parameter.
 
 (case "a recursive consumer of a dictionary record inlines and erases the dictionary"
-  (doc    "`fold-n` takes a dictionary `(Record (op (-> Int64 Int64)))` and applies its `op` `n` times.
+  (doc    "`fold-n` takes a dictionary `(Record (: op (-> Int64 Int64)))` and applies its `op` `n` times.
            Called with `(record (op (fn (x) (+ x 10))))`, the dictionary is compile-time-known, so
            `fold-n` is monomorphized with the `op` inlined directly (`(. d op)` folds to `(+ acc 10)` —
            no call_indirect, no runtime record) and the dictionary argument erased. Folding `+10` from 0
            three times = 30.")
   (input  (do
-            (def (fold-n (const (: d (Record (op (-> Int64 Int64))))) (: n Int64) (: acc Int64))
+            (def (fold-n (const (: d (Record (: op (-> Int64 Int64))))) (: n Int64) (: acc Int64))
               (if (= n 0) acc (fold-n d (- n 1) ((. d op) acc))))
             (def (main) (fold-n (record (op (fn (x) (+ x 10)))) 3 0))
             (export main)))
@@ -5825,7 +5825,7 @@
            specialization, the ad-hoc-polymorphism analogue of per-type monomorphization). `(+10)` folded
            from 0 thrice = 30; `(*2)` folded from 1 thrice = 8; 30 + 8 = 38.")
   (input  (do
-            (def (fold-n (const (: d (Record (op (-> Int64 Int64))))) (: n Int64) (: acc Int64))
+            (def (fold-n (const (: d (Record (: op (-> Int64 Int64))))) (: n Int64) (: acc Int64))
               (if (= n 0) acc (fold-n d (- n 1) ((. d op) acc))))
             (def (main) (+ (fold-n (record (op (fn (x) (+ x 10)))) 3 0)
                            (fold-n (record (op (fn (x) (* x 2)))) 3 1)))
@@ -5844,7 +5844,7 @@
            rejects it (CDZ0201, 'must be compile-time-known'), rather than silently passing it at runtime.
            The rejection is the program's outcome; there is no value.")
   (input  (do
-            (def (fold-n (const (: d (Record (op (-> Int64 Int64))))) (: n Int64) (: acc Int64))
+            (def (fold-n (const (: d (Record (: op (-> Int64 Int64))))) (: n Int64) (: acc Int64))
               (if (= n 0) acc (fold-n d (- n 1) ((. d op) acc))))
             (def (main (: k Int64)) (fold-n (record (op (fn (x) (+ x k)))) 3 0))
             (export main)))
@@ -5959,7 +5959,7 @@
            `apply2` applies `d.op` twice; with `op = (+ n 10)`: `5 → 25`, `100 → 120`; 25 + 120 = 145.")
   (input  (do
             (@ inline-never
-              (def (apply2 (const (: d (Record (op (-> Int64 Int64))))) (: x Int64))
+              (def (apply2 (const (: d (Record (: op (-> Int64 Int64))))) (: x Int64))
                 ((. d op) ((. d op) x))))
             (def (main) (+ (apply2 (record (op (fn (n) (+ n 10)))) 5)
                            (apply2 (record (op (fn (n) (+ n 10)))) 100)))

--- a/spec/semantics/14-effects-and-handlers.sexp
+++ b/spec/semantics/14-effects-and-handlers.sexp
@@ -2836,7 +2836,7 @@
            either direction. The arm resumes `(record (total 50) (items (list 5 6 7)))`; the body
            projects the scalar and folds the list field — 50 + 3 + 7 → 60.")
   (input  (do
-            (effect St (op page (-> Int64 (Record (total Int64) (items (List Int64))))))
+            (effect St (op page (-> Int64 (Record (: total Int64) (: items (List Int64))))))
             (def (main (: n Int64))
               (handle St 0
                 ((page (k) s (resume (record (total (* k 10)) (items (list k (+ k 1) (+ k 2)))) s)))
@@ -2852,7 +2852,7 @@
            op and the ARM uses one field to query the other — contains(seen, want) → 100, plus len 3
            → 103. The collection field must arrive beside the scalar with both intact.")
   (input  (do
-            (effect St (op audit (-> (Record (want Int64) (seen (Set Int64))) Int64)))
+            (effect St (op audit (-> (Record (: want Int64) (: seen (Set Int64))) Int64)))
             (def (main (: n Int64))
               (handle St 0
                 ((audit (r) s (resume (+ (* 100 (if (Set.contains (. r seen) (. r want)) 1 0))
@@ -3617,11 +3617,11 @@
 
 (case "an overflowing literal in a RECORD op argument's narrow field is rejected"
   (doc    "The compound-descent face: the width check must recurse into a Record op argument's
-           fields — `(record (small 999) …)` against `(Record (small UInt8) …)` is CDZ0302. (Tuple
+           fields — `(record (small 999) …)` against `(Record (: small UInt8) …)` is CDZ0302. (Tuple
            and List elements were covered by the same descent from the start; the Record row arm
            was a fold-in.)")
   (input  (do
-            (effect Send (op put (-> (Record (small UInt8) (big Int64)) Int64)))
+            (effect Send (op put (-> (Record (: small UInt8) (: big Int64)) Int64)))
             (def (main (: n Int64))
               (handle Send 0
                 ((put (r) s (resume (+ (Int64.of (. r small)) (. r big)) s)))
@@ -10055,8 +10055,8 @@
 
 (case "an operation with a RECORD parameter binds the compound and the arm reads its fields"
   (doc    "The record companion of the tuple-parameter case: an operation whose declared PARAMETER is a
-           `(Record (a Int64) (b Int64))` binds the whole record to the arm's parameter, whose fields the arm
-           reads by member access. `Add.sum : (-> (Record (a Int64) (b Int64)) Int64)`; performed as
+           `(Record (: a Int64) (: b Int64))` binds the whole record to the arm's parameter, whose fields the arm
+           reads by member access. `Add.sum : (-> (Record (: a Int64) (: b Int64)) Int64)`; performed as
            `(Add.sum (record (a 3) (b 4)))`, the arm binds `p` and resumes with `(+ (. p a) (. p b))` = 7.
            The arm references `p` TWICE (once per field), but the argument is a PURE record — it reaches no
            perform — so substituting it into both uses duplicates no effect and the fold serves it (the
@@ -10064,7 +10064,7 @@
            compound; the precise perform-detector does not misread a record's field pairs as a call). Pins
            that a record OP parameter threads and is field-readable, matching the tuple parameter.")
   (input  (do
-            (effect Add (op sum (-> (Record (a Int64) (b Int64)) Int64)))
+            (effect Add (op sum (-> (Record (: a Int64) (: b Int64)) Int64)))
             (def (main)
               (handle Add 0 ((sum (p) s (resume (+ (. p a) (. p b)) s)))
                 (Add.sum (record (a 3) (b 4))))) (export main)))
@@ -11259,7 +11259,7 @@
 ; `RecordCtor` decode originally accepted only the 2-element `(name type)` pair; the ML `{a: Int64, …}`
 ; return lowers each field to a 3-element `(: a Int64)` triple, so the record decoded to `None` → the op had
 ; NO `(-> Unit result)` scheme → the nullary-perform site fell back to the op's META-record and `St.get()`
-; typed as `(Record (apply …) (effect-op …) (t …))` instead of `{a, b}` (CDZ0203 "record has no field a" at
+; typed as `(Record (: apply …) (effect-op …) (t …))` instead of `{a, b}` (CDZ0203 "record has no field a" at
 ; a consumer). Handling `St` with a `get` arm that resumes `(record (a 1) (b 2))` and reading field `a` = 1
 ; pins that a structural-record effect-op return threads its declared type to the perform site (the
 ; `type_in_env` companion of the same `(: name type)` decode fix `typeval_of` carries for variant payloads).
@@ -12155,7 +12155,7 @@
            resumes `(record (x (* id 2)) (y (+ id 1)))` and the body projects both fields — 10 + 6 =
            16. The field layout must survive the resume marshal.")
   (input  (do
-            (effect St (op fetch (-> Int64 (Record (x Int64) (y Int64)))))
+            (effect St (op fetch (-> Int64 (Record (: x Int64) (: y Int64)))))
             (def (main (: n Int64))
               (handle St 0
                 ((fetch (id) s (resume (record (x (* id 2)) (y (+ id 1))) s)))
@@ -12169,7 +12169,7 @@
            to the op and the ARM projects both fields — 10·5 − 3 = 47. With the result-direction pin
            above and the record-STATE pins, structural records cover all three effect positions.")
   (input  (do
-            (effect St (op score (-> (Record (hits Int64) (misses Int64)) Int64)))
+            (effect St (op score (-> (Record (: hits Int64) (: misses Int64)) Int64)))
             (def (main (: n Int64))
               (handle St 0
                 ((score (r) s (resume (- (* (. r hits) 10) (. r misses)) s)))
@@ -13119,7 +13119,7 @@
 (case "a record op argument with a HEAP field crosses the perform and its scalar field accumulates state"
   (doc    "The :4626 record-op-arg pin is all-scalar + stateless; this record carries a ROPE field beside the scalar through the perform AND the arm accumulates the scalar into STATE across two performs — the op-arg boxing keeps the heap handle beside the scalar while the state cell threads independently.")
   (input  (do
-            (effect Db (op put (-> (Record (name String) (qty Int64)) Int64)))
+            (effect Db (op put (-> (Record (: name String) (: qty Int64)) Int64)))
             (def (main (: k Int64))
               (handle Db 0
                 ((put (r) s (resume (+ s (. r qty)) (+ s (. r qty)))))

--- a/spec/semantics/15-rows-and-open-sums.sexp
+++ b/spec/semantics/15-rows-and-open-sums.sexp
@@ -166,7 +166,7 @@
            `(Record.project (record (a 1) (b 2) (c 3)) (a c))` keeps `a` and `c`, dropping `b`, yielding
            the closed record `(record (a 1) (c 3))`. The result renders in canonical key-sorted order.")
   (input  (Record.project (record (a 1) (b 2) (c 3)) (a c)))
-  (output (: (record (a 1) (c 3)) (Record (a Int64) (c Int64)))))
+  (output (: (record (a 1) (c 3)) (Record (: a Int64) (: c Int64)))))
 
 (case "a row op over a constant record folds through a single-use let binding"
   (doc    "Witnesses type-system.md #A Record Is Restricted To A Named Set Of Its Fields (the compile-time
@@ -252,7 +252,7 @@
            (record (a 1) (b 2) (c 3)) (b))` drops `b`, yielding `(record (a 1) (c 3))` — the complement of
            projecting the fields kept.")
   (input  (Record.without (record (a 1) (b 2) (c 3)) (b)))
-  (output (: (record (a 1) (c 3)) (Record (a Int64) (c Int64)))))
+  (output (: (record (a 1) (c 3)) (Record (: a Int64) (: c Int64)))))
 
 (case "dropping an absent field from a record is rejected"
   (doc    "Witnesses type-system.md #A Record Is Reduced By Dropping A Named Set Of Its Fields (2nd
@@ -267,7 +267,7 @@
            its source's value. `(Record.merge (record (a 1)) (record (b 2)))` yields `(record (a 1) (b 2))`
            — the row analogue of forming a record from two groups of fields.")
   (input  (Record.merge (record (a 1)) (record (b 2))))
-  (output (: (record (a 1) (b 2)) (Record (a Int64) (b Int64)))))
+  (output (: (record (a 1) (b 2)) (Record (: a Int64) (: b Int64)))))
 
 ; The merge above builds both operand records from CONSTANT literals, so the union folds to a constant
 ; record. A record carrying a RUNTIME field value cannot fold — the merge runs on the value heap. These
@@ -523,7 +523,7 @@
            shared payload in place and the alias would read the NEW x — this pins the alias reads the OLD
            one. done.x = k+1 = 4; alias.x = k = 3 → 4 + 100·3 = 304.")
   (input  (do
-            (def (bump-x (: r (Record (x Int64) (y Int64))))
+            (def (bump-x (: r (Record (: x Int64) (: y Int64))))
               (Record.with r #"x" (+ (. r x) 1)))
             (def (main (: k Int64))
               (let ((seed (record (x k) (y 100))))
@@ -543,9 +543,9 @@
            dead, and the per-step `with` must not reuse the shared seed's cell). done.x = k+5 = 8;
            seed.x = k = 3 → 8 + 1000·3 = 3008.")
   (input  (do
-            (def (bump-x (: r (Record (x Int64) (y Int64))))
+            (def (bump-x (: r (Record (: x Int64) (: y Int64))))
               (Record.with r #"x" (+ (. r x) 1)))
-            (def (go-n (: r (Record (x Int64) (y Int64))) (: n Int64))
+            (def (go-n (: r (Record (: x Int64) (: y Int64))) (: n Int64))
               (if (> n 0) (go-n (bump-x r) (- n 1)) r))
             (def (main (: k Int64))
               (let ((seed (record (x k) (y 100))))
@@ -581,7 +581,7 @@
            (not a trap) made this soundness-priority. This closes #45's second face; the first (witness 1, the
            owned-operand field-dup trap) is the sibling pin above.")
   (input  (do
-            (type Slot (Filled (Record (name String) (qty Int64))) (Empty))
+            (type Slot (Filled (Record (: name String) (: qty Int64))) (Empty))
             (def (bump-qty (: s Slot) (: d Int64))
               (match s
                 ((Slot.Filled r) (Slot.Filled (Record.extend (Record.without r (qty)) #"qty" (+ (. r qty) d))))
@@ -634,7 +634,7 @@
            `(Record.extend (record (a 1)) #"b" 2)` yields `(record (a 1) (b 2))`. The added field may hold
            any type. The field name is a `#field` label operand (a static label, not a runtime value).")
   (input  (Record.extend (record (a 1)) #"b" 2))
-  (output (: (record (a 1) (b 2)) (Record (a Int64) (b Int64)))))
+  (output (: (record (a 1) (b 2)) (Record (: a Int64) (: b Int64)))))
 
 (case "extending a record with an already-present field is rejected"
   (doc    "Witnesses type-system.md #A Field Is Added To Or Replaced In A Record By A Derived Operation
@@ -651,16 +651,15 @@
            (Record.without r (z)) (record (z v)))`. `(Record.with (record (a 1) (b 2)) #"b" 9)` yields
            `(record (a 1) (b 9))` — an explicit update distinct from `extend`.")
   (input  (Record.with (record (a 1) (b 2)) #"b" 9))
-  (output (: (record (a 1) (b 9)) (Record (a Int64) (b Int64)))))
+  (output (: (record (a 1) (b 9)) (Record (: a Int64) (: b Int64)))))
 
 (case "updating a record field changes its type to the new value's"
   (doc    "Witnesses type-system.md #A Field Is Added To Or Replaced In A Record By A Derived Operation
            (2nd sentence: 'a new value of a possibly different type'): the result is a new closed record
            whose field `b` has whatever type the new value holds. `(Record.with (record (a 1) (b 2)) #"b"
-           true)` retypes `b` from Int64 to Bool, yielding `(record (a 1) (b true))` of type `(Record (a
-           Int64) (b Bool))`. Pins that `with` is not constrained to the field's prior type.")
+           true)` retypes `b` from Int64 to Bool, yielding `(record (a 1) (b true))` of type `(Record (: a Int64) (: b Bool))`. Pins that `with` is not constrained to the field's prior type.")
   (input  (Record.with (record (a 1) (b 2)) #"b" true))
-  (output (: (record (a 1) (b true)) (Record (a Int64) (b Bool)))))
+  (output (: (record (a 1) (b true)) (Record (: a Int64) (: b Bool)))))
 
 (case "Record.with over a RUNTIME field leaves the original record readable (persistence)"
   (doc    "The runtime + persistence face of `Record.with` (the pins above are const-folded whole-value
@@ -841,7 +840,7 @@
            (b 2)))`. No Option: field presence is static, so a missing field is CDZ0212, not a runtime None
            (contrast `List.at` on a runtime index).")
   (input  (Record.pop (record (a 1) (b 2)) a))
-  (output (: (tuple 1 (record (b 2))) (Tuple Int64 (Record (b Int64))))))
+  (output (: (tuple 1 (record (b 2))) (Tuple Int64 (Record (: b Int64))))))
 
 (case "popping an absent field is rejected"
   (doc    "Witnesses type-system.md #A Record Is Reduced By Dropping A Named Set Of Its Fields (2nd
@@ -1512,10 +1511,10 @@
 ; --- Open-row projection over COLLECTION-borne records. ---
 
 (case "an open-row projection reads list-element records in a fold AND a wider record at another site"
-  (doc    "The open-row instantiation pins use DIRECT literal args; this projects records pulled OUT OF A COLLECTION — get-x applied to (List (Record (x Int64) (t Int64))) elements inside a recursive fold (match-bound heap elements, not literals) plus a third 3-field width at a direct site keeping the def polymorphic. A per-def single-layout specialization or literal-only projection misreads.")
+  (doc    "The open-row instantiation pins use DIRECT literal args; this projects records pulled OUT OF A COLLECTION — get-x applied to (List (Record (: x Int64) (: t Int64))) elements inside a recursive fold (match-bound heap elements, not literals) plus a third 3-field width at a direct site keeping the def polymorphic. A per-def single-layout specialization or literal-only projection misreads.")
   (input  (do
             (def (get-x r) (. r x))
-            (def (sum-xs (: rs (List (Record (x Int64) (t Int64)))) (: i Int64) (: acc Int64))
+            (def (sum-xs (: rs (List (Record (: x Int64) (: t Int64)))) (: i Int64) (: acc Int64))
               (match (List.at rs i)
                 ((Option.Some r) (sum-xs rs (+ i 1) (+ acc (get-x r))))
                 ((Option.None _u) acc)))

--- a/spec/semantics/21-host-closures.sexp
+++ b/spec/semantics/21-host-closures.sexp
@@ -1744,12 +1744,11 @@
   (output (: (tuple 5 6) (Tuple Int64 Int64))))
 
 (case "a closure returning a record crosses as the typed value form"
-  (doc    "A record result — `(record (x n) (y n+10))` → `(: (record (x 3) (y 13)) (Record (x Int64) (y
-           Int64)))`. Field names + the record type node are baked in the template; only the leaf values are
+  (doc    "A record result — `(record (x n) (y n+10))` → `(: (record (x 3) (y 13)) (Record (: x Int64) (: y Int64)))`. Field names + the record type node are baked in the template; only the leaf values are
            walked at run time.")
   (input  (do (def (mk) (fn ((: n Int64)) (record (x n) (y (+ n 10))))) (export mk)))
   (call   mk (: 3 Int64))
-  (output (: (record (x 3) (y 13)) (Record (x Int64) (y Int64)))))
+  (output (: (record (x 3) (y 13)) (Record (: x Int64) (: y Int64)))))
 
 (case "a closure returning a tuple with a Bool leaf"
   (doc    "A mixed-leaf compound — `(tuple n (< n 5))` → `(: (tuple 2 true) (Tuple Int64 Bool))`. The Bool
@@ -1791,7 +1790,7 @@
               (export mk)))
   (call   mk (: 100 Int64))
   (output (: (record (a 100) (b (record (c 101) (d 102))))
-             (Record (a Int64) (b (Record (c Int64) (d Int64)))))))
+             (Record (: a Int64) (: b (Record (: c Int64) (: d Int64)))))))
 
 (case "a Tuple ARG composes with a NESTED-tuple RESULT"
   (doc    "`mk : (-> (Tuple Int64 Int64) (Tuple Int64 (Tuple Int64 Int64)))` — a fixed-shape tuple ARG (rebuilt
@@ -1884,13 +1883,13 @@
   (output (: (tuple 5 6) (Tuple Int64 Int64))))
 
 (case "multi-export record result — canonical field order"
-  (doc    "Two closures returning a `(Record (lo Int64) (hi Int64))`. `call(mka-handle, 3)` → `(record (lo 3)
+  (doc    "Two closures returning a `(Record (: lo Int64) (: hi Int64))`. `call(mka-handle, 3)` → `(record (lo 3)
            (hi 103))`, rendered in CANONICAL sorted-name order `(record (hi 103) (lo 3))`.")
   (input  (do (def (mka) (fn ((: n Int64)) (record (lo n) (hi (+ n 100)))))
               (def (mkb) (fn ((: n Int64)) (record (lo (- 0 n)) (hi n))))
               (export mka) (export mkb)))
   (call   mka (: 3 Int64))
-  (output (: (record (hi 103) (lo 3)) (Record (hi Int64) (lo Int64)))))
+  (output (: (record (hi 103) (lo 3)) (Record (: hi Int64) (: lo Int64)))))
 
 (case "multi-export record result — the second closure, with a negative leaf"
   (doc    "The SAME program's other export: `call(mkb-handle, 3)` → `(record (lo -3) (hi 3))` → canonical
@@ -1899,7 +1898,7 @@
               (def (mkb) (fn ((: n Int64)) (record (lo (- 0 n)) (hi n))))
               (export mka) (export mkb)))
   (call   mkb (: 3 Int64))
-  (output (: (record (hi 3) (lo -3)) (Record (hi Int64) (lo Int64)))))
+  (output (: (record (hi 3) (lo -3)) (Record (: hi Int64) (: lo Int64)))))
 
 (case "multi-export compound result — three capturing closures share one call"
   (doc    "THREE same-signature closures (two capturing `k`, one not) each returning `(Tuple Int64 Int64)`.
@@ -1939,14 +1938,14 @@
   (output (: 2 Int64)))
 
 (case "a record-returning closure alongside a parameterized plain export — the closure"
-  (doc    "`mk : () -> (-> Int64 (Record (a Int64) (b Int64)))` returns `(record (a n) (b 2n))`, beside a
+  (doc    "`mk : () -> (-> Int64 (Record (: a Int64) (: b Int64)))` returns `(record (a n) (b 2n))`, beside a
            parameterized plain `inc : (Int64) -> Int64`. `call(mk-handle, 4)` → `(: (record (a 4) (b 8))
-           (Record (a Int64) (b Int64)))`.")
+           (Record (: a Int64) (: b Int64)))`.")
   (input  (do (def (mk) (fn ((: n Int64)) (record (a n) (b (* n 2)))))
               (def (inc (: x Int64)) (+ x 1))
               (export mk) (export inc)))
   (call   mk (: 4 Int64))
-  (output (: (record (a 4) (b 8)) (Record (a Int64) (b Int64)))))
+  (output (: (record (a 4) (b 8)) (Record (: a Int64) (: b Int64)))))
 
 (case "a record-returning closure alongside a parameterized plain export — the plain"
   (doc    "The SAME program, calling `inc(41)` = 42. Pins the parameterized plain export reachable beside a
@@ -2035,13 +2034,13 @@
   (output (: (tuple 5 6) (Tuple Int64 Int64))))
 
 (case "round-trip: a consumer returns a record built from the closure result"
-  (doc    "`mk` doubles; `app : (own<t>, Int64) -> (Record (inp Int64) (out Int64))` = `(record (inp x) (out
+  (doc    "`mk` doubles; `app : (own<t>, Int64) -> (Record (: inp Int64) (: out Int64))` = `(record (inp x) (out
            (g x)))`. `app(handle, 10)` → `(: (record (inp 10) (out 20)) …)`.")
   (input  (do (def (mk) (fn ((: n Int64)) (* n 2)))
               (def (app (: g (-> Int64 Int64)) (: x Int64)) (record (inp x) (out (g x))))
               (export mk) (export app)))
   (call   app (: 10 Int64))
-  (output (: (record (inp 10) (out 20)) (Record (inp Int64) (out Int64)))))
+  (output (: (record (inp 10) (out 20)) (Record (: inp Int64) (: out Int64)))))
 
 (case "round-trip: a scalar consumer + a compound consumer of the same closure — the compound"
   (doc    "One closure signature, TWO consumers: `asnum` returns the value, `aspair` returns `(tuple x (g
@@ -2142,14 +2141,14 @@
 
 (case "distinct-sig round-trip: TWO compound consumers of different sigs — the record one"
   (doc    "The SAME program's OTHER consumer: `appb(mkb-handle, true)` → `(: (record (flag true) (val 7))
-           (Record (flag Bool) (val Int64)))`. Confirms each distinct-sig consumer decodes its own template.")
+           (Record (: flag Bool) (: val Int64)))`. Confirms each distinct-sig consumer decodes its own template.")
   (input  (do (def (mka) (fn ((: n Int64)) (+ n 1)))
               (def (mkb) (fn ((: b Bool)) (: (if b 7 8) Int64)))
               (def (appa (: g (-> Int64 Int64)) (: x Int64)) (tuple x (g x)))
               (def (appb (: h (-> Bool Int64)) (: y Bool)) (record (flag y) (val (h y))))
               (export mka) (export mkb) (export appa) (export appb)))
   (call   appb (: true Bool))
-  (output (: (record (flag true) (val 7)) (Record (flag Bool) (val Int64)))))
+  (output (: (record (flag true) (val 7)) (Record (: flag Bool) (: val Int64)))))
 
 (case "distinct-sig round-trip: a compound consumer + a byte-rope consumer of different sigs — the byte-rope"
   (doc    "A COMPOUND consumer (`appa` → tuple value form) AND a BYTE-ROPE consumer (`appb` → raw list<u8>)
@@ -2644,12 +2643,12 @@
   (output (: 10 Int64)))
 
 (case "round-trip: a consumer applies a closure taking a Record arg built in-guest"
-  (doc    "`mk : () -> (-> (Record (a Int64) (b Int64)) Int64)` multiplies the two fields; `app` applies it to
+  (doc    "`mk : () -> (-> (Record (: a Int64) (: b Int64)) Int64)` multiplies the two fields; `app` applies it to
            a guest-built `(record (a x) (b x+1))`. `app(handle, 6)` → `g((record (a 6) (b 7)))` = 42. A RECORD
            closure argument crosses the round trip (field names are compile-time-only; the value is an i32
            heap handle in-guest).")
-  (input  (do (def (mk) (fn ((: r (Record (a Int64) (b Int64)))) (* (. r a) (. r b))))
-              (def (app (: g (-> (Record (a Int64) (b Int64)) Int64)) (: x Int64))
+  (input  (do (def (mk) (fn ((: r (Record (: a Int64) (: b Int64)))) (* (. r a) (. r b))))
+              (def (app (: g (-> (Record (: a Int64) (: b Int64)) Int64)) (: x Int64))
                 (g (record (a x) (b (+ x 1)))))
               (export mk) (export app)))
   (call   app (: 6 Int64))
@@ -2712,9 +2711,9 @@
            `appa : (own<t0>, Int64) -> Int64` applies `g` to `(tuple x+1 x)`. `appa(handle, 7)` →
            `g((tuple 8 7))` = 8-7 = 1. Each group's closure takes its own compound argument built in-guest.")
   (input  (do (def (mka) (fn ((: p (Tuple Int64 Int64))) (- (. p 0) (. p 1))))
-              (def (mkb) (fn ((: r (Record (a Int64) (b Int64)))) (* (. r a) (. r b))))
+              (def (mkb) (fn ((: r (Record (: a Int64) (: b Int64)))) (* (. r a) (. r b))))
               (def (appa (: g (-> (Tuple Int64 Int64) Int64)) (: x Int64)) (g (tuple (+ x 1) x)))
-              (def (appb (: h (-> (Record (a Int64) (b Int64)) Int64)) (: y Int64))
+              (def (appb (: h (-> (Record (: a Int64) (: b Int64)) Int64)) (: y Int64))
                 (h (record (a y) (b y))))
               (export mka) (export mkb) (export appa) (export appb)))
   (call   appa (: 7 Int64))
@@ -2725,9 +2724,9 @@
            `(record (a y) (b y))`. `appb(handle, 6)` → `h((record (a 6) (b 6)))` = 36. Confirms each distinct
            signature threads its own compound argument through its own resource type.")
   (input  (do (def (mka) (fn ((: p (Tuple Int64 Int64))) (- (. p 0) (. p 1))))
-              (def (mkb) (fn ((: r (Record (a Int64) (b Int64)))) (* (. r a) (. r b))))
+              (def (mkb) (fn ((: r (Record (: a Int64) (: b Int64)))) (* (. r a) (. r b))))
               (def (appa (: g (-> (Tuple Int64 Int64) Int64)) (: x Int64)) (g (tuple (+ x 1) x)))
-              (def (appb (: h (-> (Record (a Int64) (b Int64)) Int64)) (: y Int64))
+              (def (appb (: h (-> (Record (: a Int64) (: b Int64)) Int64)) (: y Int64))
                 (h (record (a y) (b y))))
               (export mka) (export mkb) (export appa) (export appb)))
   (call   appb (: 6 Int64))
@@ -2835,14 +2834,14 @@
   (output (: 7 Int64)))
 
 (case "a fixed-shape scalar RECORD closure ARG crosses the DIRECT-CALL boundary"
-  (doc    "Like the tuple-arg case but the closure argument is a RECORD `(Record (a Int64) (b Int64))`. A
+  (doc    "Like the tuple-arg case but the closure argument is a RECORD `(Record (: a Int64) (: b Int64))`. A
            record of aliased-width scalars flattens the same way (its fields in canonical SORTED-key order —
            the value-heap cell's field order), so the guest `call` rebuilds the record cell from the flat
            fields. `call(handle, (record 3 4))` → `(. p a) + (. p b)` = 7. (The corpus arg is the value form
            in field order; the `record` head token is dropped by the runner's tuple-literal parser.)")
-  (input  (do (def (mk) (fn ((: p (Record (a Int64) (b Int64)))) (+ (. p a) (. p b))))
+  (input  (do (def (mk) (fn ((: p (Record (: a Int64) (: b Int64)))) (+ (. p a) (. p b))))
               (export mk)))
-  (call   mk (: (record 3 4) (Record (a Int64) (b Int64))))
+  (call   mk (: (record 3 4) (Record (: a Int64) (: b Int64))))
   (output (: 7 Int64)))
 
 (case "a NARROW-int-field Tuple closure ARG flattens + rebuilds (exercises the i32->i64 extend)"
@@ -3052,7 +3051,7 @@
   (output (: (tuple 13 7) (Tuple Int64 Int64))))
 
 (case "a fixed-shape Tuple ARG with a RECORD RESULT crosses the direct-call boundary"
-  (doc    "Like the tuple-result case but the closure returns a RECORD `(Record (sum Int64) (diff Int64))` —
+  (doc    "Like the tuple-result case but the closure returns a RECORD `(Record (: sum Int64) (: diff Int64))` —
            a fixed-shape compound rendered via the value-form template (fields in canonical sorted-key order).
            `call(handle, (10, 3))` → `(record (diff 7) (sum 13))`. Confirms a record result rides the same
            value-form tuple-arg path.")
@@ -3060,7 +3059,7 @@
                          (record (sum (+ (. p 0) (. p 1))) (diff (- (. p 0) (. p 1))))))
               (export mk)))
   (call   mk (: (tuple 10 3) (Tuple Int64 Int64)))
-  (output (: (record (diff 7) (sum 13)) (Record (diff Int64) (sum Int64)))))
+  (output (: (record (diff 7) (sum 13)) (Record (: diff Int64) (: sum Int64)))))
 
 ; A fixed-shape compound ARGUMENT now composes with a VARIABLE-LENGTH COLLECTION result (List/Map/Set) too —
 ; the value-encode result core + the shared list<u8> envelope thread the `TupleArgRebuild`. So a single-export
@@ -3320,57 +3319,57 @@
 ; it as `(record (name value)…)`; cdz-run sorts the named fields to match the boundary tuple's positions.
 
 (case "a RECORD closure ARG among scalars crosses the direct-call boundary (scalar result)"
-  (doc    "`mk : (-> Int64 (Record (x Int64) (y Int64)) Int64)` — a scalar `n` then a RECORD `r`. The record
+  (doc    "`mk : (-> Int64 (Record (: x Int64) (: y Int64)) Int64)` — a scalar `n` then a RECORD `r`. The record
            erases to a `tuple<s64,s64>` (fields sorted: x, y), flattened into core params the `call` rebuilds
            into the cell. `call(handle, 100, (record (x 10) (y 3)))` → `n + r.x + r.y` = 113.")
-  (input  (do (def (mk) (fn ((: n Int64) (: r (Record (x Int64) (y Int64)))) (+ n (+ (. r x) (. r y)))))
+  (input  (do (def (mk) (fn ((: n Int64) (: r (Record (: x Int64) (: y Int64)))) (+ n (+ (. r x) (. r y)))))
               (export mk)))
-  (call   mk (: 100 Int64) (: (record (x 10) (y 3)) (Record (x Int64) (y Int64))))
+  (call   mk (: 100 Int64) (: (record (x 10) (y 3)) (Record (: x Int64) (: y Int64))))
   (output (: 113 Int64)))
 
 (case "a SOLE RECORD closure ARG crosses the direct-call boundary"
-  (doc    "`mk : (-> (Record (a Int64) (b Int64)) Int64)` — the record is the SOLE arg (base_param=1). Erases
+  (doc    "`mk : (-> (Record (: a Int64) (: b Int64)) Int64)` — the record is the SOLE arg (base_param=1). Erases
            to `tuple<s64,s64>`, rebuilt in the `call`. `call(handle, (record (a 10) (b 3)))` → `r.a + r.b` = 13.")
-  (input  (do (def (mk) (fn ((: r (Record (a Int64) (b Int64)))) (+ (. r a) (. r b))))
+  (input  (do (def (mk) (fn ((: r (Record (: a Int64) (: b Int64)))) (+ (. r a) (. r b))))
               (export mk)))
-  (call   mk (: (record (a 10) (b 3)) (Record (a Int64) (b Int64))))
+  (call   mk (: (record (a 10) (b 3)) (Record (: a Int64) (: b Int64))))
   (output (: 13 Int64)))
 
 (case "a RECORD closure ARG whose fields are NOT in sorted source order"
-  (doc    "`mk : (-> (Record (z Int64) (a Int64)) Int64)` — fields declared `z` THEN `a`, but the boundary
+  (doc    "`mk : (-> (Record (: z Int64) (: a Int64)) Int64)` — fields declared `z` THEN `a`, but the boundary
            tuple sorts them to `(a, z)`. The guest reads `. r z`/`. r a` by name (correct regardless of layout);
            cdz-run sorts the corpus's `(z 100)(a 3)` fields to match. `call(handle, (record (z 100) (a 3)))` →
            `r.z - r.a` = 97 (proving the sorted-field round-trip is sound, not a coincidental positional match).")
-  (input  (do (def (mk) (fn ((: r (Record (z Int64) (a Int64)))) (- (. r z) (. r a))))
+  (input  (do (def (mk) (fn ((: r (Record (: z Int64) (: a Int64)))) (- (. r z) (. r a))))
               (export mk)))
-  (call   mk (: (record (z 100) (a 3)) (Record (z Int64) (a Int64))))
+  (call   mk (: (record (z 100) (a 3)) (Record (: z Int64) (: a Int64))))
   (output (: 97 Int64)))
 
 (case "a RECORD closure ARG with a narrow Bool field, among scalars"
-  (doc    "`mk : (-> Int64 (Record (v Int64) (flag Bool)) Int64)` — the record has a NARROW Bool field (sorted
+  (doc    "`mk : (-> Int64 (Record (: v Int64) (: flag Bool)) Int64)` — the record has a NARROW Bool field (sorted
            BEFORE `v`: flag, v). The rebuild boxes the Bool via `box-bool`. `call(handle, 100, (record (v 10)
            (flag true)))` → `if r.flag then n + r.v else n` = 110.")
-  (input  (do (def (mk) (fn ((: n Int64) (: r (Record (v Int64) (flag Bool)))) (if (. r flag) (+ n (. r v)) n)))
+  (input  (do (def (mk) (fn ((: n Int64) (: r (Record (: v Int64) (: flag Bool)))) (if (. r flag) (+ n (. r v)) n)))
               (export mk)))
-  (call   mk (: 100 Int64) (: (record (v 10) (flag true)) (Record (v Int64) (flag Bool))))
+  (call   mk (: 100 Int64) (: (record (v 10) (flag true)) (Record (: v Int64) (: flag Bool))))
   (output (: 110 Int64)))
 
 (case "a RECORD closure ARG with a LIST result"
-  (doc    "`mk : (-> Int64 (Record (x Int64) (y Int64)) (List Int64))` — a record arg composes with a
+  (doc    "`mk : (-> Int64 (Record (: x Int64) (: y Int64)) (List Int64))` — a record arg composes with a
            collection result: the list-`call` rebuilds the record cell, dispatches, value-encodes the List.
            `call(handle, 100, (record (x 10) (y 3)))` → `(list 100 10 3)`.")
-  (input  (do (def (mk) (fn ((: n Int64) (: r (Record (x Int64) (y Int64)))) (list n (. r x) (. r y))))
+  (input  (do (def (mk) (fn ((: n Int64) (: r (Record (: x Int64) (: y Int64)))) (list n (. r x) (. r y))))
               (export mk)))
-  (call   mk (: 100 Int64) (: (record (x 10) (y 3)) (Record (x Int64) (y Int64))))
+  (call   mk (: 100 Int64) (: (record (x 10) (y 3)) (Record (: x Int64) (: y Int64))))
   (output (: (list 100 10 3) (List Int64))))
 
 (case "a RECORD closure ARG on the MULTI-EXPORT path"
-  (doc    "Two same-sig record-arg closures `(-> (Record (x Int64) (y Int64)) Int64)` share ONE `call` that
+  (doc    "Two same-sig record-arg closures `(-> (Record (: x Int64) (: y Int64)) Int64)` share ONE `call` that
            rebuilds the record cell. Driving `mk-b` (subtract): `call(handle, (record (x 10) (y 3)))` → 7.")
-  (input  (do (def (mk-a) (fn ((: r (Record (x Int64) (y Int64)))) (+ (. r x) (. r y))))
-              (def (mk-b) (fn ((: r (Record (x Int64) (y Int64)))) (- (. r x) (. r y))))
+  (input  (do (def (mk-a) (fn ((: r (Record (: x Int64) (: y Int64)))) (+ (. r x) (. r y))))
+              (def (mk-b) (fn ((: r (Record (: x Int64) (: y Int64)))) (- (. r x) (. r y))))
               (export mk-a) (export mk-b)))
-  (call   mk-b (: (record (x 10) (y 3)) (Record (x Int64) (y Int64))))
+  (call   mk-b (: (record (x 10) (y 3)) (Record (: x Int64) (: y Int64))))
   (output (: 7 Int64)))
 
 ; A NESTED fixed-shape compound ARG — a tuple/record whose FIELD is itself a tuple/record — crosses the
@@ -3392,24 +3391,24 @@
   (output (: 113 Int64)))
 
 (case "a NESTED Record ARG (a record containing a record) crosses the direct-call boundary"
-  (doc    "`mk : (-> (Record (n Int64) (inner (Record (x Int64) (y Int64)))) Int64)` — a record with a record
+  (doc    "`mk : (-> (Record (: n Int64) (: inner (Record (: x Int64) (: y Int64)))) Int64)` — a record with a record
            field. Each level flattens to its sorted-key leaves + rebuilds recursively. `call(handle, (record
            (n 100) (inner (record (x 10) (y 3)))))` → `r.n + r.inner.x + r.inner.y` = 113.")
-  (input  (do (def (mk) (fn ((: r (Record (n Int64) (inner (Record (x Int64) (y Int64))))))
+  (input  (do (def (mk) (fn ((: r (Record (: n Int64) (: inner (Record (: x Int64) (: y Int64))))))
                          (+ (. r n) (+ (. (. r inner) x) (. (. r inner) y)))))
               (export mk)))
   (call   mk (: (record (n 100) (inner (record (x 10) (y 3))))
-                (Record (n Int64) (inner (Record (x Int64) (y Int64))))))
+                (Record (: n Int64) (: inner (Record (: x Int64) (: y Int64))))))
   (output (: 113 Int64)))
 
 (case "a NESTED mixed ARG (a tuple containing a record) crosses the direct-call boundary"
-  (doc    "`mk : (-> (Tuple Int64 (Record (x Int64) (y Int64))) Int64)` — a tuple whose second field is a
+  (doc    "`mk : (-> (Tuple Int64 (Record (: x Int64) (: y Int64))) Int64)` — a tuple whose second field is a
            RECORD. The nested-compound rebuild is kind-agnostic (tuple or record at any level). `call(handle,
            (100, (record (x 10) (y 3))))` → `p.0 + p.1.x + p.1.y` = 113.")
-  (input  (do (def (mk) (fn ((: p (Tuple Int64 (Record (x Int64) (y Int64)))))
+  (input  (do (def (mk) (fn ((: p (Tuple Int64 (Record (: x Int64) (: y Int64)))))
                          (+ (. p 0) (+ (. (. p 1) x) (. (. p 1) y)))))
               (export mk)))
-  (call   mk (: (tuple 100 (record (x 10) (y 3))) (Tuple Int64 (Record (x Int64) (y Int64)))))
+  (call   mk (: (tuple 100 (record (x 10) (y 3))) (Tuple Int64 (Record (: x Int64) (: y Int64)))))
   (output (: 113 Int64)))
 
 (case "a DOUBLY-nested Tuple ARG (three levels deep) crosses the direct-call boundary"
@@ -3434,25 +3433,25 @@
   (output (: 110 Int64)))
 
 (case "a RECORD with a nested TUPLE field crosses the direct-call boundary"
-  (doc    "`mk : (-> (Record (n Int64) (pair (Tuple Int64 Int64))) Int64)` — a record whose `pair` field is a
+  (doc    "`mk : (-> (Record (: n Int64) (: pair (Tuple Int64 Int64))) Int64)` — a record whose `pair` field is a
            TUPLE (mixed nesting kinds). The recursive rebuild + type mint are kind-agnostic. `call(handle,
            (record (n 100) (pair (tuple 10 3))))` → `r.n + r.pair.0 + r.pair.1` = 113.")
-  (input  (do (def (mk) (fn ((: r (Record (n Int64) (pair (Tuple Int64 Int64)))))
+  (input  (do (def (mk) (fn ((: r (Record (: n Int64) (: pair (Tuple Int64 Int64)))))
                          (+ (. r n) (+ (. (. r pair) 0) (. (. r pair) 1)))))
               (export mk)))
   (call   mk (: (record (n 100) (pair (tuple 10 3)))
-                (Record (n Int64) (pair (Tuple Int64 Int64)))))
+                (Record (: n Int64) (: pair (Tuple Int64 Int64)))))
   (output (: 113 Int64)))
 
 (case "a TRIPLY-nested Record ARG crosses the direct-call boundary"
-  (doc    "`mk : (-> (Record (a Int64) (b (Record (c Int64) (d (Record (e Int64) (f Int64)))))) Int64)` — three
+  (doc    "`mk : (-> (Record (: a Int64) (: b (Record (: c Int64) (: d (Record (: e Int64) (: f Int64)))))) Int64)` — three
            record levels. The recursive rebuild + mint descend arbitrarily deep. `call(handle, (record (a 1000)
            (b (record (c 100) (d (record (e 10) (f 3)))))))` → 1000+100+10+3 = 1113.")
-  (input  (do (def (mk) (fn ((: r (Record (a Int64) (b (Record (c Int64) (d (Record (e Int64) (f Int64))))))))
+  (input  (do (def (mk) (fn ((: r (Record (: a Int64) (: b (Record (: c Int64) (: d (Record (: e Int64) (: f Int64))))))))
                          (+ (. r a) (+ (. (. r b) c) (+ (. (. (. r b) d) e) (. (. (. r b) d) f))))))
               (export mk)))
   (call   mk (: (record (a 1000) (b (record (c 100) (d (record (e 10) (f 3))))))
-                (Record (a Int64) (b (Record (c Int64) (d (Record (e Int64) (f Int64))))))))
+                (Record (: a Int64) (: b (Record (: c Int64) (: d (Record (: e Int64) (: f Int64))))))))
   (output (: 1113 Int64)))
 
 ; A NESTED compound ARG can also sit AMONG scalar args (single-export): the recursive rebuild interleaves the
@@ -3526,14 +3525,14 @@
   (output (: (tuple 100 10 3) (Tuple Int64 Int64 Int64))))
 
 (case "a NESTED Record ARG with a LIST result crosses the direct-call boundary"
-  (doc    "`mk : (-> (Record (n Int64) (inner (Record (x Int64) (y Int64)))) (List Int64))` — a nested RECORD
+  (doc    "`mk : (-> (Record (: n Int64) (: inner (Record (: x Int64) (: y Int64)))) (List Int64))` — a nested RECORD
            arg + a collection result (both the nested-record rebuild + the value-encode result compose).
            `call(handle, (record (n 100) (inner (record (x 10) (y 3)))))` → `(list 100 10 3)`.")
-  (input  (do (def (mk) (fn ((: r (Record (n Int64) (inner (Record (x Int64) (y Int64))))))
+  (input  (do (def (mk) (fn ((: r (Record (: n Int64) (: inner (Record (: x Int64) (: y Int64))))))
                          (list (. r n) (. (. r inner) x) (. (. r inner) y))))
               (export mk)))
   (call   mk (: (record (n 100) (inner (record (x 10) (y 3))))
-                (Record (n Int64) (inner (Record (x Int64) (y Int64))))))
+                (Record (: n Int64) (: inner (Record (: x Int64) (: y Int64))))))
   (output (: (list 100 10 3) (List Int64))))
 
 ; The NESTED compound ARG extends to the MULTI-EXPORT path: N same-sig nested-tuple-arg closures share ONE
@@ -3937,11 +3936,11 @@
            cross exactly as two tuples do. `mk : (-> {a:Int64 b:Int64} {a:Int64 b:Int64} Int64)` reads `p.a +
            q.b`; each record flattens to its sorted-key field scalars, rebuilt in-guest. `call(handle,
            {a:5 b:5}, {a:5 b:10})` → `5 + 10` = 15.")
-  (input  (do (def (mk) (fn ((: p (Record (a Int64) (b Int64))) (: q (Record (a Int64) (b Int64))))
+  (input  (do (def (mk) (fn ((: p (Record (: a Int64) (: b Int64))) (: q (Record (: a Int64) (: b Int64))))
                 (+ (. p a) (. q b))))
               (export mk)))
-  (call   mk (: (record (a 5) (b 5)) (Record (a Int64) (b Int64)))
-             (: (record (a 5) (b 10)) (Record (a Int64) (b Int64))))
+  (call   mk (: (record (a 5) (b 5)) (Record (: a Int64) (: b Int64)))
+             (: (record (a 5) (b 10)) (Record (: a Int64) (: b Int64))))
   (output (: 15 Int64)))
 
 ; N-COMPOUND-ARGS × LIST-RESULT: the N-compound-args path composes with EVERY closure RESULT shape that crosses
@@ -4608,13 +4607,13 @@
   (call   mk (: None (Option (Tuple Int64 Int64))))
   (output (: 0 Int64)))
 
-(case "COMPOUND SUM PAYLOAD: (Option (Record (x Int64) (y Int64))) — a RECORD payload"
+(case "COMPOUND SUM PAYLOAD: (Option (Record (: x Int64) (: y Int64))) — a RECORD payload"
   (doc    "The payload is a RECORD (fields in canonical sorted-key order) rather than a positional tuple —
            crosses as `option<tuple<s64,s64>>` all the same (a record IS a positional cell; field names are
            compile-time). Driving `Some({x:10, y:20})`: `r.x + r.y` → 30.")
-  (input  (do (def (mk) (fn ((: o (Option (Record (x Int64) (y Int64))))) (match o ((Some r) (+ (. r x) (. r y))) (None -1))))
+  (input  (do (def (mk) (fn ((: o (Option (Record (: x Int64) (: y Int64))))) (match o ((Some r) (+ (. r x) (. r y))) (None -1))))
               (export mk)))
-  (call   mk (: (Some (record (x 10) (y 20))) (Option (Record (x Int64) (y Int64)))))
+  (call   mk (: (Some (record (x 10) (y 20))) (Option (Record (: x Int64) (: y Int64)))))
   (output (: 30 Int64)))
 
 (case "COMPOUND SUM PAYLOAD: (Option (Tuple Int64 (Tuple Int64 Int64))) — a NESTED tuple payload"

--- a/spec/semantics/26-program-conditions.sexp
+++ b/spec/semantics/26-program-conditions.sexp
@@ -3500,7 +3500,7 @@
 (case "@invariant ESTABLISH fires through a ROW-OP re-wrap (Record.without + Record.extend rebuild the payload)"
   (doc    "The establish matrix covers literal/lambda/list-element/update-rewrap construction sites — none rebuilds the payload via ROW OPS: bump strips hi with without, re-adds via extend, re-wraps Rng.R. The divert must catch THIS site even though the payload came from row ops, not a record literal (d=5 -> 13; d=-20 violates -> trap at the re-wrap).")
   (input  (do
-            (@ (invariant (match self (((. Rng R) r) (< (. r lo) (. r hi))))) (type Rng (R (Record (lo Int64) (hi Int64)))))
+            (@ (invariant (match self (((. Rng R) r) (< (. r lo) (. r hi))))) (type Rng (R (Record (: lo Int64) (: hi Int64)))))
             (def (bump (: v Rng) (: d Int64))
               (match v (((. Rng R) r)
                 (Rng.R (Record.extend (Record.without r (hi)) #"hi" (+ (. r hi) d))))))
@@ -3513,7 +3513,7 @@
 (case "@invariant over a RECORD-payload newtype establishes on the record's relational fields"
   (doc    "No establish case has a RECORD payload: (type Rng (R (Record (lo)(hi)))) with the relational field invariant (< lo hi) establishes at construction (2,10 -> 8; 10,2 -> trap).")
   (input  (do
-            (@ (invariant (match self (((. Rng R) r) (< (. r lo) (. r hi))))) (type Rng (R (Record (lo Int64) (hi Int64)))))
+            (@ (invariant (match self (((. Rng R) r) (< (. r lo) (. r hi))))) (type Rng (R (Record (: lo Int64) (: hi Int64)))))
             (def (mk (: a Int64) (: b Int64))
               (match (Rng.R (record (lo a) (hi b))) (((. Rng R) r) (- (. r hi) (. r lo)))))
             (export mk)))

--- a/spec/semantics/27-discrete-event-simulation.sexp
+++ b/spec/semantics/27-discrete-event-simulation.sexp
@@ -999,7 +999,7 @@
            An insort that copied the record payload shallowly against the tuple spine (or swapped
            payloads between entries during the prepend recursion) crosses the id/pri pairs.")
   (input  (do
-        (def (insort (: q (List (Tuple Int64 (Record (id Int64) (pri Int64))))) (: e (Tuple Int64 (Record (id Int64) (pri Int64)))))
+        (def (insort (: q (List (Tuple Int64 (Record (: id Int64) (: pri Int64))))) (: e (Tuple Int64 (Record (: id Int64) (: pri Int64)))))
           (match q
             ((list) (list e))
             ((list h .. t)


### PR DESCRIPTION
Candidate PR for v-syntax's merge-request (ref 57e32f488, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.