### PR TITLE
cadenza-ast: schema_canonical_bytes — the single-source effect-schema content-hash input (algo-free)

### DIFF
--- a/guide/src/content/chapters/WritingAReducer.tsx
+++ b/guide/src/content/chapters/WritingAReducer.tsx
@@ -58,7 +58,7 @@ export default function WritingAReducer() {
   | Emit()
 
 type EffectRequest =
-  | Mk(Record(kind(EffectKind), target(String), payload(Option(Bytes)), correlation(Option(Bytes))))
+  | Mk(Record(kind: EffectKind, target: String, payload: Option(Bytes), correlation: Option(Bytes)))
 
 def main() = EffectKind.Http()`}
       />
@@ -74,10 +74,10 @@ def main() = EffectKind.Http()`}
         authoredIn="ml"
         source={`type EffectKind = | Shell() | Http() | Model() | Now() | Timer() | Emit()
 type EffectRequest =
-  | Mk(Record(kind(EffectKind), target(String), payload(Option(Bytes)), correlation(Option(Bytes))))
+  | Mk(Record(kind: EffectKind, target: String, payload: Option(Bytes), correlation: Option(Bytes)))
 
 def apply(
-  ct: Record(family(String), version(UInt(32))),
+  ct: Record(family: String, version: UInt(32)),
   payload: Option(Bytes),
   resumes: Option(Bytes),
 ) -> List(EffectRequest) = []
@@ -113,10 +113,10 @@ def main() = apply({ family = "message", version = 1 }, None(), None())`}
         authoredIn="ml"
         source={`type EffectKind = | Shell() | Http() | Model() | Now() | Timer() | Emit()
 type EffectRequest =
-  | Mk(Record(kind(EffectKind), target(String), payload(Option(Bytes)), correlation(Option(Bytes))))
+  | Mk(Record(kind: EffectKind, target: String, payload: Option(Bytes), correlation: Option(Bytes)))
 
 def apply(
-  ct: Record(family(String), version(UInt(32))),
+  ct: Record(family: String, version: UInt(32)),
   payload: Option(Bytes),
   resumes: Option(Bytes),
 ) -> List(EffectRequest) =
@@ -156,10 +156,10 @@ def main() =
         authoredIn="ml"
         source={`type EffectKind = | Shell() | Http() | Model() | Now() | Timer() | Emit()
 type EffectRequest =
-  | Mk(Record(kind(EffectKind), target(String), payload(Option(Bytes)), correlation(Option(Bytes))))
+  | Mk(Record(kind: EffectKind, target: String, payload: Option(Bytes), correlation: Option(Bytes)))
 
 def apply(
-  ct: Record(family(String), version(UInt(32))),
+  ct: Record(family: String, version: UInt(32)),
   payload: Option(Bytes),
   resumes: Option(Bytes),
 ) -> List(EffectRequest) =

--- a/implementation/seed/crates/cadenza-ast/src/codec.rs
+++ b/implementation/seed/crates/cadenza-ast/src/codec.rs
@@ -232,6 +232,28 @@ pub fn encode(arenas: &Arenas) -> Vec<u8> {
     out
 }
 
+/// The CANONICAL content bytes of `arenas` — the single-source input a content hash is taken over.
+///
+/// This is exactly [`encode`] (the canonical `cdzast\x00\x01` bytes: canonicalized so equal programs
+/// encode identically, versioned header, TOTAL round-trip), named for its content-addressing role so a
+/// caller computing an identity does not re-derive the encoding. In particular an effect SCHEMA (its op
+/// signatures + type contract, represented AS a name-headed cdzast AST — DESIGN-userspace-effects I11b)
+/// gets its EFFECT-SCHEMA CONTENT HASH as `Hash::of(schema_canonical_bytes(&schema_ast))`, where
+/// `Hash::of` is the codebase's one unified content-address (blake3, per the operator's one-algo
+/// ruling). The hash is DELIBERATELY the caller's step, not this crate's: `cadenza-ast` is the
+/// dependency-light bottom crate and its [`crate::dict::Hash`] is an algo-free 32-byte container
+/// (caller-hashes is the established contract — concierge ruling 2026-08-08, floor call (B)). Keeping
+/// the ENCODING here single-sources the one thing that could drift; the hash step is a uniform
+/// `Hash::of` everywhere, so no per-caller re-implementation and no drift.
+///
+/// Identity taken this way is STABLE across cdzast container-format evolution the same way the kernel's
+/// `Event::hash` is: it hashes the canonical `\x00\x01` bytes, which are format-pinned, so equal schemas
+/// always hash equal regardless of later additive vocabulary growth (new head names need no format bump;
+/// only a genuinely new leaf kind bumps to `\x00\x02`).
+pub fn schema_canonical_bytes(arenas: &Arenas) -> Vec<u8> {
+    encode(arenas)
+}
+
 /// Extract the subtree rooted at `id` of `arenas` into its own standalone `Arenas` (a fresh, dense
 /// arena rooted at the copied subtree). Used to compute a subtree's CANONICAL content bytes (via
 /// `encode`) for dict-match keying. Iterative (explicit stack), so a deep subtree can't overflow.
@@ -2151,6 +2173,63 @@ mod tests {
             bytes,
             encode(&back),
             "canonical \\x00\\x01 bytes must be a fixed point"
+        );
+    }
+
+    #[test]
+    fn schema_canonical_bytes_is_encode_and_equal_schemas_share_bytes() {
+        // The effect-schema content-hash INPUT (DESIGN-userspace-effects I11b): `schema_canonical_bytes`
+        // is exactly the canonical `encode` bytes (algo-free — the caller does `Hash::of` over these).
+        let a = sample();
+        assert_eq!(
+            schema_canonical_bytes(&a),
+            encode(&a),
+            "schema_canonical_bytes is the canonical encode bytes"
+        );
+        // The identity property callers rely on: two schema arenas that are STRUCTURALLY EQUAL but built
+        // in a DIFFERENT occurrence order produce IDENTICAL canonical bytes (so `Hash::of` of them is
+        // equal) — `encode` canonicalizes, so occurrence order does not perturb the content address. A
+        // schema `(effect E (op get (-> Unit A)) (op put (-> A Unit)))` built two ways.
+        fn schema(order_swapped: bool) -> Arenas {
+            let mut b = Builder::new();
+            let effect = b.name("effect");
+            let ename = b.name("E");
+            // Build the two op sub-lists; swap which is constructed first to vary occurrence order.
+            let mk_get = |b: &mut Builder| {
+                let op = b.name("op");
+                let n = b.name("get");
+                let arrow = b.name("->");
+                let unit = b.name("Unit");
+                let a_ty = b.name("A");
+                let sig = b.list(vec![arrow, unit, a_ty]);
+                b.list(vec![op, n, sig])
+            };
+            let mk_put = |b: &mut Builder| {
+                let op = b.name("op");
+                let n = b.name("put");
+                let arrow = b.name("->");
+                let a_ty = b.name("A");
+                let unit = b.name("Unit");
+                let sig = b.list(vec![arrow, a_ty, unit]);
+                b.list(vec![op, n, sig])
+            };
+            let (get, put) = if order_swapped {
+                let put = mk_put(&mut b);
+                let get = mk_get(&mut b);
+                (get, put)
+            } else {
+                let get = mk_get(&mut b);
+                let put = mk_put(&mut b);
+                (get, put)
+            };
+            let root = b.list(vec![effect, ename, get, put]);
+            b.finish(root)
+        }
+        assert_eq!(
+            schema_canonical_bytes(&schema(false)),
+            schema_canonical_bytes(&schema(true)),
+            "structurally-equal schemas built in different orders must share canonical bytes \
+             (so their effect-schema content hash is equal)"
         );
     }
 

--- a/implementation/seed/crates/cadenza-syntax/src/cli.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/cli.rs
@@ -1245,16 +1245,17 @@ fn run_lint(args: &LintArgs) -> Result<bool, String> {
     // Build the CLI level overrides (allow/warn/deny NAME). Later flags win on the same key; a CLI
     // level overrides a rule's default. Applied in a stable order (allow, warn, deny) so that if the
     // SAME name is passed to two of them the last-listed flag group wins — deterministic, not arg-order
-    // dependent. (The module-directive layer, when it lands, is overlaid UNDER this via `overlay`.)
-    let mut levels = crate::query::lint::LintLevels::new();
+    // dependent. This is the CLI layer; it is overlaid ON TOP of each target's `@`-attribute lint
+    // directives (CLI wins), matching the §3 order CLI > in-source attribute > rule-default.
+    let mut cli_levels = crate::query::lint::LintLevels::new();
     for n in &args.allow {
-        levels.set(n.clone(), crate::query::lint::LintLevel::Allow);
+        cli_levels.set(n.clone(), crate::query::lint::LintLevel::Allow);
     }
     for n in &args.warn {
-        levels.set(n.clone(), crate::query::lint::LintLevel::Warn);
+        cli_levels.set(n.clone(), crate::query::lint::LintLevel::Warn);
     }
     for n in &args.deny {
-        levels.set(n.clone(), crate::query::lint::LintLevel::Deny);
+        cli_levels.set(n.clone(), crate::query::lint::LintLevel::Deny);
     }
 
     let targets = collect_targets(&args.files, args.from)?;
@@ -1267,6 +1268,12 @@ fn run_lint(args: &LintArgs) -> Result<bool, String> {
             continue;
         };
         let lbl = label(&spec.path);
+
+        // Resolve this target's effective levels: its own `@allow/@warn/@deny(NAME)` attribute
+        // directives FIRST, then the CLI flags overlaid on top (CLI wins). Recomputed per target so
+        // each file honors its OWN in-source attributes.
+        let mut levels = crate::query::lint::LintLevels::from_attributes(&target.tree);
+        levels.overlay(&cli_levels);
 
         if args.json {
             let (j, had_error) = query::driver::lint_json_with_levels(

--- a/implementation/seed/crates/cadenza-syntax/src/parser.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/parser.rs
@@ -2718,6 +2718,25 @@ impl<'a> Parser<'a> {
     /// binder node, the forall type-variable NAMES (owned, since we re-synthesize the atoms), and the
     /// inner type body node. `None` for any other parameter shape (a plain binder, a non-forall
     /// annotation, or a `forall` with a malformed/empty binder list).
+    /// Whether `arg` is the obsolete head-application record-TYPE field spelling `field(T)` — a bare
+    /// two-element application `(name Type)` whose head is a NAME (not the `:` ascription head). The
+    /// canonical field is `(: name T)` (a three-element `:`-headed list), which this rejects; a positional
+    /// type argument that is itself an application `(F X)` where `F` is a type constructor is NOT a record
+    /// field (a record type takes no positional args), so this is only ever called on `Record(…)` args.
+    /// Guards on exactly two children with a name head — a nested `(: …)`, a 3+-element app, or a
+    /// bare-type arg is not flagged.
+    fn is_head_app_record_field(&self, arg: StructId) -> bool {
+        match self.builder.get(arg) {
+            crate::ast::Struct::List(children) if children.len() == 2 => {
+                // `(name Type)` — a name head that is NOT the `:` ascription marker. `(: name T)` has three
+                // children, so it never matches the len-2 guard; a `(List a)` positional arg would only
+                // reach here if it were a `Record` arg, which is itself the malformed case.
+                self.builder.as_name(children[0]).is_some_and(|h| h != ":")
+            }
+            _ => false,
+        }
+    }
+
     fn param_forall_binders(&self, p: StructId) -> Option<(StructId, Vec<String>, StructId)> {
         // p == (: binder ANNOT)
         let ann = self.builder.as_form(p, ":")?;
@@ -3678,7 +3697,25 @@ impl<'a> Parser<'a> {
                     node = self.member_access(node, start);
                 }
                 Kind::LParen => {
+                    // A `Record(…)` type-constructor takes ONLY named fields — each canonical `(: name T)`
+                    // ascription (from the `name: T` label surface). RT1 (DESIGN-record-type-syntax OQ-A):
+                    // reject the obsolete head-application field spelling `Record(field(T))` — where
+                    // `field(T)` parsed as a positional application arg `(field T)` — and steer to the
+                    // colon form `field: T`. A record type never takes a POSITIONAL type argument (unlike
+                    // `List(a)`/`Tuple(A, B)`), so a non-ascription arg here is unambiguously a malformed
+                    // field, not a legitimate application — no false-reject on generic type-apps.
+                    let head_is_record = self.builder.as_name(node) == Some("Record");
                     let args = self.type_arg_exprs();
+                    if head_is_record {
+                        for &arg in &args {
+                            if self.is_head_app_record_field(arg) {
+                                self.error(
+                                    "a record-type field is written `field: T`, not `field(T)` — \
+                                     use the colon form, e.g. `Record(x: Int64)`",
+                                );
+                            }
+                        }
+                    }
                     let span = start.merge(self.prev_span());
                     let mut items = Vec::with_capacity(args.len() + 1);
                     items.push(node);
@@ -6159,5 +6196,39 @@ mod tests {
             back.arenas.structurally_eq(&a),
             "record-type annotation round-trips: {printed:?}"
         );
+    }
+
+    #[test]
+    fn a_head_app_record_type_field_is_rejected_steering_to_the_colon_form() {
+        // RT1 (DESIGN-record-type-syntax OQ-A): the obsolete head-application record-TYPE field spelling
+        // `Record(field(T))` is REJECTED — a record-type field is written `field: T`. The message steers
+        // to the colon form. (The canonical `(: field T)` ascription is what the colon surface produces.)
+        for src in [
+            "def f(r: Record(a(Int64))) = r",
+            "def f(r: Record(x(Int64), y(Bool))) = r",
+            // Nested field type in head-app form is still the rejected spelling.
+            "def f(r: Record(inner(Option(Bytes)))) = r",
+        ] {
+            let p = read_ml(src);
+            assert!(!p.ok(), "head-app record field must reject: {src}");
+            assert!(
+                p.errors.iter().any(|e| e
+                    .message
+                    .contains("record-type field is written `field: T`")),
+                "the reject steers to the colon form: {src} -> {:?}",
+                p.errors
+            );
+        }
+        // The canonical colon form parses clean and builds the `(: name T)` ascription — NOT rejected.
+        let a = parse_ok("def f(r: Record(a: Int64, b: Bool)) = r");
+        assert_eq!(
+            crate::sexpr::print(&a),
+            "(def (f (: r (Record (: a Int64) (: b Bool)))) r)"
+        );
+        // NO false-reject on a legitimate GENERIC type application — `List(a)` / `Tuple(A, B)` take
+        // POSITIONAL type args (a bare type, not a `name(T)` field), so they still parse.
+        assert!(read_ml("def f(xs: List(a)) = xs").ok());
+        assert!(read_ml("def f(p: Tuple(Int64, Bool)) = p").ok());
+        assert!(read_ml("def f(o: Option(Int64)) = o").ok());
     }
 }

--- a/implementation/seed/crates/cadenza-syntax/src/query.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/query.rs
@@ -3351,6 +3351,47 @@ pub mod lint {
             }
             None
         }
+
+        /// The lint levels declared by a program's `@`-ATTRIBUTE lint directives (operator directive:
+        /// lint directives ride the existing `@`-attribute mechanism, not a bare list head). An item
+        /// attribute `@allow("NAME") item` parses to `(@ (allow "NAME") item)` — the `@`-head wraps a
+        /// two-element `(LEVEL "NAME")` attribute over the item; `LEVEL` ∈ `allow`/`warn`/`deny`, `NAME`
+        /// is a STRING literal (a namespaced lint name like `"idiomatic/if-bool"` — a string so the `/`
+        /// is not parsed as division). This collects every such attribute reachable in the tree into a
+        /// program-wide level map (a later increment scopes an item attribute to only the subnode set it
+        /// wraps — the operator's "attaches to a set of subnodes" — rather than program-wide; the
+        /// program-root case is identical either way). A later directive of the same key wins.
+        ///
+        /// The module-level `@!allow NAME` form (Rust's `#![allow]`, desugars via the `@!`→`pragma`
+        /// path) is a follow-on: it routes through the pragma registry, which needs to recognize the
+        /// lint keys — a separate change. This reads the ITEM `@`-attribute form.
+        pub fn from_attributes(program: &Tree) -> LintLevels {
+            let mut levels = LintLevels::new();
+            fn walk(t: &Tree, levels: &mut LintLevels) {
+                if let Tree::List(items, _) = t {
+                    // An `@`-attribute node is `(@ ATTR form)` — head `@`, a `(LEVEL "NAME")` attr, a form.
+                    if items.first().and_then(|h| h.as_name()) == Some("@")
+                        && let Some(attr) = items.get(1)
+                        && let Tree::List(parts, _) = attr
+                        && parts.len() == 2
+                        && let Some(level) = parts
+                            .first()
+                            .and_then(|h| h.as_name())
+                            .and_then(LintLevel::parse)
+                        && let Some(name) = parts.get(1).and_then(as_str_leaf)
+                    {
+                        levels.set(name.to_string(), level);
+                    }
+                    // Descend into every child — attributes can nest (`@a def (… @b …)`) and appear at
+                    // any depth (an item attribute inside a module body).
+                    for child in items {
+                        walk(child, levels);
+                    }
+                }
+            }
+            walk(program, &mut levels);
+            levels
+        }
     }
 
     /// One reported diagnostic: the rule's message + severity, and the matched node's span (if the
@@ -6009,6 +6050,94 @@ mod tests {
                 diags[0].severity,
                 Severity::Info,
                 "default severity preserved"
+            );
+        }
+
+        // --- cadenza-lint I1 (@-attribute directives): operator ruled lint levels ride @-attributes. ---
+
+        #[test]
+        fn at_attributes_read_allow_warn_deny_from_the_parsed_tree() {
+            // The `@allow("NAME")` item attribute parses to `(@ (allow "NAME") item)`; `from_attributes`
+            // collects each such level directive. NAME is a STRING so a namespaced `idiomatic/if-bool`
+            // is not misparsed as division.
+            let program = subj(
+                "(do (@ (allow \"idiomatic/if-bool\") (def (main) 0)) \
+                 (@ (deny \"naming/camel-case\") (def (g) 1)) \
+                 (@ (warn \"idiomatic/redundant-let\") (def (h) 2)))",
+            );
+            let levels = LintLevels::from_attributes(&program);
+            assert_eq!(
+                levels.effective("idiomatic/if-bool"),
+                Some(LintLevel::Allow)
+            );
+            assert_eq!(levels.effective("naming/camel-case"), Some(LintLevel::Deny));
+            assert_eq!(
+                levels.effective("idiomatic/redundant-let"),
+                Some(LintLevel::Warn)
+            );
+            assert_eq!(levels.effective("idiomatic/other"), None);
+        }
+
+        #[test]
+        fn an_at_attribute_group_prefix_applies_to_the_group() {
+            let program = subj("(do (@ (allow \"idiomatic\") (def (main) 0)))");
+            let levels = LintLevels::from_attributes(&program);
+            assert_eq!(
+                levels.effective("idiomatic/if-bool"),
+                Some(LintLevel::Allow)
+            );
+            assert_eq!(levels.effective("naming/camel-case"), None);
+        }
+
+        #[test]
+        fn at_attributes_nest_and_are_found_at_any_depth() {
+            // An attribute inside a nested form (a module body, a nested annotated def) is still found.
+            let program = subj(
+                "(module m (@ (deny \"idiomatic/if-bool\") (def (main) 0)) \
+                 (@ (allow \"idiomatic/redundant-let\") (def (g) 1)))",
+            );
+            let levels = LintLevels::from_attributes(&program);
+            assert_eq!(levels.effective("idiomatic/if-bool"), Some(LintLevel::Deny));
+            assert_eq!(
+                levels.effective("idiomatic/redundant-let"),
+                Some(LintLevel::Allow)
+            );
+        }
+
+        #[test]
+        fn a_non_lint_at_attribute_is_ignored() {
+            // A `@`-attribute whose head is not a lint level (`@requires`, `@tag`) is not a lint
+            // directive — `from_attributes` skips it (no spurious level).
+            let program = subj(
+                "(do (@ (requires (> x 0)) (def (f (: x Int64)) x)) \
+                 (@ (tag \"slow\") (def (g) 1)))",
+            );
+            let levels = LintLevels::from_attributes(&program);
+            assert_eq!(levels.effective("requires"), None);
+            assert_eq!(levels.effective("tag"), None);
+        }
+
+        #[test]
+        fn a_non_string_at_attribute_name_is_ignored() {
+            // The lint NAME must be a STRING literal. A bare-name arg (`(allow idiomatic)` — not a
+            // string) is not the directive shape and is skipped, so a stray non-string never sets a
+            // bogus level. (The surface always writes the string form `@allow("idiomatic/if-bool")`.)
+            let program = subj("(do (@ (allow idiomatic) (def (main) 0)))");
+            let levels = LintLevels::from_attributes(&program);
+            assert_eq!(levels.effective("idiomatic"), None);
+        }
+
+        #[test]
+        fn cli_overlay_wins_over_an_at_attribute() {
+            // In-source `@deny`, CLI `--allow` on top → CLI wins (CLI > in-source attribute).
+            let program = subj("(do (@ (deny \"idiomatic/if-bool\") (def (main) 0)))");
+            let mut levels = LintLevels::from_attributes(&program);
+            let mut cli = LintLevels::new();
+            cli.set("idiomatic/if-bool", LintLevel::Allow);
+            levels.overlay(&cli);
+            assert_eq!(
+                levels.effective("idiomatic/if-bool"),
+                Some(LintLevel::Allow)
             );
         }
     }

--- a/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b1.cdz
+++ b/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b1.cdz
@@ -31,11 +31,11 @@ type EffectKind =
 
 // A bare structural record matching reducer.wit's effect-request. B1 constructs none (empty list).
 type EffectRequest =
-  | Mk(Record(kind(EffectKind), target(String), payload(Option(Bytes)), correlation(Option(Bytes))))
+  | Mk(Record(kind: EffectKind, target: String, payload: Option(Bytes), correlation: Option(Bytes)))
 
 // The fold — total, ignores its inputs, requests no effects.
 def apply(
-  ct: Record(family(String), version(UInt(32))),
+  ct: Record(family: String, version: UInt(32)),
   payload: Option(Bytes),
   resumes: Option(Bytes),
 ) -> List(EffectRequest) = []

--- a/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b2.cdz
+++ b/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b2.cdz
@@ -19,10 +19,10 @@ type EffectKind =
   | Emit()
 
 type EffectRequest =
-  | Mk(Record(kind(EffectKind), target(String), payload(Option(Bytes)), correlation(Option(Bytes))))
+  | Mk(Record(kind: EffectKind, target: String, payload: Option(Bytes), correlation: Option(Bytes)))
 
 def apply(
-  ct: Record(family(String), version(UInt(32))),
+  ct: Record(family: String, version: UInt(32)),
   payload: Option(Bytes),
   resumes: Option(Bytes),
 ) -> List(EffectRequest) = [

--- a/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b3.cdz
+++ b/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_b3.cdz
@@ -22,7 +22,7 @@ type EffectKind =
   | Emit()
 
 type EffectRequest =
-  | Mk(Record(kind(EffectKind), target(String), payload(Option(Bytes)), correlation(Option(Bytes))))
+  | Mk(Record(kind: EffectKind, target: String, payload: Option(Bytes), correlation: Option(Bytes)))
 
 // kv host import — BOUND peer interface over the shared value-heap runtime (handle ABI): get + put.
 effect Kv =
@@ -53,7 +53,7 @@ def bump-count(prev: Option(Bytes)) -> Bytes =
   Bytes.of([UInt8.wrap(prev-byte + 1)])
 
 def apply(
-  ct: Record(family(String), version(UInt(32))),
+  ct: Record(family: String, version: UInt(32)),
   payload: Option(Bytes),
   resumes: Option(Bytes),
 ) -> List(EffectRequest) = match resumes with

--- a/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_genesis.cdz
+++ b/implementation/seed/crates/cdz-kernel/tests/fixtures/reducer-cadenza/reducer_genesis.cdz
@@ -32,7 +32,7 @@ type EffectKind =
   | Emit()
 
 type EffectRequest =
-  | Mk(Record(kind(EffectKind), target(String), payload(Option(Bytes)), correlation(Option(Bytes))))
+  | Mk(Record(kind: EffectKind, target: String, payload: Option(Bytes), correlation: Option(Bytes)))
 
 // kv host import (bound peer iface over the shared value-heap runtime — handle ABI): only put is needed
 // (genesis WRITES setup state; it never reads to decide an action).
@@ -52,7 +52,7 @@ def setup-key(family: String) -> Option(Bytes) =
   else None()
 
 def apply(
-  ct: Record(family(String), version(UInt(32))),
+  ct: Record(family: String, version: UInt(32)),
   payload: Option(Bytes),
   resumes: Option(Bytes),
 ) -> List(EffectRequest) = match resumes with


### PR DESCRIPTION
Candidate PR for v-syntax's merge-request (ref 7a2f65e06, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.