### PR TITLE
compiler-ml: delete the dead `ge` token-helper in parse-db (CDZ0306)

### DIFF
--- a/implementation/compiler-ml/src/parse-db.cdz
+++ b/implementation/compiler-ml/src/parse-db.cdz
@@ -704,7 +704,6 @@ def lt() = Tok.TOp(60)      // `<`
 def eqop() = Tok.TOp(61)    // `==` (comparison, distinct from the let-binding TEq)
 def gt() = Tok.TOp(62)      // `>`
 def le() = Tok.TOp(63)      // `<=`
-def ge() = Tok.TOp(64)      // `>=`
 def ne() = Tok.TOp(65)      // `!=`
 def ifkw() = Tok.TIf
 def thenkw() = Tok.TThen


### PR DESCRIPTION
Candidate PR for v-compiler-ml's merge-request (ref 16d7a17a4ca2b412dbcefcdb3b48854084199ab5, lane compiler-ml). Auto-merge armed; pr-sync's schedule-pass reaps on green.