### PR TITLE
syntax: RT1 — reject the head-app record-TYPE field spelling Record(field(T)), steer to Record(field: T)

### DIFF
--- a/implementation/seed/crates/cadenza-syntax/src/cli.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/cli.rs
@@ -1245,16 +1245,17 @@ fn run_lint(args: &LintArgs) -> Result<bool, String> {
     // Build the CLI level overrides (allow/warn/deny NAME). Later flags win on the same key; a CLI
     // level overrides a rule's default. Applied in a stable order (allow, warn, deny) so that if the
     // SAME name is passed to two of them the last-listed flag group wins — deterministic, not arg-order
-    // dependent. (The module-directive layer, when it lands, is overlaid UNDER this via `overlay`.)
-    let mut levels = crate::query::lint::LintLevels::new();
+    // dependent. This is the CLI layer; it is overlaid ON TOP of each target's module-directive layer
+    // (CLI wins), matching the §3 order CLI > module > rule-default.
+    let mut cli_levels = crate::query::lint::LintLevels::new();
     for n in &args.allow {
-        levels.set(n.clone(), crate::query::lint::LintLevel::Allow);
+        cli_levels.set(n.clone(), crate::query::lint::LintLevel::Allow);
     }
     for n in &args.warn {
-        levels.set(n.clone(), crate::query::lint::LintLevel::Warn);
+        cli_levels.set(n.clone(), crate::query::lint::LintLevel::Warn);
     }
     for n in &args.deny {
-        levels.set(n.clone(), crate::query::lint::LintLevel::Deny);
+        cli_levels.set(n.clone(), crate::query::lint::LintLevel::Deny);
     }
 
     let targets = collect_targets(&args.files, args.from)?;
@@ -1267,6 +1268,12 @@ fn run_lint(args: &LintArgs) -> Result<bool, String> {
             continue;
         };
         let lbl = label(&spec.path);
+
+        // Resolve this target's effective levels: its own `(allow/warn/deny NAME)` module directives
+        // FIRST, then the CLI flags overlaid on top (CLI wins). Recomputed per target so each file
+        // honors its OWN in-source directives.
+        let mut levels = crate::query::lint::LintLevels::from_module_directives(&target.tree);
+        levels.overlay(&cli_levels);
 
         if args.json {
             let (j, had_error) = query::driver::lint_json_with_levels(

--- a/implementation/seed/crates/cadenza-syntax/src/parser.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/parser.rs
@@ -2718,6 +2718,25 @@ impl<'a> Parser<'a> {
     /// binder node, the forall type-variable NAMES (owned, since we re-synthesize the atoms), and the
     /// inner type body node. `None` for any other parameter shape (a plain binder, a non-forall
     /// annotation, or a `forall` with a malformed/empty binder list).
+    /// Whether `arg` is the obsolete head-application record-TYPE field spelling `field(T)` — a bare
+    /// two-element application `(name Type)` whose head is a NAME (not the `:` ascription head). The
+    /// canonical field is `(: name T)` (a three-element `:`-headed list), which this rejects; a positional
+    /// type argument that is itself an application `(F X)` where `F` is a type constructor is NOT a record
+    /// field (a record type takes no positional args), so this is only ever called on `Record(…)` args.
+    /// Guards on exactly two children with a name head — a nested `(: …)`, a 3+-element app, or a
+    /// bare-type arg is not flagged.
+    fn is_head_app_record_field(&self, arg: StructId) -> bool {
+        match self.builder.get(arg) {
+            crate::ast::Struct::List(children) if children.len() == 2 => {
+                // `(name Type)` — a name head that is NOT the `:` ascription marker. `(: name T)` has three
+                // children, so it never matches the len-2 guard; a `(List a)` positional arg would only
+                // reach here if it were a `Record` arg, which is itself the malformed case.
+                self.builder.as_name(children[0]).is_some_and(|h| h != ":")
+            }
+            _ => false,
+        }
+    }
+
     fn param_forall_binders(&self, p: StructId) -> Option<(StructId, Vec<String>, StructId)> {
         // p == (: binder ANNOT)
         let ann = self.builder.as_form(p, ":")?;
@@ -3678,7 +3697,25 @@ impl<'a> Parser<'a> {
                     node = self.member_access(node, start);
                 }
                 Kind::LParen => {
+                    // A `Record(…)` type-constructor takes ONLY named fields — each canonical `(: name T)`
+                    // ascription (from the `name: T` label surface). RT1 (DESIGN-record-type-syntax OQ-A):
+                    // reject the obsolete head-application field spelling `Record(field(T))` — where
+                    // `field(T)` parsed as a positional application arg `(field T)` — and steer to the
+                    // colon form `field: T`. A record type never takes a POSITIONAL type argument (unlike
+                    // `List(a)`/`Tuple(A, B)`), so a non-ascription arg here is unambiguously a malformed
+                    // field, not a legitimate application — no false-reject on generic type-apps.
+                    let head_is_record = self.builder.as_name(node) == Some("Record");
                     let args = self.type_arg_exprs();
+                    if head_is_record {
+                        for &arg in &args {
+                            if self.is_head_app_record_field(arg) {
+                                self.error(
+                                    "a record-type field is written `field: T`, not `field(T)` — \
+                                     use the colon form, e.g. `Record(x: Int64)`",
+                                );
+                            }
+                        }
+                    }
                     let span = start.merge(self.prev_span());
                     let mut items = Vec::with_capacity(args.len() + 1);
                     items.push(node);
@@ -6159,5 +6196,39 @@ mod tests {
             back.arenas.structurally_eq(&a),
             "record-type annotation round-trips: {printed:?}"
         );
+    }
+
+    #[test]
+    fn a_head_app_record_type_field_is_rejected_steering_to_the_colon_form() {
+        // RT1 (DESIGN-record-type-syntax OQ-A): the obsolete head-application record-TYPE field spelling
+        // `Record(field(T))` is REJECTED — a record-type field is written `field: T`. The message steers
+        // to the colon form. (The canonical `(: field T)` ascription is what the colon surface produces.)
+        for src in [
+            "def f(r: Record(a(Int64))) = r",
+            "def f(r: Record(x(Int64), y(Bool))) = r",
+            // Nested field type in head-app form is still the rejected spelling.
+            "def f(r: Record(inner(Option(Bytes)))) = r",
+        ] {
+            let p = read_ml(src);
+            assert!(!p.ok(), "head-app record field must reject: {src}");
+            assert!(
+                p.errors.iter().any(|e| e
+                    .message
+                    .contains("record-type field is written `field: T`")),
+                "the reject steers to the colon form: {src} -> {:?}",
+                p.errors
+            );
+        }
+        // The canonical colon form parses clean and builds the `(: name T)` ascription — NOT rejected.
+        let a = parse_ok("def f(r: Record(a: Int64, b: Bool)) = r");
+        assert_eq!(
+            crate::sexpr::print(&a),
+            "(def (f (: r (Record (: a Int64) (: b Bool)))) r)"
+        );
+        // NO false-reject on a legitimate GENERIC type application — `List(a)` / `Tuple(A, B)` take
+        // POSITIONAL type args (a bare type, not a `name(T)` field), so they still parse.
+        assert!(read_ml("def f(xs: List(a)) = xs").ok());
+        assert!(read_ml("def f(p: Tuple(Int64, Bool)) = p").ok());
+        assert!(read_ml("def f(o: Option(Int64)) = o").ok());
     }
 }

--- a/implementation/seed/crates/cadenza-syntax/src/query.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/query.rs
@@ -3351,6 +3351,41 @@ pub mod lint {
             }
             None
         }
+
+        /// The lint levels declared by a program's MODULE DIRECTIVES — the top-level `(allow NAME)` /
+        /// `(warn NAME)` / `(deny NAME)` forms (DESIGN-cadenza-lint §3). Scans the direct children of the
+        /// program root (a `(do …)` / `(module …)` wrapper, or a single top-level form) for those three
+        /// heads, each with one bare-name argument (a lint name or a group prefix). A later directive of
+        /// the same key wins (last-write). Unknown heads / malformed directives are IGNORED here — a lint
+        /// driver never rejects (it only reports); a program that is also COMPILED validates the directive
+        /// registry separately (rcdzc, CDZ0601). This is the MODULE layer; the CLI layer overlays ON TOP
+        /// via [`Self::overlay`] (CLI wins), matching the §3 order CLI > module > rule-default.
+        pub fn from_module_directives(program: &Tree) -> LintLevels {
+            let mut levels = LintLevels::new();
+            // The forms to scan: the root's direct children (unwrapping a `(do …)`/`(module …)` head), or
+            // the root itself when it is a single top-level form.
+            let forms: &[Tree] = match program {
+                Tree::List(items, _) => items,
+                Tree::Atom(_, _) => std::slice::from_ref(program),
+            };
+            for form in forms {
+                let Tree::List(parts, _) = form else { continue };
+                let (Some(head), Some(arg)) = (
+                    parts.first().and_then(|h| h.as_name()),
+                    parts.get(1).and_then(|a| a.as_name()),
+                ) else {
+                    continue;
+                };
+                // Exactly `(HEAD NAME)` — a directive with more/fewer args is not one of ours; skip it.
+                if parts.len() != 2 {
+                    continue;
+                }
+                if let Some(level) = LintLevel::parse(head) {
+                    levels.set(arg.to_string(), level);
+                }
+            }
+            levels
+        }
     }
 
     /// One reported diagnostic: the rule's message + severity, and the matched node's span (if the
@@ -6009,6 +6044,78 @@ mod tests {
                 diags[0].severity,
                 Severity::Info,
                 "default severity preserved"
+            );
+        }
+
+        // --- cadenza-lint I1 (module directives): (allow/warn/deny NAME) read from the program. ---
+
+        #[test]
+        fn module_directives_read_allow_warn_deny() {
+            let program = subj(
+                "(do (allow idiomatic/if-bool) (deny naming/camel-case) (warn idiomatic/redundant-let) \
+                 (def (main) 0) (export main))",
+            );
+            let levels = LintLevels::from_module_directives(&program);
+            assert_eq!(
+                levels.effective("idiomatic/if-bool"),
+                Some(LintLevel::Allow)
+            );
+            assert_eq!(levels.effective("naming/camel-case"), Some(LintLevel::Deny));
+            assert_eq!(
+                levels.effective("idiomatic/redundant-let"),
+                Some(LintLevel::Warn)
+            );
+            // An un-mentioned lint has no override.
+            assert_eq!(levels.effective("idiomatic/other"), None);
+        }
+
+        #[test]
+        fn a_module_group_directive_applies_to_the_group() {
+            let program = subj("(do (allow idiomatic) (def (main) 0) (export main))");
+            let levels = LintLevels::from_module_directives(&program);
+            assert_eq!(
+                levels.effective("idiomatic/if-bool"),
+                Some(LintLevel::Allow)
+            );
+            assert_eq!(levels.effective("naming/camel-case"), None);
+        }
+
+        #[test]
+        fn module_directives_ignore_unknown_heads_and_malformed_forms() {
+            // A lint driver never rejects — an unknown head (`pragma`, `def`), a bad level name, or a
+            // directive with the wrong arity is simply not a lint-level directive and is skipped.
+            let program = subj(
+                "(do (pragma default-int Int64) (allow) (allow a b) (bogus idiomatic/x) \
+                 (def (main) 0) (export main))",
+            );
+            let levels = LintLevels::from_module_directives(&program);
+            assert_eq!(levels.effective("idiomatic/x"), None, "bogus head ignored");
+            assert_eq!(
+                levels.effective("a"),
+                None,
+                "wrong-arity (allow a b) ignored"
+            );
+        }
+
+        #[test]
+        fn a_module_only_wrapped_program_is_scanned() {
+            // A `(module NAME …)` wrapper's directives are read the same as a `(do …)` program's.
+            let program = subj("(module m (deny idiomatic/if-bool) (def (main) 0))");
+            let levels = LintLevels::from_module_directives(&program);
+            assert_eq!(levels.effective("idiomatic/if-bool"), Some(LintLevel::Deny));
+        }
+
+        #[test]
+        fn cli_overlay_wins_over_a_module_directive() {
+            // module denies; CLI allows on top → the CLI level wins (CLI > module).
+            let program = subj("(do (deny idiomatic/if-bool) (def (main) 0) (export main))");
+            let mut levels = LintLevels::from_module_directives(&program);
+            let mut cli = LintLevels::new();
+            cli.set("idiomatic/if-bool", LintLevel::Allow);
+            levels.overlay(&cli);
+            assert_eq!(
+                levels.effective("idiomatic/if-bool"),
+                Some(LintLevel::Allow)
             );
         }
     }

--- a/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b1.cdz
+++ b/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b1.cdz
@@ -31,11 +31,11 @@ type EffectKind =
 
 // A bare structural record matching reducer.wit's effect-request. B1 constructs none (empty list).
 type EffectRequest =
-  | Mk(Record(kind(EffectKind), target(String), payload(Option(Bytes)), correlation(Option(Bytes))))
+  | Mk(Record(kind: EffectKind, target: String, payload: Option(Bytes), correlation: Option(Bytes)))
 
 // The fold — total, ignores its inputs, requests no effects.
 def apply(
-  ct: Record(family(String), version(UInt(32))),
+  ct: Record(family: String, version: UInt(32)),
   payload: Option(Bytes),
   resumes: Option(Bytes),
 ) -> List(EffectRequest) = []

--- a/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b2.cdz
+++ b/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b2.cdz
@@ -19,10 +19,10 @@ type EffectKind =
   | Emit()
 
 type EffectRequest =
-  | Mk(Record(kind(EffectKind), target(String), payload(Option(Bytes)), correlation(Option(Bytes))))
+  | Mk(Record(kind: EffectKind, target: String, payload: Option(Bytes), correlation: Option(Bytes)))
 
 def apply(
-  ct: Record(family(String), version(UInt(32))),
+  ct: Record(family: String, version: UInt(32)),
   payload: Option(Bytes),
   resumes: Option(Bytes),
 ) -> List(EffectRequest) = [

--- a/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b3.cdz
+++ b/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b3.cdz
@@ -22,7 +22,7 @@ type EffectKind =
   | Emit()
 
 type EffectRequest =
-  | Mk(Record(kind(EffectKind), target(String), payload(Option(Bytes)), correlation(Option(Bytes))))
+  | Mk(Record(kind: EffectKind, target: String, payload: Option(Bytes), correlation: Option(Bytes)))
 
 // kv host import — BOUND peer interface over the shared value-heap runtime (handle ABI): get + put.
 effect Kv =
@@ -53,7 +53,7 @@ def bump-count(prev: Option(Bytes)) -> Bytes =
   Bytes.of([UInt8.wrap(prev-byte + 1)])
 
 def apply(
-  ct: Record(family(String), version(UInt(32))),
+  ct: Record(family: String, version: UInt(32)),
   payload: Option(Bytes),
   resumes: Option(Bytes),
 ) -> List(EffectRequest) = match resumes with

--- a/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_genesis.cdz
+++ b/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_genesis.cdz
@@ -32,7 +32,7 @@ type EffectKind =
   | Emit()
 
 type EffectRequest =
-  | Mk(Record(kind(EffectKind), target(String), payload(Option(Bytes)), correlation(Option(Bytes))))
+  | Mk(Record(kind: EffectKind, target: String, payload: Option(Bytes), correlation: Option(Bytes)))
 
 // kv host import (bound peer iface over the shared value-heap runtime — handle ABI): only put is needed
 // (genesis WRITES setup state; it never reads to decide an action).
@@ -52,7 +52,7 @@ def setup-key(family: String) -> Option(Bytes) =
   else None()
 
 def apply(
-  ct: Record(family(String), version(UInt(32))),
+  ct: Record(family: String, version: UInt(32)),
   payload: Option(Bytes),
   resumes: Option(Bytes),
 ) -> List(EffectRequest) = match resumes with

--- a/implementation/seed/crates/rcdzc/src/db.rs
+++ b/implementation/seed/crates/rcdzc/src/db.rs
@@ -6189,7 +6189,25 @@ fn top_items(ast: &Arenas) -> Vec<StructId> {
 /// comment. It DECLARES nothing (`scan_top_level` has no branch for it — it is simply skipped), so it
 /// produces no index entry; it is listed here ONLY so `unknown_top_forms` recognizes it as legitimate
 /// and does not reject it as an unmodeled declaration. It is inert at every later stage (a no-op form).
-const TOP_LEVEL_FORMS: &[&str] = &["def", "export", "type", "effect", "bind", "module-doc"];
+///
+/// `allow`/`warn`/`deny` are the LINT-LEVEL directives (`(allow NAME)`/`(warn NAME)`/`(deny NAME)`,
+/// DESIGN-cadenza-lint §3) — lint-only metadata the COMPILER has no stake in (concierge ruling: rcdzc
+/// stays decoupled; the lint NAME is validated by `cdz lint`, which owns the lint catalog, NOT here). Like
+/// `module-doc` they DECLARE nothing (no `scan_top_level` branch — skipped) and are inert at every later
+/// stage; listed here ONLY so a program carrying a lint directive at top level does not DECLINE when it is
+/// compiled (the directive is ignored by the compile path, honored by `cdz lint`). A compile-time
+/// lint-name check, if ever wanted, belongs in `cdz lint` / a shared catalog crate, never in rcdzc.
+const TOP_LEVEL_FORMS: &[&str] = &[
+    "def",
+    "export",
+    "type",
+    "effect",
+    "bind",
+    "module-doc",
+    "allow",
+    "warn",
+    "deny",
+];
 
 /// The declaration/directive keywords a top-level `(head …)` form may legitimately lead with — the
 /// closed candidate pool for a "did you mean?" when an unknown top-level head is a plausible TYPO of one

--- a/implementation/seed/crates/rcdzc/src/link.rs
+++ b/implementation/seed/crates/rcdzc/src/link.rs
@@ -354,6 +354,15 @@ pub fn link(files: &[(String, Arenas)], entry: &str) -> Result<LinkedProgram, Re
             if ast.as_form(item, "module-doc").is_some() {
                 continue;
             }
+            // The lint-level directives `(allow/warn/deny NAME)` are lint-only metadata (the compiler
+            // ignores them; `cdz lint` honors them — concierge ruling, DESIGN-cadenza-lint §3). Inert,
+            // declare nothing — skip so they never land in the merged `(do …)` as an unbound call.
+            if ast.as_form(item, "allow").is_some()
+                || ast.as_form(item, "warn").is_some()
+                || ast.as_form(item, "deny").is_some()
+            {
+                continue;
+            }
             if ast.as_form(item, "export").is_some() && !is_entry {
                 continue;
             }

--- a/implementation/seed/crates/rcdzc/src/tests.rs
+++ b/implementation/seed/crates/rcdzc/src/tests.rs
@@ -26013,6 +26013,34 @@ mod match_engine {
         }
     }
 
+    #[test]
+    fn a_lint_level_directive_is_inert_accepted_not_declined() {
+        // DESIGN-cadenza-lint §3 (concierge ruling: rcdzc INERT-ACCEPTS, does not validate). A program
+        // carrying a `(allow/warn/deny NAME)` lint-level directive at top level COMPILES — the directive
+        // is lint-only metadata the compiler ignores (like `module-doc`): it declares nothing, is skipped
+        // in the link merge (never lands as an unbound call), and is NOT flagged by `unknown_top_forms`.
+        // Before the fix it declined "unbound name `allow` at the top level".
+        for src in [
+            "(do (allow idiomatic/if-bool) (def (main) 0) (export main))",
+            "(do (deny naming/camel-case) (def (main) 0) (export main))",
+            "(do (warn idiomatic/redundant-let) (def (main) 0) (export main))",
+            // Multiple directives + a group prefix, interleaved with real declarations.
+            "(do (allow idiomatic) (deny naming/camel-case) (def (main) 0) (export main))",
+        ] {
+            let diags = crate::diagnostics(&mut crate::db::Db::load(parse(src)));
+            assert!(
+                diags.is_empty(),
+                "a lint-level directive must be inert-accepted, not flagged: {src}\n  -> {:?}",
+                diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+            );
+            // And it COMPILES end-to-end (the directive is skipped in the link merge — no unbound call).
+            assert!(
+                compile_component(&crate::codec::encode(&parse(src))).is_ok(),
+                "a program with a lint-level directive must compile: {src}"
+            );
+        }
+    }
+
     /// A MALFORMED top-level `@`-annotation — one that wraps no well-formed definition — must name the
     /// annotation SHAPE, not resolve as the misleading "unbound name `@` at the top level". `@` is the
     /// general-purpose annotation head `(@ <name> (def …))`; `strip_annotations` rewrites every well-formed


### PR DESCRIPTION
Candidate PR for v-syntax's merge-request (ref 30d9b0ad3, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.