### PR TITLE
compiler-ml: extend db-demand with the NApp nullary-call producer (lazy demand spine coverage)

### DIFF
--- a/implementation/compiler-ml/src/db-demand.cdz
+++ b/implementation/compiler-ml/src/db-demand.cdz
@@ -31,7 +31,7 @@ import { Resolved } from "resolve-db"
 
 import { resolve-into-db } from "db-resolve"
 
-import { Tree, Node, node-at } from "parse-db"
+import { Tree, Node, node-at, def-body-of } from "parse-db"
 
 /// Demand the type fact at `id`, threading the Db explicitly. Returns `(db', fact)`:
 ///   - FILLED slot → `(db, memoized-fact)` — the Db is UNCHANGED (no recompute, no re-fill).
@@ -125,6 +125,23 @@ def demand-var(db: Db, id: Int64) = match Map.lookup(db-resolved-col(db), id) wi
       let ty = def-arrow-type(db-tree(db), defName, db-resolved-col(db), db-ty-col(db)) in (fill-ty(db, id, ty), ty)
   | _ => let ty = Ty.TyErr in (fill-ty(db, id, ty), ty)
 
+/// NApp NULLARY-call producer (`(mk)` = NApp(calleeName, -1)): the call's type is the callee BODY's type —
+/// beta-reduction over zero args, the result IS the body (mirrors infer-db's nullary NApp arm, rcdzc type_of
+/// reading the callee body's type). DEMAND the callee body's type (threading db, so it memoizes), then the
+/// call node's type = that body type. calleeName maps to its def-body via def-body-of; an unknown callee (no
+/// def-body) or an arg-bearing call (argId != -1, the param slice — a later producer) declines TyErr here.
+/// This is the smallest correct NApp arm: nullary, no param binding, no recursion descent (a recursive nullary
+/// self-call would re-enter — guarded by the memo HIT once its body is filled, but a genuine cycle is a later
+/// slice; the covered programs are non-recursive nullary calls like `(def (mk) 5) (mk)`).
+def demand-app(db: Db, id: Int64, calleeName: Int64, argId: Int64) =
+  (if (argId == (-1))
+   then (match def-body-of(db-tree(db), calleeName) with
+          | Option.Some(bodyId) =>
+              (match demand-typed-node(db, bodyId) with
+                | (db1, bodyTy) => (fill-ty(db1, id, bodyTy), bodyTy))    // call type = body type
+          | Option.None(_) => let ty = Ty.TyErr in (fill-ty(db, id, ty), ty))  // unknown callee → decline
+   else let ty = Ty.TyErr in (fill-ty(db, id, ty), ty))                  // arg-bearing call → param slice (later)
+
 def demand-typed-node(db: Db, id: Int64) = match require-ty(db, id) with
   | Option.Some(fact) => (db, fact)                                   // memo HIT — no recompute
   | Option.None(_) => match node-at(db-tree(db), id) with
@@ -132,6 +149,7 @@ def demand-typed-node(db: Db, id: Int64) = match require-ty(db, id) with
       | Option.Some(Node.NIf(c, t, e)) => demand-if(db, id, c, t, e)
       | Option.Some(Node.NLet(_, valId, bodyId)) => demand-let(db, id, valId, bodyId)
       | Option.Some(Node.NVar(_)) => demand-var(db, id)               // cross-column: resolve → binder type
+      | Option.Some(Node.NApp(calleeName, argId)) => demand-app(db, id, calleeName, argId)  // nullary call → body type
       // CATCH-ALL fallback (not just genuine leaves): every node kind WITHOUT an explicit arm above routes here
       // — a genuine leaf (NLit/NBoolLit/NAnnLit) computes its type from source, while any UNHANDLED composite
       // (e.g. NApp/NMatch, not yet given a producer) falls through demand-typed-leaf's `Option.Some(_) => TyErr`
@@ -324,4 +342,35 @@ def dd-diff-let-var-agrees-with-walk() =
   match parse-tokens([Tok.TLet, Tok.TName(1), Tok.TEq, Tok.TNum(2), Tok.TIn, Tok.TName(1)]) with
     | (root, tree) => (if agree(db-of(tree), root) then unit else trap("let x=2 in x: demand ≡ walk root type"))
 
-export { demand-typed, demand-typed-leaf, compute-leaf-type, demand-typed-node, demand-var, demand-typed-root }
+// ---- NApp nullary-call producer: a nullary call demand-types to its callee body's type -----------------
+import { add-node, empty-tree, record-def } from "parse-db"
+
+@test
+def dd-napp-nullary-types-to-body() =
+  // `(def (mk) 42) (mk)` — a nullary call NApp(900, -1) demand-types to the callee body's type (NLit 42 → int).
+  // Body = NLit(42) under name 900 via record-def; the call node's fact is the body's, filled via the producer.
+  (match add-node(empty-tree(), Node.NLit(42)) with | (bodyId, t1) =>
+    (let t1d = record-def(t1, 900, bodyId) in
+     (match add-node(t1d, Node.NApp(900, -1)) with | (root, tree) =>
+      (match demand-typed-node(db-of(tree), root) with
+        | (_db, fact) => (if is-int-ty(fact) then unit else trap("nullary (mk) types to its body's int type"))))))
+
+@test
+def dd-napp-nullary-memoizes-body-and-call() =
+  // demanding the nullary call fills BOTH the call node AND the body it demanded = 2 facts (the producer
+  // threaded the body's fill through). Pins the memo covers the demanded callee body.
+  (match add-node(empty-tree(), Node.NLit(7)) with | (bodyId, t1) =>
+    (let t1d = record-def(t1, 900, bodyId) in
+     (match add-node(t1d, Node.NApp(900, -1)) with | (root, tree) =>
+      (match demand-typed-node(db-of(tree), root) with
+        | (db1, _f) => (if typed-filled(db1) == 2 then unit else trap("nullary call memoizes call + body = 2 facts"))))))
+
+@test
+def dd-napp-unknown-callee-declines() =
+  // a nullary call to an UNKNOWN name (no record-def → def-body-of misses) declines TyErr (not a guess).
+  (match add-node(empty-tree(), Node.NApp(999, -1)) with | (root, tree) =>
+    (match demand-typed-node(db-of(tree), root) with
+      | (_db, Ty.TyErr) => unit
+      | _ => trap("a nullary call to an unknown callee declines TyErr")))
+
+export { demand-typed, demand-typed-leaf, compute-leaf-type, demand-typed-node, demand-var, demand-typed-root, demand-app }

--- a/implementation/compiler-ml/src/unify-subst.cdz
+++ b/implementation/compiler-ml/src/unify-subst.cdz
@@ -23,8 +23,8 @@
 ///   - deferred behaves as before (a SignDef/WidthDef takes the other — deferred is not a solvable var, it's a
 ///     literal's not-yet-constrained axis that grounds by defaulting; only SVar/WVar record bindings).
 import { Sign, Width, IntType, Ty, sign-eq, width-eq } from "ty"
-import { Subst, apply-sign, apply-width, subst-bind-sign, subst-bind-width } from "subst"
-import { sign-occurs, width-occurs } from "hm-vars"
+import { Subst, apply-sign, apply-width, apply, subst-bind-sign, subst-bind-width, subst-bind-ty } from "subst"
+import { sign-occurs, width-occurs, ty-occurs } from "hm-vars"
 
 /// Unify two SIGNS under a Subst, returning the extended Subst (or None on conflict). Resolves both sides first,
 /// then: same-var → unchanged; either side an unbound var → occurs-check + bind; two concretes → must be equal;
@@ -71,10 +71,30 @@ def unify-int-su(su: Subst, a: IntType, b: IntType) = match a with
         | Option.Some(su1) => unify-width-su(su1, wa, wb)
         | Option.None(_) => Option.None(unit))
 
-/// Unify two `Ty` under a Subst → `Some(extended Subst)` or `None` (conflict). Ints thread through unify-int-su;
-/// Bool~Bool no-ops (var-free); TyErr always conflicts (poison); TyFn unifies pairwise-params + result threading
-/// the Subst; TySum by decl-identity. The Subst-threading counterpart of unify-ty.cdz's stateless `unify-ty`.
-def unify-ty-su(su: Subst, a: Ty, b: Ty) = match a with
+/// Unify two `Ty` under a Subst → `Some(extended Subst)` or `None` (conflict). Mirrors rcdzc `unify` (unify.rs:236):
+/// FIRST resolve both sides through the current Subst (apply — so a bound var becomes its solution), THEN dispatch.
+/// A TyVar (after resolve, still unbound) is BOUND to the other side after an occurs-check (B3 — rcdzc unify.rs:244
+/// `(Ty::Var(v), t)|(t, Ty::Var(v)) => occurs-check then subst.tys.insert(v,t)`); two same-id vars are already
+/// equal. Concrete pairs dispatch structurally (unify-ty-concrete). This is the inline-unify primitive the demand
+/// type_of calls per node.
+def unify-ty-su(su: Subst, a: Ty, b: Ty) = bind-or-unify-ty(su, apply(su, a), apply(su, b))
+
+/// The resolved-both-sides step (ra/rb already `apply`d): handle the type-variable cases (rcdzc unify.rs:243-256),
+/// else dispatch to the concrete structural unify. A var on EITHER side binds to the other (occurs-checked).
+def bind-or-unify-ty(su: Subst, ra: Ty, rb: Ty) = match ra with
+  | Ty.TyVar(va) => (match rb with
+      | Ty.TyVar(vb) => (if va == vb then Option.Some(su)                         // same var → already equal
+                         else (if ty-occurs(su, va, rb) then Option.None(unit)    // occurs (a in b) → infinite → reject
+                               else Option.Some(subst-bind-ty(su, va, rb))))      // bind va := the other var
+      | _ => (if ty-occurs(su, va, rb) then Option.None(unit)                     // occurs → infinite type → reject
+              else Option.Some(subst-bind-ty(su, va, rb))))                       // bind va := the concrete/compound rb
+  | _ => (match rb with
+      | Ty.TyVar(vb) => (if ty-occurs(su, vb, ra) then Option.None(unit)          // symmetric: var on the RIGHT
+                         else Option.Some(subst-bind-ty(su, vb, ra)))
+      | _ => unify-ty-concrete(su, ra, rb))                                       // neither is a var → structural
+
+/// Structural unify of two NON-var (resolved) types (the concrete dispatch — was unify-ty-su's body pre-B3).
+def unify-ty-concrete(su: Subst, a: Ty, b: Ty) = match a with
   | Ty.TyInt(ita) => (match b with
     | Ty.TyInt(itb) => unify-int-su(su, ita, itb)
     | _ => Option.None(unit))
@@ -92,10 +112,8 @@ def unify-ty-su(su: Subst, a: Ty, b: Ty) = match a with
   | Ty.TySum(na) => (match b with
     | Ty.TySum(nb) => (if na == nb then Option.Some(su) else Option.None(unit))
     | _ => Option.None(unit))
-  // ARC-B5 B1 placeholder: a TyVar does NOT bind yet — B3 adds the real bind-with-occurs (mirroring rcdzc
-  // unify@unify.rs:244 `(Ty::Var(v), t) => occurs-check then subst.tys.insert(v,t)`), which needs the B2
-  // whole-type `tys` map. B1 adds the arm for exhaustiveness only; conservatively declines (a var unifies with
-  // nothing until B3). NOTE: this arm is only reachable once the descent seeds TyVars — no live caller yet.
+  // unreachable: bind-or-unify-ty handles both TyVar cases before dispatching here; a TyVar never reaches
+  // unify-ty-concrete. Arm present for exhaustiveness only.
   | Ty.TyVar(_) => Option.None(unit)
 
 /// Unify two same-length param lists PAIRWISE, threading the Subst left-to-right (each pair sees prior bindings).
@@ -119,7 +137,7 @@ def unify-ty-list-su(su: Subst, a: List(Ty), b: List(Ty), i: Int64) =
 // SUBST-THREADING witnesses they pin exactly this solver's paths + serve as permanent emit-slot regression pins).
 // ---- TESTS: unify BINDS vars into the Subst; a bound var stays solved (real solve, not inert) --------
 import { ty-int64, ty-fixed-int } from "ty"
-import { subst-empty, apply } from "subst"
+import { subst-empty } from "subst"
 
 @test
 def us-binds-sign-var-to-concrete() =
@@ -218,6 +236,64 @@ def us-fn-params-thread-and-bind() =
         | Ty.TyInt(IntType.IntType(Sign.Signed, Width.WFixed(w))) => (if w == 64 then unit else trap("param bound to Int64"))
         | _ => trap("fn param sign/width bind through the list"))
     | Option.None(_) => trap("(fn SVarInt -> SVarInt) ~ (fn Int64 -> Int64) unifies")
+
+// ---- B3: whole-type TyVar binding (rcdzc unify.rs:243-256) ----
+
+@test
+def us-b3-tyvar-binds-to-concrete() =
+  // unify TyVar 0 ~ TyBool → binds 0 := TyBool; applying to TyVar 0 yields TyBool. The whole-type analog of
+  // the sign/width var bind, mirroring rcdzc unify.rs:244.
+  match unify-ty-su(subst-empty(), Ty.TyVar(0), Ty.TyBool) with
+    | Option.Some(su) => (match apply(su, Ty.TyVar(0)) with
+        | Ty.TyBool => unit
+        | _ => trap("TyVar 0 ~ TyBool binds 0 to TyBool"))
+    | Option.None(_) => trap("TyVar 0 ~ TyBool must unify (bind)")
+
+@test
+def us-b3-tyvar-binds-on-either-side() =
+  // symmetric: TyBool ~ TyVar 0 (var on the RIGHT) also binds 0 := TyBool (rcdzc's `(t, Var v)` case).
+  match unify-ty-su(subst-empty(), ty-int64(), Ty.TyVar(0)) with
+    | Option.Some(su) => (match apply(su, Ty.TyVar(0)) with
+        | Ty.TyInt(IntType.IntType(Sign.Signed, Width.WFixed(w))) => (if w == 64 then unit else trap("var binds to Int64"))
+        | _ => trap("Int64 ~ TyVar 0 binds 0 to Int64 (var on the right)"))
+    | Option.None(_) => trap("Int64 ~ TyVar 0 must unify")
+
+@test
+def us-b3-same-var-already-equal() =
+  // TyVar 0 ~ TyVar 0 → already equal, no binding, Subst unchanged (rcdzc `(Var v, Var w) if v==w`).
+  match unify-ty-su(subst-empty(), Ty.TyVar(0), Ty.TyVar(0)) with
+    | Option.Some(_) => unit
+    | Option.None(_) => trap("TyVar 0 ~ TyVar 0 is already equal")
+
+@test
+def us-b3-bound-var-stays-solved-conflict() =
+  // THE real-solve pin: bind TyVar 0 := TyBool, then unify TyVar 0 ~ Int64 on that Subst → CONFLICT (0 resolves
+  // to TyBool via apply, and TyBool ~ Int64 is a concrete conflict). A whole-type var solved once stays solved.
+  match unify-ty-su(subst-empty(), Ty.TyVar(0), Ty.TyBool) with
+    | Option.Some(su) => (match unify-ty-su(su, Ty.TyVar(0), ty-int64()) with
+        | Option.None(_) => unit
+        | Option.Some(_) => trap("a var bound to TyBool must conflict with Int64"))
+    | Option.None(_) => trap("first unify binds")
+
+@test
+def us-b3-occurs-check-rejects-infinite() =
+  // occurs-check: unify TyVar 0 ~ (fn (TyVar 0) -> Bool) → 0 occurs in the fn param → REJECT (infinite type),
+  // mirroring rcdzc's occurs guard before the bind. Returns None.
+  let f = Ty.TyFn(List.push(([] : List(Ty)), Ty.TyVar(0)), Ty.TyBool) in
+  match unify-ty-su(subst-empty(), Ty.TyVar(0), f) with
+    | Option.None(_) => unit
+    | Option.Some(_) => trap("TyVar 0 ~ (fn (TyVar0) -> Bool) must fail the occurs-check")
+
+@test
+def us-b3-var-to-var-then-concrete-propagates() =
+  // TyVar 0 ~ TyVar 1 binds 0:=1; then TyVar 1 ~ TyBool binds 1:=Bool; TyVar 0 resolves THROUGH the chain to Bool.
+  match unify-ty-su(subst-empty(), Ty.TyVar(0), Ty.TyVar(1)) with
+    | Option.Some(su1) => (match unify-ty-su(su1, Ty.TyVar(1), Ty.TyBool) with
+        | Option.Some(su2) => (match apply(su2, Ty.TyVar(0)) with
+            | Ty.TyBool => unit
+            | _ => trap("TyVar 0 resolves through 0->1->Bool"))
+        | Option.None(_) => trap("bind 1 := Bool"))
+    | Option.None(_) => trap("bind 0 := 1")
 
 export {
   unify-sign-su,


### PR DESCRIPTION
Candidate PR for v-compiler-ml's merge-request (ref 0276e02b1, lane compiler-ml). Auto-merge armed; pr-sync's schedule-pass reaps on green.