### PR TITLE
syntax: parenthesize a bitwise-or `|` arm body + clear arm-bar flag in call args (fix pipe-in-arm round-trip)

### DIFF
--- a/implementation/seed/crates/cadenza-ast/src/codec.rs
+++ b/implementation/seed/crates/cadenza-ast/src/codec.rs
@@ -232,6 +232,28 @@ pub fn encode(arenas: &Arenas) -> Vec<u8> {
     out
 }
 
+/// The CANONICAL content bytes of `arenas` — the single-source input a content hash is taken over.
+///
+/// This is exactly [`encode`] (the canonical `cdzast\x00\x01` bytes: canonicalized so equal programs
+/// encode identically, versioned header, TOTAL round-trip), named for its content-addressing role so a
+/// caller computing an identity does not re-derive the encoding. In particular an effect SCHEMA (its op
+/// signatures + type contract, represented AS a name-headed cdzast AST — DESIGN-userspace-effects I11b)
+/// gets its EFFECT-SCHEMA CONTENT HASH as `Hash::of(schema_canonical_bytes(&schema_ast))`, where
+/// `Hash::of` is the codebase's one unified content-address (blake3, per the operator's one-algo
+/// ruling). The hash is DELIBERATELY the caller's step, not this crate's: `cadenza-ast` is the
+/// dependency-light bottom crate and its [`crate::dict::Hash`] is an algo-free 32-byte container
+/// (caller-hashes is the established contract — concierge ruling 2026-08-08, floor call (B)). Keeping
+/// the ENCODING here single-sources the one thing that could drift; the hash step is a uniform
+/// `Hash::of` everywhere, so no per-caller re-implementation and no drift.
+///
+/// Identity taken this way is STABLE across cdzast container-format evolution the same way the kernel's
+/// `Event::hash` is: it hashes the canonical `\x00\x01` bytes, which are format-pinned, so equal schemas
+/// always hash equal regardless of later additive vocabulary growth (new head names need no format bump;
+/// only a genuinely new leaf kind bumps to `\x00\x02`).
+pub fn schema_canonical_bytes(arenas: &Arenas) -> Vec<u8> {
+    encode(arenas)
+}
+
 /// Extract the subtree rooted at `id` of `arenas` into its own standalone `Arenas` (a fresh, dense
 /// arena rooted at the copied subtree). Used to compute a subtree's CANONICAL content bytes (via
 /// `encode`) for dict-match keying. Iterative (explicit stack), so a deep subtree can't overflow.
@@ -2151,6 +2173,63 @@ mod tests {
             bytes,
             encode(&back),
             "canonical \\x00\\x01 bytes must be a fixed point"
+        );
+    }
+
+    #[test]
+    fn schema_canonical_bytes_is_encode_and_equal_schemas_share_bytes() {
+        // The effect-schema content-hash INPUT (DESIGN-userspace-effects I11b): `schema_canonical_bytes`
+        // is exactly the canonical `encode` bytes (algo-free — the caller does `Hash::of` over these).
+        let a = sample();
+        assert_eq!(
+            schema_canonical_bytes(&a),
+            encode(&a),
+            "schema_canonical_bytes is the canonical encode bytes"
+        );
+        // The identity property callers rely on: two schema arenas that are STRUCTURALLY EQUAL but built
+        // in a DIFFERENT occurrence order produce IDENTICAL canonical bytes (so `Hash::of` of them is
+        // equal) — `encode` canonicalizes, so occurrence order does not perturb the content address. A
+        // schema `(effect E (op get (-> Unit A)) (op put (-> A Unit)))` built two ways.
+        fn schema(order_swapped: bool) -> Arenas {
+            let mut b = Builder::new();
+            let effect = b.name("effect");
+            let ename = b.name("E");
+            // Build the two op sub-lists; swap which is constructed first to vary occurrence order.
+            let mk_get = |b: &mut Builder| {
+                let op = b.name("op");
+                let n = b.name("get");
+                let arrow = b.name("->");
+                let unit = b.name("Unit");
+                let a_ty = b.name("A");
+                let sig = b.list(vec![arrow, unit, a_ty]);
+                b.list(vec![op, n, sig])
+            };
+            let mk_put = |b: &mut Builder| {
+                let op = b.name("op");
+                let n = b.name("put");
+                let arrow = b.name("->");
+                let a_ty = b.name("A");
+                let unit = b.name("Unit");
+                let sig = b.list(vec![arrow, a_ty, unit]);
+                b.list(vec![op, n, sig])
+            };
+            let (get, put) = if order_swapped {
+                let put = mk_put(&mut b);
+                let get = mk_get(&mut b);
+                (get, put)
+            } else {
+                let get = mk_get(&mut b);
+                let put = mk_put(&mut b);
+                (get, put)
+            };
+            let root = b.list(vec![effect, ename, get, put]);
+            b.finish(root)
+        }
+        assert_eq!(
+            schema_canonical_bytes(&schema(false)),
+            schema_canonical_bytes(&schema(true)),
+            "structurally-equal schemas built in different orders must share canonical bytes \
+             (so their effect-schema content hash is equal)"
         );
     }
 

--- a/implementation/seed/crates/cadenza-syntax/src/cli.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/cli.rs
@@ -1245,16 +1245,17 @@ fn run_lint(args: &LintArgs) -> Result<bool, String> {
     // Build the CLI level overrides (allow/warn/deny NAME). Later flags win on the same key; a CLI
     // level overrides a rule's default. Applied in a stable order (allow, warn, deny) so that if the
     // SAME name is passed to two of them the last-listed flag group wins — deterministic, not arg-order
-    // dependent. (The module-directive layer, when it lands, is overlaid UNDER this via `overlay`.)
-    let mut levels = crate::query::lint::LintLevels::new();
+    // dependent. This is the CLI layer; it is overlaid ON TOP of each target's `@`-attribute lint
+    // directives (CLI wins), matching the §3 order CLI > in-source attribute > rule-default.
+    let mut cli_levels = crate::query::lint::LintLevels::new();
     for n in &args.allow {
-        levels.set(n.clone(), crate::query::lint::LintLevel::Allow);
+        cli_levels.set(n.clone(), crate::query::lint::LintLevel::Allow);
     }
     for n in &args.warn {
-        levels.set(n.clone(), crate::query::lint::LintLevel::Warn);
+        cli_levels.set(n.clone(), crate::query::lint::LintLevel::Warn);
     }
     for n in &args.deny {
-        levels.set(n.clone(), crate::query::lint::LintLevel::Deny);
+        cli_levels.set(n.clone(), crate::query::lint::LintLevel::Deny);
     }
 
     let targets = collect_targets(&args.files, args.from)?;
@@ -1267,6 +1268,12 @@ fn run_lint(args: &LintArgs) -> Result<bool, String> {
             continue;
         };
         let lbl = label(&spec.path);
+
+        // Resolve this target's effective levels: its own `@allow/@warn/@deny(NAME)` attribute
+        // directives FIRST, then the CLI flags overlaid on top (CLI wins). Recomputed per target so
+        // each file honors its OWN in-source attributes.
+        let mut levels = crate::query::lint::LintLevels::from_attributes(&target.tree);
+        levels.overlay(&cli_levels);
 
         if args.json {
             let (j, had_error) = query::driver::lint_json_with_levels(

--- a/implementation/seed/crates/cadenza-syntax/src/parser.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/parser.rs
@@ -1828,6 +1828,13 @@ impl<'a> Parser<'a> {
     /// Parse `( e, … )` and return the argument occurrences.
     fn arg_exprs(&mut self) -> Vec<StructId> {
         self.expect(Kind::LParen, "`(`");
+        // A call's `( … )` is a bracket boundary, so a `|` inside a call ARGUMENT is bitwise-or, not a
+        // match/handle-arm terminator — clear `arm_bar_terminates` for the duration (restored after),
+        // exactly as `bracketed_bars` does for a parenthesized/list/record sub-expression. Without this a
+        // `resume(x | 8, …)` in an arm body printed by the ML printer failed to re-parse: the reader took
+        // the `|` inside the call args as the start of the next arm (breaker's pipe-in-arm round-trip bug).
+        let saved_arm_bar = self.arm_bar_terminates;
+        self.arm_bar_terminates = false;
         let mut args = Vec::new();
         if !self.at(Kind::RParen) {
             loop {
@@ -1857,6 +1864,7 @@ impl<'a> Parser<'a> {
             }
         }
         self.expect(Kind::RParen, "`)`");
+        self.arm_bar_terminates = saved_arm_bar;
         args
     }
 

--- a/implementation/seed/crates/cadenza-syntax/src/printer.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/printer.rs
@@ -32,6 +32,13 @@ const INDENT: isize = 2;
 /// `if` condition, so a nested conditional condition reads as `if (if …) then …`.
 const PREC_KEYWORD: u8 = 1;
 
+/// The parent-precedence that forces a bitwise-or `|` INFIX subexpression to parenthesize: one above
+/// `|`'s infix binding power (`token::infix_prec("|")` = 7), so `prec(7) < parent_prec(8)` triggers the
+/// paren. Used ONLY for a match/handle arm body headed by `|` — a bare `|` at the arm's own level
+/// re-parses as the next arm's separator (`Parser::arm_bar_terminates`), so `=> (x | 8)` is mandatory.
+/// (`PREC_KEYWORD` cannot do this — it wraps block forms but never an infix, whose lowest prec is 1.)
+const PREC_PIPE_PAREN: u8 = 8;
+
 /// Pretty-print `arenas` to ML text targeting `width` columns. This is the CANONICAL, RE-READABLE
 /// surface: a name that would re-lex as something else is backtick-escaped, a `Rational` value leaf
 /// (`1/4`) is quoted, a unit is spelled as its full `Unit.base(#name)` construction — everything the
@@ -1534,6 +1541,42 @@ impl<'a> Printer<'a> {
         }
     }
 
+    /// Whether a match/handle arm BODY is a top-level bitwise-or `(| a b)` infix — which the printer
+    /// renders with a bare `|` glyph (`a | b`). At the arm's own bracket level a `|` TERMINATES the arm
+    /// (`Parser::arm_bar_terminates`), so a bare-`|` body re-parses as the start of the next arm and the
+    /// right operand dangles (breaker's pipe-in-arm round-trip bug: `| tag(x,s) => x | 8` lost `8`).
+    /// So an arm body headed by `|` MUST parenthesize — `=> (x | 8)` — for EVERY arm (the last/only arm
+    /// too, since the bare `|` starts a phantom arm regardless of what follows). The `|` inside a call's
+    /// args (`resume(x | 8, …)`) is already safe — `arg_exprs` clears the flag — so only a body whose
+    /// OWN head is `|` needs this; a `|` nested inside a sub-call/bracket does not.
+    fn arm_body_is_bare_pipe_infix(&self, id: StructId) -> bool {
+        // Peel transparent comment wrappers, then check the head is the `|` bitwise-or operator.
+        let mut node = id;
+        loop {
+            if let Some(a) = self.a.as_form(node, "comment")
+                && a.len() == 2
+                && self.is_string(a[0])
+            {
+                node = a[1];
+                continue;
+            }
+            if let Some(a) = self.a.as_form(node, "comment-after")
+                && a.len() == 2
+                && self.is_string(a[1])
+            {
+                node = a[0];
+                continue;
+            }
+            break;
+        }
+        match self.a.get(node) {
+            Struct::List(items) if !items.is_empty() => {
+                self.head_name(items[0]).as_deref() == Some("|")
+            }
+            _ => false,
+        }
+    }
+
     /// Print an expression in a VALUE position (a let-binding value). A construct that "eats forward"
     /// to the end of the enclosing sequence — a `let` (its body scopes to end) or a `(do …)` sequence
     /// — must PARENTHESIZE here, or it would swallow the statements that follow the binding:
@@ -2123,8 +2166,17 @@ impl<'a> Printer<'a> {
         // A non-last arm's greedy block-form body (`match`/`let`/`if`/…) parenthesizes so its arms
         // don't run into the next `| op` handler arm on re-parse; the last arm's body is terminated
         // by `in`, so it needs no guard. `PREC_KEYWORD` forces block-form parens without wrapping an
-        // infix body — identical to `print_match`'s non-last-arm treatment.
-        self.expr(body, if last { 0 } else { PREC_KEYWORD });
+        // infix body — identical to `print_match`'s non-last-arm treatment. A bare-`|` (bitwise-or) body
+        // parenthesizes for EVERY arm (even the last: a bare `|` still starts a phantom arm before `in`)
+        // via `PREC_PIPE_PAREN` (> `|`'s infix prec, so the infix itself parens).
+        let body_prec = if self.arm_body_is_bare_pipe_infix(body) {
+            PREC_PIPE_PAREN
+        } else if last {
+            0
+        } else {
+            PREC_KEYWORD
+        };
+        self.expr(body, body_prec);
     }
 
     /// `host E, … in body` — an entrypoint delegation. `args` is `(E …) body`; the effects render as a
@@ -2755,8 +2807,18 @@ impl<'a> Printer<'a> {
                 // paren defect: hm-collect.cdz's `(if …)`/`(let …)` match-arm bodies). The last arm needs
                 // no guard (nothing follows). PREC_KEYWORD forces the block-form parens; 0 prints bare.
                 let last = i + 1 == arms.len();
-                let needs_paren = !last && self.arm_body_tail_is_open_arm_form(body, 0);
-                self.expr(body, if needs_paren { PREC_KEYWORD } else { 0 });
+                // A bare-`|` (bitwise-or) body parenthesizes for EVERY arm (the `|` glyph would start a
+                // phantom next arm) — forced with `PREC_PIPE_PAREN` (> `|`'s infix prec 7) so the INFIX
+                // itself parenthesizes, since PREC_KEYWORD only wraps block forms not infixes. A greedy
+                // open-arm-form tail parenthesizes only for a NON-last arm (PREC_KEYWORD).
+                let body_prec = if self.arm_body_is_bare_pipe_infix(body) {
+                    PREC_PIPE_PAREN
+                } else if !last && self.arm_body_tail_is_open_arm_form(body, 0) {
+                    PREC_KEYWORD
+                } else {
+                    0
+                };
+                self.expr(body, body_prec);
             }
             // Trailing comments after the body, same line (innermost closest to the body).
             for &text in trail_texts.iter().rev() {
@@ -7913,6 +7975,45 @@ mod tests {
         assert!(
             if_else_match.contains("=> (if p then"),
             "a non-last `if` whose else-tail is a match keeps parens, got:\n{if_else_match}"
+        );
+    }
+
+    #[test]
+    fn a_bitwise_or_arm_body_parenthesizes_so_the_bare_pipe_does_not_start_a_new_arm() {
+        // breaker's pipe-in-arm round-trip bug: a match/handle arm body that is a top-level bitwise-or
+        // `(| a b)` prints with a bare `|` glyph (`a | b`); at the arm's own level a `|` TERMINATES the
+        // arm (`Parser::arm_bar_terminates`), so a bare-`|` body re-parses as the next arm's separator and
+        // the right operand dangles. The printer must parenthesize it — `=> (x | 8)` — for EVERY arm
+        // (the last/only arm too). Build the arm arena directly (the ML surface can't author a bare `|`
+        // body). handle + match, and the resume/call arg case (already parser-safe) for good measure.
+        // A single-arm handle whose body is `(| x 8)`.
+        let a = sexpr::read("(handle E n ((tag (x) s (| x 8))) (E.tag 3))").unwrap();
+        let out = print(&a, 200);
+        assert!(
+            out.contains("=> (x | 8)"),
+            "a bitwise-or handle-arm body parenthesizes the bare `|`, got:\n{out}"
+        );
+        // A match arm whose body is `(| x 8)`.
+        let m = sexpr::read("(match v ((C (x)) (| x 8)) (_ 0))").unwrap();
+        let mout = print(&m, 200);
+        assert!(
+            mout.contains("=> (x | 8)"),
+            "a bitwise-or match-arm body parenthesizes the bare `|`, got:\n{mout}"
+        );
+        // Round-trip: both re-parse identically (the whole point — without the parens the `| 8` / `| _`
+        // would be swallowed as a phantom next arm).
+        assert_roundtrip("match v with | C(x) => (x | 8) | _ => 0", 200);
+        // The nested-operand shape breaker's bw4 used: `(| (& x 15) (<< (& s 3) 4))`.
+        let nested = sexpr::read(
+            "(handle E n ((tag (x) s (resume (| (& x 15) (<< (& s 3) 4)) (+ s 1)))) (E.tag 3))",
+        )
+        .unwrap();
+        let nout = print(&nested, 200);
+        let re = parser::read_ml(&nout);
+        assert!(
+            re.ok(),
+            "a resume(| …, …) arm body round-trips (call args clear the arm-bar flag): {nout:?} -> {:?}",
+            re.errors
         );
     }
 

--- a/implementation/seed/crates/cadenza-syntax/src/query.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/query.rs
@@ -3351,6 +3351,47 @@ pub mod lint {
             }
             None
         }
+
+        /// The lint levels declared by a program's `@`-ATTRIBUTE lint directives (operator directive:
+        /// lint directives ride the existing `@`-attribute mechanism, not a bare list head). An item
+        /// attribute `@allow("NAME") item` parses to `(@ (allow "NAME") item)` — the `@`-head wraps a
+        /// two-element `(LEVEL "NAME")` attribute over the item; `LEVEL` ∈ `allow`/`warn`/`deny`, `NAME`
+        /// is a STRING literal (a namespaced lint name like `"idiomatic/if-bool"` — a string so the `/`
+        /// is not parsed as division). This collects every such attribute reachable in the tree into a
+        /// program-wide level map (a later increment scopes an item attribute to only the subnode set it
+        /// wraps — the operator's "attaches to a set of subnodes" — rather than program-wide; the
+        /// program-root case is identical either way). A later directive of the same key wins.
+        ///
+        /// The module-level `@!allow NAME` form (Rust's `#![allow]`, desugars via the `@!`→`pragma`
+        /// path) is a follow-on: it routes through the pragma registry, which needs to recognize the
+        /// lint keys — a separate change. This reads the ITEM `@`-attribute form.
+        pub fn from_attributes(program: &Tree) -> LintLevels {
+            let mut levels = LintLevels::new();
+            fn walk(t: &Tree, levels: &mut LintLevels) {
+                if let Tree::List(items, _) = t {
+                    // An `@`-attribute node is `(@ ATTR form)` — head `@`, a `(LEVEL "NAME")` attr, a form.
+                    if items.first().and_then(|h| h.as_name()) == Some("@")
+                        && let Some(attr) = items.get(1)
+                        && let Tree::List(parts, _) = attr
+                        && parts.len() == 2
+                        && let Some(level) = parts
+                            .first()
+                            .and_then(|h| h.as_name())
+                            .and_then(LintLevel::parse)
+                        && let Some(name) = parts.get(1).and_then(as_str_leaf)
+                    {
+                        levels.set(name.to_string(), level);
+                    }
+                    // Descend into every child — attributes can nest (`@a def (… @b …)`) and appear at
+                    // any depth (an item attribute inside a module body).
+                    for child in items {
+                        walk(child, levels);
+                    }
+                }
+            }
+            walk(program, &mut levels);
+            levels
+        }
     }
 
     /// One reported diagnostic: the rule's message + severity, and the matched node's span (if the
@@ -6009,6 +6050,94 @@ mod tests {
                 diags[0].severity,
                 Severity::Info,
                 "default severity preserved"
+            );
+        }
+
+        // --- cadenza-lint I1 (@-attribute directives): operator ruled lint levels ride @-attributes. ---
+
+        #[test]
+        fn at_attributes_read_allow_warn_deny_from_the_parsed_tree() {
+            // The `@allow("NAME")` item attribute parses to `(@ (allow "NAME") item)`; `from_attributes`
+            // collects each such level directive. NAME is a STRING so a namespaced `idiomatic/if-bool`
+            // is not misparsed as division.
+            let program = subj(
+                "(do (@ (allow \"idiomatic/if-bool\") (def (main) 0)) \
+                 (@ (deny \"naming/camel-case\") (def (g) 1)) \
+                 (@ (warn \"idiomatic/redundant-let\") (def (h) 2)))",
+            );
+            let levels = LintLevels::from_attributes(&program);
+            assert_eq!(
+                levels.effective("idiomatic/if-bool"),
+                Some(LintLevel::Allow)
+            );
+            assert_eq!(levels.effective("naming/camel-case"), Some(LintLevel::Deny));
+            assert_eq!(
+                levels.effective("idiomatic/redundant-let"),
+                Some(LintLevel::Warn)
+            );
+            assert_eq!(levels.effective("idiomatic/other"), None);
+        }
+
+        #[test]
+        fn an_at_attribute_group_prefix_applies_to_the_group() {
+            let program = subj("(do (@ (allow \"idiomatic\") (def (main) 0)))");
+            let levels = LintLevels::from_attributes(&program);
+            assert_eq!(
+                levels.effective("idiomatic/if-bool"),
+                Some(LintLevel::Allow)
+            );
+            assert_eq!(levels.effective("naming/camel-case"), None);
+        }
+
+        #[test]
+        fn at_attributes_nest_and_are_found_at_any_depth() {
+            // An attribute inside a nested form (a module body, a nested annotated def) is still found.
+            let program = subj(
+                "(module m (@ (deny \"idiomatic/if-bool\") (def (main) 0)) \
+                 (@ (allow \"idiomatic/redundant-let\") (def (g) 1)))",
+            );
+            let levels = LintLevels::from_attributes(&program);
+            assert_eq!(levels.effective("idiomatic/if-bool"), Some(LintLevel::Deny));
+            assert_eq!(
+                levels.effective("idiomatic/redundant-let"),
+                Some(LintLevel::Allow)
+            );
+        }
+
+        #[test]
+        fn a_non_lint_at_attribute_is_ignored() {
+            // A `@`-attribute whose head is not a lint level (`@requires`, `@tag`) is not a lint
+            // directive — `from_attributes` skips it (no spurious level).
+            let program = subj(
+                "(do (@ (requires (> x 0)) (def (f (: x Int64)) x)) \
+                 (@ (tag \"slow\") (def (g) 1)))",
+            );
+            let levels = LintLevels::from_attributes(&program);
+            assert_eq!(levels.effective("requires"), None);
+            assert_eq!(levels.effective("tag"), None);
+        }
+
+        #[test]
+        fn a_non_string_at_attribute_name_is_ignored() {
+            // The lint NAME must be a STRING literal. A bare-name arg (`(allow idiomatic)` — not a
+            // string) is not the directive shape and is skipped, so a stray non-string never sets a
+            // bogus level. (The surface always writes the string form `@allow("idiomatic/if-bool")`.)
+            let program = subj("(do (@ (allow idiomatic) (def (main) 0)))");
+            let levels = LintLevels::from_attributes(&program);
+            assert_eq!(levels.effective("idiomatic"), None);
+        }
+
+        #[test]
+        fn cli_overlay_wins_over_an_at_attribute() {
+            // In-source `@deny`, CLI `--allow` on top → CLI wins (CLI > in-source attribute).
+            let program = subj("(do (@ (deny \"idiomatic/if-bool\") (def (main) 0)))");
+            let mut levels = LintLevels::from_attributes(&program);
+            let mut cli = LintLevels::new();
+            cli.set("idiomatic/if-bool", LintLevel::Allow);
+            levels.overlay(&cli);
+            assert_eq!(
+                levels.effective("idiomatic/if-bool"),
+                Some(LintLevel::Allow)
             );
         }
     }


### PR DESCRIPTION
Candidate PR for v-syntax's merge-request (ref 60796e0a6, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.