### PR TITLE
syntax: cadenza-lint I1c — wire the level layer to `cdz lint` (--allow/--warn/--deny)

### DIFF
--- a/implementation/seed/crates/cadenza-syntax/src/cli.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/cli.rs
@@ -170,6 +170,19 @@ pub struct LintArgs {
     /// Emit diagnostics as JSON (`[{file?, line, col, severity, message, matched}]`).
     #[arg(long)]
     json: bool,
+
+    /// Suppress a named lint (or a whole group, e.g. `idiomatic`). Repeatable. Overrides the rule's
+    /// default level; a CLI level wins over any module `(allow/warn/deny …)` directive.
+    #[arg(long = "allow", value_name = "NAME")]
+    allow: Vec<String>,
+
+    /// Report a named lint (or group) as a warning. Repeatable. See `--allow` for precedence.
+    #[arg(long = "warn", value_name = "NAME")]
+    warn: Vec<String>,
+
+    /// Promote a named lint (or group) to an error (fails the run). Repeatable. See `--allow`.
+    #[arg(long = "deny", value_name = "NAME")]
+    deny: Vec<String>,
 }
 
 #[derive(Args)]
@@ -1229,6 +1242,21 @@ fn run_lint(args: &LintArgs) -> Result<bool, String> {
         return Err("no lint rules — pass --rules FILE and/or --rule '(lint …)'".into());
     }
 
+    // Build the CLI level overrides (allow/warn/deny NAME). Later flags win on the same key; a CLI
+    // level overrides a rule's default. Applied in a stable order (allow, warn, deny) so that if the
+    // SAME name is passed to two of them the last-listed flag group wins — deterministic, not arg-order
+    // dependent. (The module-directive layer, when it lands, is overlaid UNDER this via `overlay`.)
+    let mut levels = crate::query::lint::LintLevels::new();
+    for n in &args.allow {
+        levels.set(n.clone(), crate::query::lint::LintLevel::Allow);
+    }
+    for n in &args.warn {
+        levels.set(n.clone(), crate::query::lint::LintLevel::Warn);
+    }
+    for n in &args.deny {
+        levels.set(n.clone(), crate::query::lint::LintLevel::Deny);
+    }
+
     let targets = collect_targets(&args.files, args.from)?;
     let multi = targets.len() > 1;
     let mut any_error = false;
@@ -1241,8 +1269,13 @@ fn run_lint(args: &LintArgs) -> Result<bool, String> {
         let lbl = label(&spec.path);
 
         if args.json {
-            let (j, had_error) =
-                query::driver::lint_json(&set, &target, &src, spec.path.as_deref());
+            let (j, had_error) = query::driver::lint_json_with_levels(
+                &set,
+                &target,
+                &src,
+                spec.path.as_deref(),
+                &levels,
+            );
             // `j` is a per-file array; collect its elements for one flat array at the end.
             let inner = j.trim_start_matches('[').trim_end_matches(']');
             if !inner.is_empty() {
@@ -1250,7 +1283,8 @@ fn run_lint(args: &LintArgs) -> Result<bool, String> {
             }
             any_error |= had_error;
         } else {
-            let (report, had_error) = query::driver::lint_report(&set, &target, &src, &lbl);
+            let (report, had_error) =
+                query::driver::lint_report_with_levels(&set, &target, &src, &lbl, &levels);
             print!("{report}");
             any_error |= had_error;
         }

--- a/implementation/seed/crates/cadenza-syntax/src/query.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/query.rs
@@ -1945,7 +1945,19 @@ pub mod driver {
         src: &str,
         label: &str,
     ) -> (String, bool) {
-        let diags = lint::run(lints, &target.tree, target.spans.as_ref());
+        lint_report_with_levels(lints, target, src, label, &lint::LintLevels::default())
+    }
+
+    /// [`lint_report`] with per-lint level overrides applied (allow suppresses, deny → error, warn →
+    /// warning). The level-free [`lint_report`] delegates here with an empty [`lint::LintLevels`].
+    pub fn lint_report_with_levels(
+        lints: &lint::LintSet,
+        target: &Target,
+        src: &str,
+        label: &str,
+        levels: &lint::LintLevels,
+    ) -> (String, bool) {
+        let diags = lint::run_with_levels(lints, &target.tree, target.spans.as_ref(), levels);
         let mut out = String::new();
         for d in &diags {
             let loc = match d.span {
@@ -1968,7 +1980,19 @@ pub mod driver {
         src: &str,
         file: Option<&str>,
     ) -> (String, bool) {
-        let diags = lint::run(lints, &target.tree, target.spans.as_ref());
+        lint_json_with_levels(lints, target, src, file, &lint::LintLevels::default())
+    }
+
+    /// [`lint_json`] with per-lint level overrides applied. The level-free [`lint_json`] delegates
+    /// here with an empty [`lint::LintLevels`].
+    pub fn lint_json_with_levels(
+        lints: &lint::LintSet,
+        target: &Target,
+        src: &str,
+        file: Option<&str>,
+        levels: &lint::LintLevels,
+    ) -> (String, bool) {
+        let diags = lint::run_with_levels(lints, &target.tree, target.spans.as_ref(), levels);
         let mut arr = json::Array::new();
         for d in &diags {
             let mut obj = json::Object::new();
@@ -5440,6 +5464,33 @@ mod tests {
             assert!(j.contains("\"severity\":\"warning\""), "{j}");
             assert!(j.contains("\"message\":\"avoid\""), "{j}");
             assert!(j.contains("\"file\":\"a.sexp\""), "{j}");
+        }
+
+        #[test]
+        fn lint_report_with_levels_applies_allow_and_deny() {
+            use crate::query::lint::{LintLevel, LintLevels};
+            let (target, _) = driver::load(b"(if a true false)", Format::Sexpr).unwrap();
+            let set = crate::query::lint::LintSet::compile(
+                "(lint idiomatic/if-bool (if ,c true false) \"prefer the condition\")",
+            )
+            .unwrap();
+            let src = "(if a true false)";
+            // Deny → the warning-default rule reports as an error and flags the run.
+            let mut deny = LintLevels::new();
+            deny.set("idiomatic/if-bool", LintLevel::Deny);
+            let (report, had_error) =
+                driver::lint_report_with_levels(&set, &target, src, "in.sexp", &deny);
+            assert!(had_error, "deny promotes to error: {report}");
+            assert!(report.contains("error: prefer the condition"), "{report}");
+            // Allow → suppressed entirely (empty report, no error).
+            let mut allow = LintLevels::new();
+            allow.set("idiomatic", LintLevel::Allow); // group prefix covers idiomatic/if-bool
+            let (report, had_error) =
+                driver::lint_report_with_levels(&set, &target, src, "in.sexp", &allow);
+            assert!(
+                !had_error && report.is_empty(),
+                "allow suppresses: {report:?}"
+            );
         }
     }
 


### PR DESCRIPTION
Candidate PR for v-syntax's merge-request (ref 1e52518dd, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.