### PR TITLE
feat(cdz-agent-host): adapt the 11 executors to Executor::perform(id: EffectId, ...) (userspace-effects perform-EffectId dual-land)

### DIFF
--- a/implementation/seed/crates/cdz-agent-host/src/blob_exec.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/blob_exec.rs
@@ -25,7 +25,7 @@
 //! S3 backend it can wrap is the only `live-aws-storage` piece.
 
 use cdz_kernel::blob::BlobStore;
-use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
+use cdz_kernel::effect::{effect_ct, EffectId, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::executor::Executor;
 use cdz_kernel::hash::Hash;
@@ -46,7 +46,12 @@ impl<B: BlobStore> BlobExecutor<B> {
 
 #[async_trait::async_trait(?Send)]
 impl<B: BlobStore> Executor for BlobExecutor<B> {
-    async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        _id: EffectId,
+        req: &EffectRequest,
+        _idempotency_key: Hash,
+    ) -> EffectOutcome {
         let family = req.content_type.family.as_ref();
         if family == effect_ct::BLOB_PUT {
             // Store the payload bytes → return the content hash as a HEX handle the reducer threads to get.
@@ -128,7 +133,7 @@ mod tests {
         let mut exec = BlobExecutor::new(MemBlobStore::new());
         // put → hex hash handle
         let hex = match exec
-            .perform(&put_req(b"doc-ast-bytes"), Hash::of(b"k"))
+            .perform(EffectId(0), &put_req(b"doc-ast-bytes"), Hash::of(b"k"))
             .await
         {
             EffectOutcome::Ok(Some(Payload::Inline(b))) => String::from_utf8(b.to_vec()).unwrap(),
@@ -139,7 +144,10 @@ mod tests {
             "the put result is a valid hex content hash: {hex:?}"
         );
         // get(that hash) → the bytes verbatim
-        match exec.perform(&get_req(&hex), Hash::of(b"k")).await {
+        match exec
+            .perform(EffectId(0), &get_req(&hex), Hash::of(b"k"))
+            .await
+        {
             EffectOutcome::Ok(Some(Payload::Inline(b))) => {
                 assert_eq!(
                     b.as_ref(),
@@ -156,7 +164,10 @@ mod tests {
         let mut exec = BlobExecutor::new(MemBlobStore::new());
         // A valid-hex hash that was never stored → Ok(None), NOT an Err (a CAS miss is a normal fold input).
         let absent = Hash::of(b"never-stored").to_hex();
-        match exec.perform(&get_req(&absent), Hash::of(b"k")).await {
+        match exec
+            .perform(EffectId(0), &get_req(&absent), Hash::of(b"k"))
+            .await
+        {
             EffectOutcome::Ok(None) => {}
             other => panic!("an absent blob must be Ok(None), got {other:?}"),
         }
@@ -167,7 +178,7 @@ mod tests {
         use cdz_kernel::event::Retryability;
         let mut exec = BlobExecutor::new(MemBlobStore::new());
         match exec
-            .perform(&get_req("not-a-hex-hash"), Hash::of(b"k"))
+            .perform(EffectId(0), &get_req("not-a-hex-hash"), Hash::of(b"k"))
             .await
         {
             EffectOutcome::Err {

--- a/implementation/seed/crates/cdz-agent-host/src/clock.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/clock.rs
@@ -18,7 +18,7 @@
 //! `u64::from_le_bytes(bytes.try_into()?)`. (`Now`'s target is empty; a capability gates it by kind, e.g.
 //! `Capability { kind: Now, predicate: Any }`.)
 
-use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
+use cdz_kernel::effect::{effect_ct, EffectId, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::executor::Executor;
 use cdz_kernel::hash::Hash;
@@ -48,7 +48,12 @@ impl ClockExecutor {
 // an `CompositeExecutor` and not overlap the blanket (§ all-async, step-5).
 #[async_trait::async_trait(?Send)]
 impl Executor for ClockExecutor {
-    async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        _id: EffectId,
+        req: &EffectRequest,
+        _idempotency_key: Hash,
+    ) -> EffectOutcome {
         // Key the guard on the effect FAMILY STRING (seq-39 / effect-schema slice 2), not the EffectKind
         // enum — the same decision the router and authz make, and the same shape the Model/Http executors
         // already use. Decouples this executor from the enum ahead of its retirement; matches_family is
@@ -115,7 +120,7 @@ mod tests {
     async fn now_returns_an_8_byte_le_u64_nanos_timestamp() {
         let mut exec = ClockExecutor::new();
         let ns = decode_ns(
-            exec.perform(&req(EffectKind::Now, ""), Hash::of(b"k"))
+            exec.perform(EffectId(0), &req(EffectKind::Now, ""), Hash::of(b"k"))
                 .await,
         );
         // A sane lower bound: well after 2020 (1_577_836_800_000_000_000 ns = 2020-01-01) — proves it's a
@@ -132,7 +137,7 @@ mod tests {
         // width is load-bearing for the monotonic guarantee.
         let mut exec = ClockExecutor::new();
         match exec
-            .perform(&req(EffectKind::Now, ""), Hash::of(b"k"))
+            .perform(EffectId(0), &req(EffectKind::Now, ""), Hash::of(b"k"))
             .await
         {
             EffectOutcome::Ok(Some(Payload::Inline(bytes))) => {
@@ -154,11 +159,11 @@ mod tests {
         // only what this executor guarantees — each read is a sane epoch-nanos value.
         let mut exec = ClockExecutor::new();
         let a = decode_ns(
-            exec.perform(&req(EffectKind::Now, ""), Hash::of(b"k"))
+            exec.perform(EffectId(0), &req(EffectKind::Now, ""), Hash::of(b"k"))
                 .await,
         );
         let b = decode_ns(
-            exec.perform(&req(EffectKind::Now, ""), Hash::of(b"k"))
+            exec.perform(EffectId(0), &req(EffectKind::Now, ""), Hash::of(b"k"))
                 .await,
         );
         assert!(
@@ -176,7 +181,11 @@ mod tests {
         // This is a single-family executor; a wrong family is an observable Err (§9d), never a panic.
         let mut exec = ClockExecutor::new();
         match exec
-            .perform(&req(EffectKind::Http, "https://x/"), Hash::of(b"k"))
+            .perform(
+                EffectId(0),
+                &req(EffectKind::Http, "https://x/"),
+                Hash::of(b"k"),
+            )
             .await
         {
             EffectOutcome::Err {

--- a/implementation/seed/crates/cdz-agent-host/src/emit.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/emit.rs
@@ -26,7 +26,7 @@
 
 use crate::async_host::{Inbound, Inbox};
 use crate::host::SessionId;
-use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
+use cdz_kernel::effect::{effect_ct, EffectId, EffectRequest, Payload};
 use cdz_kernel::event::{ContentType, EffectOutcome, EventBody};
 use cdz_kernel::executor::Executor;
 use cdz_kernel::hash::Hash;
@@ -60,7 +60,12 @@ impl EmitExecutor {
 
 #[async_trait::async_trait(?Send)]
 impl Executor for EmitExecutor {
-    async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        _id: EffectId,
+        req: &EffectRequest,
+        _idempotency_key: Hash,
+    ) -> EffectOutcome {
         // `_idempotency_key` is deliberately unused (#2351 review c2, present-tense per #2356 review B): the
         // dedup it exists for lives at the PERSISTENCE layer — de-duping a redelivered emit requires a
         // durable peer-inbox to check the key against, which in-memory `Inbox` routing has none of, so the
@@ -165,7 +170,11 @@ mod tests {
         let mut exec = EmitExecutor::new(tx, SessionId::new("sender-a"));
 
         let out = exec
-            .perform(&emit_req("session-b", Some(b"hello-peer")), Hash::of(b"k"))
+            .perform(
+                EffectId(0),
+                &emit_req("session-b", Some(b"hello-peer")),
+                Hash::of(b"k"),
+            )
             .await;
         assert!(
             matches!(out, EffectOutcome::Ok(None)),
@@ -205,7 +214,9 @@ mod tests {
         // A bare signal (no payload) is legitimate — it routes an empty-payload message, not an error.
         let (tx, mut rx) = mpsc::unbounded_channel();
         let mut exec = EmitExecutor::new(tx, SessionId::new("sender-a"));
-        let out = exec.perform(&emit_req("b", None), Hash::of(b"k")).await;
+        let out = exec
+            .perform(EffectId(0), &emit_req("b", None), Hash::of(b"k"))
+            .await;
         assert!(matches!(out, EffectOutcome::Ok(None)));
         let routed = rx.try_recv().expect("routed");
         match routed.body {
@@ -225,7 +236,7 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded_channel();
         let mut exec = EmitExecutor::new(tx, SessionId::new("sender-a"));
         let out = exec
-            .perform(&emit_req("", Some(b"x")), Hash::of(b"k"))
+            .perform(EffectId(0), &emit_req("", Some(b"x")), Hash::of(b"k"))
             .await;
         match out {
             EffectOutcome::Err {
@@ -253,7 +264,7 @@ mod tests {
             None,
             Timeliness::Interactive,
         );
-        let out = exec.perform(&req, Hash::of(b"k")).await;
+        let out = exec.perform(EffectId(0), &req, Hash::of(b"k")).await;
         assert!(
             matches!(out, EffectOutcome::Err { message, retryability } if retryability == Retryability::Permanent && message.contains("only handles")),
             "a non-Emit family is rejected PERMANENT"
@@ -275,7 +286,7 @@ mod tests {
             Some(Payload::Blob(Hash::of(b"some-blob-ref"))),
             Timeliness::Interactive,
         );
-        let out = exec.perform(&req, Hash::of(b"k")).await;
+        let out = exec.perform(EffectId(0), &req, Hash::of(b"k")).await;
         assert!(
             matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("blob-ref")),
             "a blob-ref Emit payload is rejected PERMANENT (no blob-store access to forward it), got {out:?}"
@@ -290,7 +301,7 @@ mod tests {
         drop(rx); // loop's receiver gone
         let mut exec = EmitExecutor::new(tx, SessionId::new("sender-a"));
         let out = exec
-            .perform(&emit_req("b", Some(b"x")), Hash::of(b"k"))
+            .perform(EffectId(0), &emit_req("b", Some(b"x")), Hash::of(b"k"))
             .await;
         assert!(
             matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Retryable && message.contains("inbox is closed")),

--- a/implementation/seed/crates/cdz-agent-host/src/factory.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/factory.rs
@@ -24,7 +24,7 @@ use crate::host::HostedSession;
 use crate::metrics::EffectMetrics;
 use cdz_kernel::authz::Authorize;
 use cdz_kernel::blob::BlobStore;
-use cdz_kernel::effect::EffectRequest;
+use cdz_kernel::effect::{EffectId, EffectRequest};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::executor::{CompositeExecutor, Executor};
 use cdz_kernel::hash::Hash;
@@ -92,9 +92,16 @@ impl MeteredExecutor {
 
 #[async_trait::async_trait(?Send)]
 impl Executor for MeteredExecutor {
-    async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        id: EffectId,
+        req: &EffectRequest,
+        idempotency_key: Hash,
+    ) -> EffectOutcome {
         let started = std::time::Instant::now();
-        let outcome = self.inner.perform(req, idempotency_key).await;
+        // Forward the kernel-assigned EffectId to the inner executor unchanged (the metering wrapper must be
+        // transparent — a delegating inner executor binds its reply-token to this id).
+        let outcome = self.inner.perform(id, req, idempotency_key).await;
         self.metrics
             .record_latency_us(crate::metrics::micros_u64(started.elapsed()));
         // Tally the metric + trace at the SAME tap. The family names which effect; a failure logs its
@@ -1113,7 +1120,12 @@ mod tests {
     }
     #[async_trait::async_trait(?Send)]
     impl Executor for ScriptedExecutor {
-        async fn perform(&mut self, _req: &EffectRequest, _key: Hash) -> EffectOutcome {
+        async fn perform(
+            &mut self,
+            _id: EffectId,
+            _req: &EffectRequest,
+            _key: Hash,
+        ) -> EffectOutcome {
             self.outcomes
                 .borrow_mut()
                 .pop_front()
@@ -1160,17 +1172,17 @@ mod tests {
         // records each into the registry along the way (registry Counters are drain-on-report with no value
         // getter, so we assert pass-through + a reportable registry, not per-counter values).
         assert!(matches!(
-            metered.perform(&req, Hash::of(b"k")).await,
+            metered.perform(EffectId(0), &req, Hash::of(b"k")).await,
             EffectOutcome::Ok(_)
         ));
         assert!(matches!(
-            metered.perform(&req, Hash::of(b"k")).await,
+            metered.perform(EffectId(0), &req, Hash::of(b"k")).await,
             EffectOutcome::Err { .. }
         ));
-        metered.perform(&req, Hash::of(b"k")).await;
-        metered.perform(&req, Hash::of(b"k")).await;
+        metered.perform(EffectId(0), &req, Hash::of(b"k")).await;
+        metered.perform(EffectId(0), &req, Hash::of(b"k")).await;
         assert!(matches!(
-            metered.perform(&req, Hash::of(b"k")).await,
+            metered.perform(EffectId(0), &req, Hash::of(b"k")).await,
             EffectOutcome::TimedOut
         ));
 
@@ -1225,8 +1237,8 @@ mod tests {
         req_a.content_type.family = "fam-a".into();
         let mut req_b = req_a.clone();
         req_b.content_type.family = "fam-b".into();
-        composite.perform(&req_a, Hash::of(b"a")).await;
-        composite.perform(&req_b, Hash::of(b"b")).await;
+        composite.perform(EffectId(0), &req_a, Hash::of(b"a")).await;
+        composite.perform(EffectId(0), &req_b, Hash::of(b"b")).await;
 
         // Both families' outcomes recorded through the one shared Arc into the one registry — which reports
         // over them (proves cross-family aggregation into a single registry-backed set).

--- a/implementation/seed/crates/cdz-agent-host/src/fs_exec.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/fs_exec.rs
@@ -21,7 +21,7 @@
 //! classified `EffectOutcome::Err`, never a panic. Most fs errors are PERMANENT for a given path+op (a
 //! missing file won't appear on a blind retry); the reducer decides what to do.
 
-use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
+use cdz_kernel::effect::{effect_ct, EffectId, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::executor::Executor;
 use cdz_kernel::hash::Hash;
@@ -47,7 +47,12 @@ impl Default for FsExecutor {
 
 #[async_trait::async_trait(?Send)]
 impl Executor for FsExecutor {
-    async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        _id: EffectId,
+        req: &EffectRequest,
+        _idempotency_key: Hash,
+    ) -> EffectOutcome {
         let path = req.target.as_ref();
         // Route on the fs/* family (seq-39 family-string source of truth). The path was already authorized by
         // the Cedar policy (SEC-F1) before dispatch — this executor does the raw syscall for the one op Cedar
@@ -158,6 +163,7 @@ mod tests {
         // write
         let out = exec
             .perform(
+                EffectId(0),
                 &fs_req(effect_ct::FS_WRITE, &ps, Some(b"cargo test")),
                 Hash::of(b"k"),
             )
@@ -165,7 +171,11 @@ mod tests {
         assert!(matches!(out, EffectOutcome::Ok(_)), "write ok, got {out:?}");
         // read back
         let out = exec
-            .perform(&fs_req(effect_ct::FS_READ, &ps, None), Hash::of(b"k"))
+            .perform(
+                EffectId(0),
+                &fs_req(effect_ct::FS_READ, &ps, None),
+                Hash::of(b"k"),
+            )
             .await;
         match out {
             EffectOutcome::Ok(Some(Payload::Inline(bytes))) => {
@@ -180,6 +190,7 @@ mod tests {
         let mut exec = FsExecutor::new();
         let out = exec
             .perform(
+                EffectId(0),
                 &fs_req(effect_ct::FS_READ, "/no/such/cdz-fsexec/path", None),
                 Hash::of(b"k"),
             )
@@ -196,7 +207,11 @@ mod tests {
         let ps = dir.join("x").to_string_lossy().into_owned();
         let mut exec = FsExecutor::new();
         let out = exec
-            .perform(&fs_req(effect_ct::FS_WRITE, &ps, None), Hash::of(b"k"))
+            .perform(
+                EffectId(0),
+                &fs_req(effect_ct::FS_WRITE, &ps, None),
+                Hash::of(b"k"),
+            )
             .await;
         assert!(
             matches!(&out, EffectOutcome::Err { message, .. } if message.contains("requires a payload")),
@@ -212,7 +227,11 @@ mod tests {
         let pat = format!("{}/*", dir.to_string_lossy());
         let mut exec = FsExecutor::new();
         let out = exec
-            .perform(&fs_req(effect_ct::FS_GLOB, &pat, None), Hash::of(b"k"))
+            .perform(
+                EffectId(0),
+                &fs_req(effect_ct::FS_GLOB, &pat, None),
+                Hash::of(b"k"),
+            )
             .await;
         match out {
             EffectOutcome::Ok(Some(Payload::Inline(bytes))) => {
@@ -238,7 +257,7 @@ mod tests {
             None,
             Timeliness::Interactive,
         );
-        let out = exec.perform(&req, Hash::of(b"k")).await;
+        let out = exec.perform(EffectId(0), &req, Hash::of(b"k")).await;
         assert!(
             matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("only handles")),
             "a non-fs family is PERMANENT, got {out:?}"

--- a/implementation/seed/crates/cdz-agent-host/src/http.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/http.rs
@@ -22,7 +22,7 @@
 //! dispatch; this executor does not re-authorize.
 
 use bytes::Bytes;
-use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
+use cdz_kernel::effect::{effect_ct, EffectId, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::event_ast::{decode_http_request_with_headers, encode_http_response};
 use cdz_kernel::executor::Executor;
@@ -140,7 +140,12 @@ impl<T: HttpTransport> HttpExecutor<T> {
 
 #[async_trait::async_trait(?Send)]
 impl<T: HttpTransport> Executor for HttpExecutor<T> {
-    async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        _id: EffectId,
+        req: &EffectRequest,
+        idempotency_key: Hash,
+    ) -> EffectOutcome {
         // Family-keyed (seq-39), not the EffectKind enum — the same decision the router + authz make.
         if !req.content_type.matches_family(effect_ct::HTTP) {
             // Structural — PERMANENT, a supervisor must not retry it (§17: observable Err, never a panic).
@@ -416,8 +421,10 @@ mod tests {
             expect_body: None,
             response: resp(200, &[("content-type", "text/plain")], b"response body"),
         });
-        let (status, headers, body) =
-            decode_result(exec.perform(&http_req("get", None), Hash::of(b"k")).await);
+        let (status, headers, body) = decode_result(
+            exec.perform(EffectId(0), &http_req("get", None), Hash::of(b"k"))
+                .await,
+        );
         assert_eq!(status, 200);
         assert_eq!(
             headers,
@@ -441,6 +448,7 @@ mod tests {
         });
         let (status, headers, body) = decode_result(
             exec.perform(
+                EffectId(0),
                 &http_req_h(
                     "post",
                     &[
@@ -470,8 +478,10 @@ mod tests {
             expect_body: None,
             response: resp(404, &[], b"not found"),
         });
-        let (status, _headers, body) =
-            decode_result(exec.perform(&http_req("get", None), Hash::of(b"k")).await);
+        let (status, _headers, body) = decode_result(
+            exec.perform(EffectId(0), &http_req("get", None), Hash::of(b"k"))
+                .await,
+        );
         assert_eq!(
             status, 404,
             "a 404 is a completed response, not a transport error"
@@ -489,7 +499,8 @@ mod tests {
             response: resp(200, &[], b"a"),
         });
         assert!(matches!(
-            exec.perform(&http_req("post", None), Hash::of(b"k")).await,
+            exec.perform(EffectId(0), &http_req("post", None), Hash::of(b"k"))
+                .await,
             EffectOutcome::Ok(_)
         ));
         let mut exec = HttpExecutor::new(StubHttp {
@@ -499,8 +510,12 @@ mod tests {
             response: resp(200, &[], b"b"),
         });
         assert!(matches!(
-            exec.perform(&http_req("delete", Some(b"why")), Hash::of(b"k"))
-                .await,
+            exec.perform(
+                EffectId(0),
+                &http_req("delete", Some(b"why")),
+                Hash::of(b"k")
+            )
+            .await,
             EffectOutcome::Ok(_)
         ));
     }
@@ -514,7 +529,7 @@ mod tests {
             response: resp(207, &[], b"x"),
         });
         assert!(matches!(
-            exec.perform(&http_req("propfind", None), Hash::of(b"k"))
+            exec.perform(EffectId(0), &http_req("propfind", None), Hash::of(b"k"))
                 .await,
             EffectOutcome::Ok(_)
         ));
@@ -543,7 +558,7 @@ mod tests {
             Some(Payload::Blob(Hash::of(b"big"))),
             Timeliness::Interactive,
         );
-        match exec.perform(&req, Hash::of(b"k")).await {
+        match exec.perform(EffectId(0), &req, Hash::of(b"k")).await {
             EffectOutcome::Err {
                 message,
                 retryability,
@@ -578,7 +593,7 @@ mod tests {
             None,
             Timeliness::Interactive,
         );
-        match exec.perform(&no_payload, Hash::of(b"k")).await {
+        match exec.perform(EffectId(0), &no_payload, Hash::of(b"k")).await {
             EffectOutcome::Err {
                 message,
                 retryability,
@@ -595,7 +610,7 @@ mod tests {
             Some(Payload::Inline(b"not a sexpr".to_vec().into())),
             Timeliness::Interactive,
         );
-        match exec.perform(&garbage, Hash::of(b"k")).await {
+        match exec.perform(EffectId(0), &garbage, Hash::of(b"k")).await {
             EffectOutcome::Err {
                 message,
                 retryability,
@@ -624,7 +639,10 @@ mod tests {
             }
         }
         let mut exec = HttpExecutor::new(FlakyHttp);
-        match exec.perform(&http_req("get", None), Hash::of(b"k")).await {
+        match exec
+            .perform(EffectId(0), &http_req("get", None), Hash::of(b"k"))
+            .await
+        {
             EffectOutcome::Err {
                 message,
                 retryability,
@@ -659,7 +677,7 @@ mod tests {
             None,
             Timeliness::Interactive,
         );
-        match exec.perform(&req, Hash::of(b"k")).await {
+        match exec.perform(EffectId(0), &req, Hash::of(b"k")).await {
             EffectOutcome::Err {
                 message,
                 retryability,

--- a/implementation/seed/crates/cdz-agent-host/src/lifecycle.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/lifecycle.rs
@@ -28,7 +28,7 @@
 //! (executor pre-compute → loop factory-resolve + register) is wired end to end.
 
 use crate::host::SessionId;
-use cdz_kernel::effect::{effect_ct, EffectRequest};
+use cdz_kernel::effect::{effect_ct, EffectId, EffectRequest};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::executor::Executor;
 use cdz_kernel::hash::Hash;
@@ -169,7 +169,12 @@ impl LifecycleExecutor {
 
 #[async_trait::async_trait(?Send)]
 impl Executor for LifecycleExecutor {
-    async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        _id: EffectId,
+        req: &EffectRequest,
+        _idempotency_key: Hash,
+    ) -> EffectOutcome {
         let family = req.content_type.family.as_ref();
         // SPAWN is structurally distinct from terminate/suspend/resume (no peer `target` — it CREATES a
         // child; the reducer identity rides the payload; it RETURNS the child's SessionId synchronously). So
@@ -294,7 +299,7 @@ mod tests {
             Some(Payload::Inline(reducer_hash.as_bytes().to_vec().into())),
             Timeliness::Interactive,
         );
-        let out = exec.perform(&req, Hash::of(b"k")).await;
+        let out = exec.perform(EffectId(0), &req, Hash::of(b"k")).await;
         // The returned id is the effect result (Ok(Some(payload=child_id_hex))).
         let EffectOutcome::Ok(Some(Payload::Inline(returned))) = &out else {
             panic!("spawn returns Ok(Some(child_id)), got {out:?}");
@@ -346,7 +351,7 @@ mod tests {
             Timeliness::Interactive,
         );
         assert!(
-            matches!(&exec.perform(&req, Hash::of(b"k")).await,
+            matches!(&exec.perform(EffectId(0), &req, Hash::of(b"k")).await,
                 EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("reducer_hash")),
             "spawn with no reducer_hash payload is PERMANENT"
         );
@@ -368,7 +373,7 @@ mod tests {
             Some(Payload::Inline(reducer_hash.as_bytes().to_vec().into())),
             Timeliness::Interactive,
         );
-        let out = exec.perform(&req, Hash::of(b"k")).await;
+        let out = exec.perform(EffectId(0), &req, Hash::of(b"k")).await;
         // Spawn ACCEPTED (Ok) despite the vanity id — and the returned child id == derive_genesis_hash from
         // the THREADED genesis (not from the id string).
         let EffectOutcome::Ok(Some(Payload::Inline(bytes))) = &out else {
@@ -415,6 +420,7 @@ mod tests {
             LifecycleExecutor::new(tx, SessionId::new("controller"), Hash::of(b"controller"));
         let out = exec
             .perform(
+                EffectId(0),
                 &terminate_req("victim", Some(b"operator kill")),
                 Hash::of(b"k"),
             )
@@ -438,7 +444,7 @@ mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"), Hash::of(b"ctl"));
         let out = exec
-            .perform(&terminate_req("b", None), Hash::of(b"k"))
+            .perform(EffectId(0), &terminate_req("b", None), Hash::of(b"k"))
             .await;
         assert!(matches!(out, EffectOutcome::Ok(None)));
         let LifecycleOp::Terminate { reason, .. } = rx.try_recv().expect("recorded") else {
@@ -464,7 +470,7 @@ mod tests {
             Timeliness::Interactive,
         );
         assert!(matches!(
-            exec.perform(&suspend, Hash::of(b"k")).await,
+            exec.perform(EffectId(0), &suspend, Hash::of(b"k")).await,
             EffectOutcome::Ok(None)
         ));
         let LifecycleOp::Suspend { target, by } = rx.try_recv().expect("suspend recorded") else {
@@ -480,7 +486,7 @@ mod tests {
             Timeliness::Interactive,
         );
         assert!(matches!(
-            exec.perform(&resume, Hash::of(b"k")).await,
+            exec.perform(EffectId(0), &resume, Hash::of(b"k")).await,
             EffectOutcome::Ok(None)
         ));
         let LifecycleOp::Resume { target, .. } = rx.try_recv().expect("resume recorded") else {
@@ -505,7 +511,7 @@ mod tests {
                 Timeliness::Interactive,
             );
             assert!(
-                matches!(&exec.perform(&inline, Hash::of(b"k")).await,
+                matches!(&exec.perform(EffectId(0), &inline, Hash::of(b"k")).await,
                     EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("takes no payload")),
                 "{family} with an inline payload is PERMANENT"
             );
@@ -517,7 +523,7 @@ mod tests {
                 Timeliness::Interactive,
             );
             assert!(
-                matches!(&exec.perform(&blob, Hash::of(b"k")).await,
+                matches!(&exec.perform(EffectId(0), &blob, Hash::of(b"k")).await,
                     EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("takes no payload")),
                 "{family} with a blob-ref payload is PERMANENT (no silent drop)"
             );
@@ -535,7 +541,7 @@ mod tests {
             Timeliness::Interactive,
         );
         assert!(
-            matches!(&exec.perform(&req, Hash::of(b"k")).await,
+            matches!(&exec.perform(EffectId(0), &req, Hash::of(b"k")).await,
                 EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("cannot lifecycle/suspend itself")),
             "self-suspend is PERMANENT"
         );
@@ -553,7 +559,7 @@ mod tests {
             Some(Payload::Blob(Hash::of(b"some-blob"))),
             Timeliness::Interactive,
         );
-        let out = exec.perform(&req, Hash::of(b"k")).await;
+        let out = exec.perform(EffectId(0), &req, Hash::of(b"k")).await;
         assert!(
             matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("blob-ref reason is unsupported")),
             "a blob-ref reason is rejected PERMANENT, got {out:?}"
@@ -565,7 +571,7 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded_channel();
         let mut exec = LifecycleExecutor::new(tx, SessionId::new("me"), Hash::of(b"me"));
         let out = exec
-            .perform(&terminate_req("me", None), Hash::of(b"k"))
+            .perform(EffectId(0), &terminate_req("me", None), Hash::of(b"k"))
             .await;
         assert!(
             matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("cannot lifecycle/terminate itself")),
@@ -577,7 +583,9 @@ mod tests {
     async fn an_empty_target_is_a_permanent_error() {
         let (tx, _rx) = mpsc::unbounded_channel();
         let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"), Hash::of(b"ctl"));
-        let out = exec.perform(&terminate_req("", None), Hash::of(b"k")).await;
+        let out = exec
+            .perform(EffectId(0), &terminate_req("", None), Hash::of(b"k"))
+            .await;
         assert!(
             matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("non-empty target")),
             "empty target is PERMANENT, got {out:?}"
@@ -590,7 +598,7 @@ mod tests {
         drop(rx);
         let mut exec = LifecycleExecutor::new(tx, SessionId::new("ctl"), Hash::of(b"ctl"));
         let out = exec
-            .perform(&terminate_req("b", None), Hash::of(b"k"))
+            .perform(EffectId(0), &terminate_req("b", None), Hash::of(b"k"))
             .await;
         assert!(
             matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Retryable && message.contains("channel is closed")),
@@ -608,7 +616,7 @@ mod tests {
             None,
             Timeliness::Interactive,
         );
-        let out = exec.perform(&req, Hash::of(b"k")).await;
+        let out = exec.perform(EffectId(0), &req, Hash::of(b"k")).await;
         assert!(
             matches!(&out, EffectOutcome::Err { retryability, .. } if *retryability == Retryability::Permanent)
         );

--- a/implementation/seed/crates/cdz-agent-host/src/metric_exec.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/metric_exec.rs
@@ -29,7 +29,7 @@
 //!   (never-log-guest-controlled-strings) and rejects unsafe strings PERMANENT — the host NEVER logs the raw
 //!   guest string. (This is safety mechanism, NOT a cardinality/count policy — that's Cedar's.)
 
-use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
+use cdz_kernel::effect::{effect_ct, EffectId, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::event_ast::{decode_metric_publish, decode_metrics_publish, MetricSample};
 use cdz_kernel::executor::Executor;
@@ -216,7 +216,12 @@ impl MetricExecutor {
 
 #[async_trait::async_trait(?Send)]
 impl Executor for MetricExecutor {
-    async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        _id: EffectId,
+        req: &EffectRequest,
+        _idempotency_key: Hash,
+    ) -> EffectOutcome {
         // Family-keyed, matching the router + authz decision. A non-metric/publish family is structural →
         // PERMANENT (§17: observable Err, never a panic).
         if !req.content_type.matches_family(effect_ct::METRIC_PUBLISH) {
@@ -336,7 +341,11 @@ mod tests {
             ("agent.model_ms", "timing", 88.0),
         ] {
             let out = exec
-                .perform(&publish_req(&sample(name, kind, val)), Hash::of(b"k"))
+                .perform(
+                    EffectId(0),
+                    &publish_req(&sample(name, kind, val)),
+                    Hash::of(b"k"),
+                )
                 .await;
             assert!(
                 matches!(out, EffectOutcome::Ok(None)),
@@ -356,7 +365,8 @@ mod tests {
         let mut exec = MetricExecutor::new(registry);
         let m = sample("agent.turns", "counter", 1.0);
         assert!(matches!(
-            exec.perform(&publish_req(&m), Hash::of(b"k")).await,
+            exec.perform(EffectId(0), &publish_req(&m), Hash::of(b"k"))
+                .await,
             EffectOutcome::Ok(None)
         ));
         assert_eq!(
@@ -366,7 +376,8 @@ mod tests {
         );
         // Repeat: same key → cache hit, no new entry.
         assert!(matches!(
-            exec.perform(&publish_req(&m), Hash::of(b"k")).await,
+            exec.perform(EffectId(0), &publish_req(&m), Hash::of(b"k"))
+                .await,
             EffectOutcome::Ok(None)
         ));
         assert_eq!(
@@ -377,6 +388,7 @@ mod tests {
         // A DIFFERENT name → a distinct cached series.
         assert!(matches!(
             exec.perform(
+                EffectId(0),
                 &publish_req(&sample("agent.other", "counter", 1.0)),
                 Hash::of(b"k")
             )
@@ -405,14 +417,16 @@ mod tests {
             ],
         };
         assert!(matches!(
-            exec.perform(&publish_req(&labeled), Hash::of(b"k")).await,
+            exec.perform(EffectId(0), &publish_req(&labeled), Hash::of(b"k"))
+                .await,
             EffectOutcome::Ok(None)
         ));
         // Same labels in REVERSE order → same series (sorted key), so no new cache entry.
         let mut reordered = labeled.clone();
         reordered.labels.reverse();
         assert!(matches!(
-            exec.perform(&publish_req(&reordered), Hash::of(b"k")).await,
+            exec.perform(EffectId(0), &publish_req(&reordered), Hash::of(b"k"))
+                .await,
             EffectOutcome::Ok(None)
         ));
         assert_eq!(
@@ -426,7 +440,7 @@ mod tests {
             ..labeled.clone()
         };
         assert!(matches!(
-            exec.perform(&publish_req(&other_labels), Hash::of(b"k"))
+            exec.perform(EffectId(0), &publish_req(&other_labels), Hash::of(b"k"))
                 .await,
             EffectOutcome::Ok(None)
         ));
@@ -446,6 +460,7 @@ mod tests {
         for i in 0..200 {
             let out = exec
                 .perform(
+                    EffectId(0),
                     &publish_req(&sample(&format!("m{i}"), "counter", 1.0)),
                     Hash::of(b"k"),
                 )
@@ -468,6 +483,7 @@ mod tests {
         let mut exec = MetricExecutor::new(registry);
         let out = exec
             .perform(
+                EffectId(0),
                 &publish_req(&sample("m", "histogram-ish", 1.0)),
                 Hash::of(b"k"),
             )
@@ -485,6 +501,7 @@ mod tests {
         // A statsd-line-corrupting char (':') in the name → rejected PERMANENT (guest-string safety).
         let out = exec
             .perform(
+                EffectId(0),
                 &publish_req(&sample("bad:name", "counter", 1.0)),
                 Hash::of(b"k"),
             )
@@ -496,6 +513,7 @@ mod tests {
         // A control char likewise.
         let out = exec
             .perform(
+                EffectId(0),
                 &publish_req(&sample("bad\nname", "counter", 1.0)),
                 Hash::of(b"k"),
             )
@@ -517,7 +535,7 @@ mod tests {
             Timeliness::Interactive,
         );
         assert!(
-            matches!(exec.perform(&wrong, Hash::of(b"k")).await, EffectOutcome::Err { message, .. } if message.contains("only handles"))
+            matches!(exec.perform(EffectId(0), &wrong, Hash::of(b"k")).await, EffectOutcome::Err { message, .. } if message.contains("only handles"))
         );
         assert!(
             exec.handles_family(effect_ct::METRIC_PUBLISH) && !exec.handles_family(effect_ct::EMIT)
@@ -530,7 +548,7 @@ mod tests {
             Timeliness::Interactive,
         );
         assert!(
-            matches!(exec.perform(&no_payload, Hash::of(b"k")).await, EffectOutcome::Err { message, .. } if message.contains("requires a payload"))
+            matches!(exec.perform(EffectId(0), &no_payload, Hash::of(b"k")).await, EffectOutcome::Err { message, .. } if message.contains("requires a payload"))
         );
         // Undecodable payload.
         let garbage = EffectRequest::new_with_family(
@@ -540,7 +558,7 @@ mod tests {
             Timeliness::Interactive,
         );
         assert!(
-            matches!(exec.perform(&garbage, Hash::of(b"k")).await, EffectOutcome::Err { message, .. } if message.contains("did not decode"))
+            matches!(exec.perform(EffectId(0), &garbage, Hash::of(b"k")).await, EffectOutcome::Err { message, .. } if message.contains("did not decode"))
         );
     }
 
@@ -562,7 +580,9 @@ mod tests {
         ] {
             let mut s = sample(&format!("m.{unit}.{kind}"), kind, 1.0);
             s.unit = unit.into();
-            let out = exec.perform(&publish_req(&s), Hash::of(b"k")).await;
+            let out = exec
+                .perform(EffectId(0), &publish_req(&s), Hash::of(b"k"))
+                .await;
             assert!(
                 matches!(out, EffectOutcome::Ok(None)),
                 "unit {unit:?} on a {kind} records cleanly (unknown unit is not an error), got {out:?}"
@@ -590,7 +610,9 @@ mod tests {
             sample("agent.queue", "gauge", 5.0),
             sample("agent.latency", "timing", 12.0),
         ];
-        let out = exec.perform(&batch_req(&batch), Hash::of(b"k")).await;
+        let out = exec
+            .perform(EffectId(0), &batch_req(&batch), Hash::of(b"k"))
+            .await;
         assert!(
             matches!(out, EffectOutcome::Ok(None)),
             "batch records, got {out:?}"
@@ -606,7 +628,9 @@ mod tests {
             sample("agent.ok", "counter", 1.0),
             sample("bad:name", "counter", 1.0), // unsafe (':' corrupts a statsd line)
         ];
-        let out = exec.perform(&batch_req(&bad_batch), Hash::of(b"k")).await;
+        let out = exec
+            .perform(EffectId(0), &batch_req(&bad_batch), Hash::of(b"k"))
+            .await;
         assert!(
             matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("unsafe chars")),
             "a batch with an unsafe sample is rejected whole, got {out:?}"
@@ -619,6 +643,7 @@ mod tests {
         // A SINGLE (non-batch) metric-publish payload still works (back-compat fallback).
         let out = exec
             .perform(
+                EffectId(0),
                 &publish_req(&sample("agent.single", "counter", 1.0)),
                 Hash::of(b"k"),
             )

--- a/implementation/seed/crates/cdz-agent-host/src/model.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/model.rs
@@ -18,7 +18,7 @@
 //! re-driven dispatch after a crash (or at least be aware the same key means "the same logical call").
 
 use bytes::Bytes;
-use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
+use cdz_kernel::effect::{effect_ct, EffectId, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::executor::Executor;
 use cdz_kernel::hash::Hash;
@@ -70,7 +70,12 @@ impl<T: ModelTransport> ModelExecutor<T> {
 
 #[async_trait::async_trait(?Send)]
 impl<T: ModelTransport> Executor for ModelExecutor<T> {
-    async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        _id: EffectId,
+        req: &EffectRequest,
+        idempotency_key: Hash,
+    ) -> EffectOutcome {
         // These are structural request errors — retrying can't fix them, so they're PERMANENT (§17
         // totality: an observable Err, never a panic).
         // Key the guard on the effect FAMILY STRING (seq-39 / effect-schema slice 2), not the EffectKind
@@ -468,6 +473,7 @@ mod tests {
         });
         match exec
             .perform(
+                EffectId(0),
                 &model_req(Some(Payload::Inline(b"prompt".to_vec().into()))),
                 Hash::of(b"k"),
             )
@@ -485,7 +491,10 @@ mod tests {
         let mut exec = ModelExecutor::new(StubTransport {
             response: Bytes::new(),
         });
-        match exec.perform(&model_req(None), Hash::of(b"k")).await {
+        match exec
+            .perform(EffectId(0), &model_req(None), Hash::of(b"k"))
+            .await
+        {
             EffectOutcome::Err {
                 message,
                 retryability,
@@ -505,6 +514,7 @@ mod tests {
         });
         match exec
             .perform(
+                EffectId(0),
                 &model_req(Some(Payload::Blob(Hash::of(b"big-body")))),
                 Hash::of(b"k"),
             )
@@ -536,6 +546,7 @@ mod tests {
         let mut exec = ModelExecutor::new(ThrottledTransport);
         match exec
             .perform(
+                EffectId(0),
                 &model_req(Some(Payload::Inline(b"prompt".to_vec().into()))),
                 Hash::of(b"k"),
             )
@@ -570,7 +581,7 @@ mod tests {
             Some(Payload::Inline(b"x".to_vec().into())),
             Timeliness::Interactive,
         );
-        match exec.perform(&req, Hash::of(b"k")).await {
+        match exec.perform(EffectId(0), &req, Hash::of(b"k")).await {
             EffectOutcome::Err {
                 message,
                 retryability,

--- a/implementation/seed/crates/cdz-agent-host/src/shell.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/shell.rs
@@ -26,7 +26,7 @@
 //! dedup handle a re-driven dispatch (post-crash) can key on. v0 runs the command each perform (documented);
 //! a dedup cache is a later refinement.
 
-use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
+use cdz_kernel::effect::{effect_ct, EffectId, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::executor::Executor;
 use cdz_kernel::hash::Hash;
@@ -53,7 +53,12 @@ impl Default for ShellExecutor {
 
 #[async_trait::async_trait(?Send)]
 impl Executor for ShellExecutor {
-    async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        _id: EffectId,
+        req: &EffectRequest,
+        _idempotency_key: Hash,
+    ) -> EffectOutcome {
         // Family guard (seq-39 family-string source of truth, same as Clock/Http/Model). A wrong family is
         // structural → PERMANENT (§17: an observable Err, never a panic; a supervisor must not retry it).
         if !req.content_type.matches_family(effect_ct::SHELL) {
@@ -303,7 +308,9 @@ mod tests {
             Some(Payload::Inline(encode_shell_pipeline(&pipeline).into())),
             Timeliness::Interactive,
         );
-        let out = ShellExecutor::new().perform(&req, Hash::of(b"k")).await;
+        let out = ShellExecutor::new()
+            .perform(EffectId(0), &req, Hash::of(b"k"))
+            .await;
         match out {
             EffectOutcome::Ok(Some(Payload::Inline(bytes))) => {
                 match decode_shell_pipeline_outcome(&bytes).expect("decodes as a pipeline outcome")
@@ -356,7 +363,7 @@ mod tests {
         // A generous timeout: a correct runner finishes in ms; a deadlocked one never returns (the bug).
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(20),
-            ShellExecutor::new().perform(&req, Hash::of(b"k")),
+            ShellExecutor::new().perform(EffectId(0), &req, Hash::of(b"k")),
         )
         .await
         .expect("pipeline must not deadlock on a large final stdout (>64KB)");
@@ -404,7 +411,9 @@ mod tests {
             Some(Payload::Inline(encode_shell_pipeline(&pipeline).into())),
             Timeliness::Interactive,
         );
-        let out = ShellExecutor::new().perform(&req, Hash::of(b"k")).await;
+        let out = ShellExecutor::new()
+            .perform(EffectId(0), &req, Hash::of(b"k"))
+            .await;
         match out {
             EffectOutcome::Ok(Some(Payload::Inline(bytes))) => {
                 match decode_shell_pipeline_outcome(&bytes).expect("decodes") {
@@ -428,7 +437,9 @@ mod tests {
     #[tokio::test]
     async fn a_command_runs_and_returns_its_stdout() {
         let mut exec = ShellExecutor::new();
-        let out = exec.perform(&shell_req("echo hello"), Hash::of(b"k")).await;
+        let out = exec
+            .perform(EffectId(0), &shell_req("echo hello"), Hash::of(b"k"))
+            .await;
         match out {
             EffectOutcome::Ok(Some(Payload::Inline(bytes))) => {
                 assert_eq!(
@@ -448,7 +459,7 @@ mod tests {
         // independent of any policy (policy lives in Cedar). Proves a `;`-injected command never runs.
         let mut exec = ShellExecutor::new();
         let out = exec
-            .perform(&shell_req("echo a ; rm -rf /"), Hash::of(b"k"))
+            .perform(EffectId(0), &shell_req("echo a ; rm -rf /"), Hash::of(b"k"))
             .await;
         match out {
             EffectOutcome::Ok(Some(Payload::Inline(bytes))) => {
@@ -466,7 +477,9 @@ mod tests {
     async fn a_non_zero_exit_is_a_permanent_error_with_the_stderr() {
         // `false` exits non-zero → a real command failure the reducer folds, PERMANENT (not a host fault).
         let mut exec = ShellExecutor::new();
-        let out = exec.perform(&shell_req("false"), Hash::of(b"k")).await;
+        let out = exec
+            .perform(EffectId(0), &shell_req("false"), Hash::of(b"k"))
+            .await;
         assert!(
             matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("exit ")),
             "a non-zero exit is a PERMANENT command-failure, got {out:?}"
@@ -478,6 +491,7 @@ mod tests {
         let mut exec = ShellExecutor::new();
         let out = exec
             .perform(
+                EffectId(0),
                 &shell_req("this-program-does-not-exist-xyz"),
                 Hash::of(b"k"),
             )
@@ -497,7 +511,7 @@ mod tests {
             None,
             Timeliness::Interactive,
         );
-        let out = exec.perform(&req, Hash::of(b"k")).await;
+        let out = exec.perform(EffectId(0), &req, Hash::of(b"k")).await;
         assert!(
             matches!(&out, EffectOutcome::Err { message, retryability } if *retryability == Retryability::Permanent && message.contains("only handles")),
             "a non-Shell family is rejected PERMANENT, got {out:?}"
@@ -508,7 +522,9 @@ mod tests {
     #[tokio::test]
     async fn an_empty_command_target_is_a_permanent_error() {
         let mut exec = ShellExecutor::new();
-        let out = exec.perform(&shell_req("   "), Hash::of(b"k")).await;
+        let out = exec
+            .perform(EffectId(0), &shell_req("   "), Hash::of(b"k"))
+            .await;
         assert!(
             matches!(&out, EffectOutcome::Err { message, .. } if message.contains("empty command")),
             "an empty/whitespace target is PERMANENT, got {out:?}"

--- a/implementation/seed/crates/cdz-agent-host/src/ws_exec.rs
+++ b/implementation/seed/crates/cdz-agent-host/src/ws_exec.rs
@@ -26,7 +26,7 @@
 //! registry over live websocket sinks. NOT feature-gated: the executor + the registry trait are always-on
 //! (hermetic), like `blob_exec`; only the socket LISTENER that fills the registry is the `live-ws` piece.
 
-use cdz_kernel::effect::{effect_ct, EffectRequest, Payload};
+use cdz_kernel::effect::{effect_ct, EffectId, EffectRequest, Payload};
 use cdz_kernel::event::EffectOutcome;
 use cdz_kernel::executor::Executor;
 use cdz_kernel::hash::Hash;
@@ -70,7 +70,12 @@ impl<R: WsConnRegistry> WsSendExecutor<R> {
 
 #[async_trait::async_trait(?Send)]
 impl<R: WsConnRegistry> Executor for WsSendExecutor<R> {
-    async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        _id: EffectId,
+        req: &EffectRequest,
+        _idempotency_key: Hash,
+    ) -> EffectOutcome {
         let family = req.content_type.family.as_ref();
         // The kernel routes by family, but be explicit: this executor serves ONLY ws/send (the outbound
         // effect). ws/connect + ws/disconnect are INBOUND events the listener emits, never effects dispatched
@@ -183,7 +188,7 @@ mod tests {
         reg.open("conn-1");
         let mut exec = WsSendExecutor::new(reg);
         let out = exec
-            .perform(&send_req("conn-1", b"hello"), Hash::of(b"k"))
+            .perform(EffectId(0), &send_req("conn-1", b"hello"), Hash::of(b"k"))
             .await;
         assert_eq!(
             out,
@@ -201,7 +206,9 @@ mod tests {
     #[tokio::test]
     async fn send_to_an_unknown_conn_id_is_a_permanent_err() {
         let mut exec = WsSendExecutor::new(MemWsConnRegistry::default());
-        let out = exec.perform(&send_req("gone", b"x"), Hash::of(b"k")).await;
+        let out = exec
+            .perform(EffectId(0), &send_req("gone", b"x"), Hash::of(b"k"))
+            .await;
         match out {
             EffectOutcome::Err { retryability, .. } => assert_eq!(
                 retryability,
@@ -218,7 +225,7 @@ mod tests {
         reg.fail("conn-flaky");
         let mut exec = WsSendExecutor::new(reg);
         let out = exec
-            .perform(&send_req("conn-flaky", b"x"), Hash::of(b"k"))
+            .perform(EffectId(0), &send_req("conn-flaky", b"x"), Hash::of(b"k"))
             .await;
         match out {
             EffectOutcome::Err { retryability, .. } => assert_eq!(
@@ -235,7 +242,8 @@ mod tests {
         let mut exec = WsSendExecutor::new(MemWsConnRegistry::default());
         // empty conn-id
         assert!(matches!(
-            exec.perform(&send_req("", b"x"), Hash::of(b"k")).await,
+            exec.perform(EffectId(0), &send_req("", b"x"), Hash::of(b"k"))
+                .await,
             EffectOutcome::Err { .. }
         ));
         // no payload
@@ -246,7 +254,7 @@ mod tests {
             Timeliness::Interactive,
         );
         assert!(matches!(
-            exec.perform(&no_payload, Hash::of(b"k")).await,
+            exec.perform(EffectId(0), &no_payload, Hash::of(b"k")).await,
             EffectOutcome::Err { .. }
         ));
     }
@@ -272,7 +280,7 @@ mod tests {
             Timeliness::Interactive,
         );
         assert!(matches!(
-            exec.perform(&misrouted, Hash::of(b"k")).await,
+            exec.perform(EffectId(0), &misrouted, Hash::of(b"k")).await,
             EffectOutcome::Err { .. }
         ));
     }

--- a/implementation/seed/crates/cdz-kernel/src/effect.rs
+++ b/implementation/seed/crates/cdz-kernel/src/effect.rs
@@ -327,23 +327,39 @@ pub mod effect_ct {
     /// the effect FAMILY string a reducer emits (the family `weather` registers AT `effect/weather`).
     pub const EFFECT_REGISTRY_PREFIX: &str = "effect/";
 
+    /// `effect/reply` — a ROUTED OUTBOUND effect family a userspace-effect HANDLER emits to answer a request
+    /// it was forwarded (userspace-effects I4). `target` = the opaque reply-token the delegating executor
+    /// minted + put in the forwarded request's framing (bound to the original `(caller SessionId, EffectId)`);
+    /// `payload` = the response bytes. The HOST `ReplyExecutor` validates+consumes the token and calls
+    /// [`crate::kernel::Session::settle_effect_result`] on the ORIGINAL caller's open (Deferred) effect —
+    /// closing the request→forward→reply→settle loop. Executor-routed + per-effect authz on the token (a
+    /// handler may only reply to a token it holds); a grantable effect (in [`ALL`]) + safe-logging. NOTE this
+    /// shares the `effect/` prefix with [`EFFECT_REGISTRY_PREFIX`] but is a DISTINCT thing: `effect/<family>`
+    /// is a store-NAME (the registration pointer), `effect/reply` is an EFFECT FAMILY (a routed verb) — so it
+    /// is explicitly EXCLUDED from [`is_registered_effect_family`] (it is a built-in, never a userspace family).
+    pub const EFFECT_REPLY: &str = "effect/reply";
+
     /// Is `family` a candidate USERSPACE-EFFECT family — i.e. NOT one of the built-in well-known partitions
     /// (so it would route to a registered handler, if one is registered)? A SYNTACTIC check: an emitted
-    /// effect whose family is not a kernel built-in (EffectKind / control/store/fs/metric/blob/ws) is a
-    /// candidate for `effect/<family>` handler resolution. Whether a handler is ACTUALLY registered is the
-    /// runtime lookup [`crate::name_store::NameStore::resolve_effect_handler`] (mechanism = "resolves in the
-    /// registry"); this predicate is the partition boundary the drive loop / delegating executor uses to
-    /// decide "try the userspace-effect path" vs "a known built-in family". Fail-safe: a family that IS a
-    /// built-in returns false (built-ins are never shadowed by a userspace handler).
+    /// effect whose family is not a kernel built-in (EffectKind / control/store/fs/metric/blob/ws / the
+    /// `effect/reply` routed family) is a candidate for `effect/<family>` handler resolution. Whether a
+    /// handler is ACTUALLY registered is the runtime lookup
+    /// [`crate::name_store::NameStore::resolve_effect_handler`] (mechanism = "resolves in the registry"); this
+    /// predicate is the partition boundary the drive loop / delegating executor uses to decide "try the
+    /// userspace-effect path" vs "a known built-in family". Fail-safe: a family that IS a built-in returns
+    /// false (built-ins are never shadowed by a userspace handler).
     pub fn is_registered_effect_family(family: &str) -> bool {
-        // A built-in well-known family is NOT a userspace effect (built-ins win — no shadowing).
+        // A built-in well-known family is NOT a userspace effect (built-ins win — no shadowing). `effect/reply`
+        // shares the `effect/` prefix but is a built-in ROUTED family (the handler's reply verb), NOT a
+        // userspace registration target — exclude it explicitly so it never mis-routes to handler resolution.
         let is_builtin = super::EffectKind::from_family(family).is_some()
             || is_control_family(family)
             || is_store_family(family)
             || is_fs_family(family)
             || is_metric_family(family)
             || is_blob_family(family)
-            || is_ws_family(family);
+            || is_ws_family(family)
+            || family == EFFECT_REPLY;
         !is_builtin && !family.is_empty()
     }
 
@@ -406,15 +422,16 @@ pub mod effect_ct {
         BLOB_PUT,
         BLOB_GET,
         WS_SEND,
+        EFFECT_REPLY,
     ];
 
     /// If `family` is a WELL-KNOWN family whose string is a FIXED, kernel-defined `&'static` — one of the
     /// built-in effect verbs ([`ALL`], via [`super::EffectKind::from_family`]) or the exact control/store/fs/
     /// metric families (`control/capabilities`, `control/summary`, `store/set`, `store/resolve`, `store/add`,
     /// `store/remove`, `store/resolve-all`, `fs/read`, `fs/write`, `fs/glob`, `metric/publish`, `blob/put`,
-    /// `blob/get`, `ws/send`, `ws/connect`, `ws/disconnect`) — return that canonical `&'static str`. `None`
-    /// for an EXTENSION family (register-by-string). (`ws/connect`/`ws/disconnect` are inbound EVENT families,
-    /// not effects, so they're here for safe-logging but NOT in [`ALL`].)
+    /// `blob/get`, `ws/send`, `ws/connect`, `ws/disconnect`, `effect/reply`) — return that canonical
+    /// `&'static str`. `None` for an EXTENSION family (register-by-string). (`ws/connect`/`ws/disconnect` are
+    /// inbound EVENT families, not effects, so they're here for safe-logging but NOT in [`ALL`].)
     ///
     /// The distinction matters for LOGGING (github-liaison #2180 residual): `ContentType.family` is a
     /// `Cow<'static, str>` and for an extension family it carries the CALLER's `Cow::Owned` verbatim — i.e.
@@ -452,6 +469,7 @@ pub mod effect_ct {
             // ALL) — but they're fixed kernel-defined strings, so classify them safe-to-log-verbatim too.
             WS_CONNECT => Some(WS_CONNECT),
             WS_DISCONNECT => Some(WS_DISCONNECT),
+            EFFECT_REPLY => Some(EFFECT_REPLY),
             _ => None,
         }
     }
@@ -1462,6 +1480,32 @@ mod tests {
         // The inbound event families are NOT grantable effects → absent from ALL (only ws/send is).
         assert!(!effect_ct::ALL.contains(&effect_ct::WS_CONNECT));
         assert!(!effect_ct::ALL.contains(&effect_ct::WS_DISCONNECT));
+    }
+
+    #[test]
+    fn effect_reply_is_a_routed_grantable_family_not_a_userspace_registration_candidate() {
+        // userspace-effects I4: effect/reply is the ROUTED OUTBOUND family a handler emits to answer a
+        // forwarded request (target = reply-token, payload = response). It shares the `effect/` prefix with
+        // EFFECT_REGISTRY_PREFIX but is a BUILT-IN routed effect, NOT a userspace-registration target.
+        assert_eq!(effect_ct::EFFECT_REPLY, "effect/reply");
+        assert!(effect_ct::EFFECT_REPLY.starts_with(effect_ct::EFFECT_REGISTRY_PREFIX));
+        // Grantable (in ALL — the capability projection reports it) + safe-logging (fixed &'static).
+        assert!(effect_ct::ALL.contains(&effect_ct::EFFECT_REPLY));
+        assert_eq!(
+            effect_ct::wellknown_static_str(effect_ct::EFFECT_REPLY),
+            Some(effect_ct::EFFECT_REPLY)
+        );
+        // CRITICAL collision guard: despite the effect/ prefix, effect/reply is NOT a userspace-effect
+        // family — it must never route to handler resolution (it IS the reply verb, a built-in).
+        assert!(
+            !effect_ct::is_registered_effect_family(effect_ct::EFFECT_REPLY),
+            "effect/reply is a built-in routed family, NOT a userspace-registration candidate"
+        );
+        // A genuine userspace family (no effect/ prefix, not a builtin) still IS a candidate.
+        assert!(effect_ct::is_registered_effect_family("weather"));
+        // A guest effect/<x> that isn't the exact reply const logs redacted (None); the registry PREFIX is
+        // a store-name space, not an effect-family — so wellknown_static_str doesn't bless arbitrary effect/*.
+        assert_eq!(effect_ct::wellknown_static_str("effect/weather"), None);
     }
 
     #[test]

--- a/implementation/seed/crates/cdz-kernel/src/executor.rs
+++ b/implementation/seed/crates/cdz-kernel/src/executor.rs
@@ -9,7 +9,7 @@
 //! side-effecting executor, re-driving the same key after a crash must not double-apply — the executor
 //! dedups on it. Naturally-idempotent executors can ignore it.
 
-use crate::effect::{EffectKind, EffectRequest, Payload};
+use crate::effect::{EffectId, EffectKind, EffectRequest, Payload};
 use crate::event::EffectOutcome;
 use crate::hash::Hash;
 use std::collections::HashMap;
@@ -27,9 +27,25 @@ use std::collections::HashMap;
 #[async_trait::async_trait(?Send)]
 pub trait Executor {
     /// Perform `req` — the un-suffixed name (the whole trait is `async`, so an `_async` suffix would be
-    /// redundant). `idempotency_key` lets a side-effecting executor dedup a re-driven dispatch after a
-    /// crash. Returns the outcome the kernel folds back as an `EffectResult`. May `.await` real I/O.
-    async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome;
+    /// redundant). Returns the outcome the kernel folds back as an `EffectResult`. May `.await` real I/O.
+    ///
+    /// `id` is the kernel `EffectId` the loop assigned this dispatch — the SAME id that keys the durable
+    /// `Dispatched` frame and that a later [`crate::kernel::Session::settle_effect_result`] settles. Most
+    /// executors ignore it (they answer synchronously and the loop folds the returned outcome). A DELEGATING
+    /// executor NEEDS it: a userspace-effect executor that returns [`EffectOutcome::Deferred`] forwards the
+    /// request to a handler session and must bind its reply-token to `(caller, id)` so the handler's
+    /// `effect/reply` settles the RIGHT open effect (`settle_effect_result` takes the `EffectId`). The id is
+    /// already on the log in the `Dispatched` record, so surfacing it here exposes no new kernel state.
+    ///
+    /// `idempotency_key` lets a side-effecting executor dedup a re-driven dispatch after a crash (a
+    /// `Hash` = `idempotency_key_for(id, req)`, not the id itself — it is a stable dedup handle, not a
+    /// reversible id, which is why the id is passed distinctly).
+    async fn perform(
+        &mut self,
+        id: EffectId,
+        req: &EffectRequest,
+        idempotency_key: Hash,
+    ) -> EffectOutcome;
 
     /// Does this executor serve effect `family`? The MECHANISM dimension the capability-manifest
     /// projection ([`crate::effect::project_manifest`]) probes over the canonical family set — "does the
@@ -97,11 +113,17 @@ impl CompositeExecutor {
 
 #[async_trait::async_trait(?Send)]
 impl Executor for CompositeExecutor {
-    async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        id: EffectId,
+        req: &EffectRequest,
+        idempotency_key: Hash,
+    ) -> EffectOutcome {
         // Route by the request's content-type FAMILY (seq-39): a request whose family has no registered
-        // executor is an OBSERVABLE Err (§9d anti-stuck), never a panic/drop.
+        // executor is an OBSERVABLE Err (§9d anti-stuck), never a panic/drop. `id` threads through unchanged
+        // so a delegating leaf executor can bind its reply-token to (caller, id).
         match self.by_family.get_mut(req.content_type.family.as_ref()) {
-            Some(inner) => inner.perform(req, idempotency_key).await,
+            Some(inner) => inner.perform(id, req, idempotency_key).await,
             None => EffectOutcome::err(format!(
                 "no executor registered for effect family {:?} (target {:?})",
                 req.content_type.family, req.target
@@ -141,7 +163,12 @@ impl RecordingExecutor {
 
 #[async_trait::async_trait(?Send)]
 impl Executor for RecordingExecutor {
-    async fn perform(&mut self, req: &EffectRequest, idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        _id: EffectId,
+        req: &EffectRequest,
+        idempotency_key: Hash,
+    ) -> EffectOutcome {
         self.seen.push((req.clone(), idempotency_key));
         EffectOutcome::Ok(Some(Payload::Inline(b"ok".to_vec().into())))
     }
@@ -181,7 +208,12 @@ pub struct ShellExecutor;
 #[cfg(all(feature = "live-exec", unix))]
 #[async_trait::async_trait(?Send)]
 impl Executor for ShellExecutor {
-    async fn perform(&mut self, req: &EffectRequest, _idempotency_key: Hash) -> EffectOutcome {
+    async fn perform(
+        &mut self,
+        _id: EffectId,
+        req: &EffectRequest,
+        _idempotency_key: Hash,
+    ) -> EffectOutcome {
         use crate::effect::EffectKind;
         if req.kind != EffectKind::Shell {
             return EffectOutcome::err(format!(
@@ -224,7 +256,12 @@ mod tests {
     struct TagExecutor(&'static [u8]);
     #[async_trait::async_trait(?Send)]
     impl Executor for TagExecutor {
-        async fn perform(&mut self, _req: &EffectRequest, _key: Hash) -> EffectOutcome {
+        async fn perform(
+            &mut self,
+            _id: EffectId,
+            _req: &EffectRequest,
+            _key: Hash,
+        ) -> EffectOutcome {
             EffectOutcome::Ok(Some(Payload::Inline(self.0.to_vec().into())))
         }
     }
@@ -235,7 +272,11 @@ mod tests {
         let mut tagged = TagExecutor(b"async-ran");
         let dyn_exec: &mut dyn Executor = &mut tagged;
         let out = dyn_exec
-            .perform(&req(EffectKind::Http, "https://ok/x"), Hash::of(b"k"))
+            .perform(
+                EffectId(1),
+                &req(EffectKind::Http, "https://ok/x"),
+                Hash::of(b"k"),
+            )
             .await;
         assert_eq!(
             out,
@@ -259,13 +300,21 @@ mod tests {
 
         // Each kind reaches its own executor — the multi-kind session a single executor couldn't serve.
         assert_eq!(
-            exec.perform(&req(EffectKind::Http, "https://ok/x"), Hash::of(b"k"))
-                .await,
+            exec.perform(
+                EffectId(1),
+                &req(EffectKind::Http, "https://ok/x"),
+                Hash::of(b"k")
+            )
+            .await,
             EffectOutcome::Ok(Some(Payload::Inline(b"http-ran".to_vec().into())))
         );
         assert_eq!(
-            exec.perform(&req(EffectKind::Shell, "echo hi"), Hash::of(b"k"))
-                .await,
+            exec.perform(
+                EffectId(1),
+                &req(EffectKind::Shell, "echo hi"),
+                Hash::of(b"k")
+            )
+            .await,
             EffectOutcome::Ok(Some(Payload::Inline(b"shell-ran".to_vec().into())))
         );
     }
@@ -278,7 +327,7 @@ mod tests {
             .with_effect(crate::effect::effect_ct::HTTP, Box::new(TagExecutor(b"h")));
         assert!(!exec.handles(&EffectKind::Model));
         match exec
-            .perform(&req(EffectKind::Model, "gpt"), Hash::of(b"k"))
+            .perform(EffectId(1), &req(EffectKind::Model, "gpt"), Hash::of(b"k"))
             .await
         {
             EffectOutcome::Err { message: msg, .. } => {
@@ -310,7 +359,7 @@ mod tests {
         let mut ext = req(EffectKind::Http, "x");
         ext.content_type.family = "embedding".into();
         assert_eq!(
-            exec.perform(&ext, Hash::of(b"k")).await,
+            exec.perform(EffectId(1), &ext, Hash::of(b"k")).await,
             EffectOutcome::Ok(Some(Payload::Inline(b"embed-e".to_vec().into())))
         );
         // with(EffectKind) delegates to with_effect(kind.family(), ..) — same registration.
@@ -319,7 +368,7 @@ mod tests {
         assert!(viaenum.handles_family(crate::effect::effect_ct::HTTP));
         assert_eq!(
             viaenum
-                .perform(&req(EffectKind::Http, "x"), Hash::of(b"k"))
+                .perform(EffectId(1), &req(EffectKind::Http, "x"), Hash::of(b"k"))
                 .await,
             EffectOutcome::Ok(Some(Payload::Inline(b"h".to_vec().into())))
         );
@@ -338,7 +387,7 @@ mod tests {
                 Box::new(TagExecutor(b"second")),
             );
         assert_eq!(
-            exec.perform(&req(EffectKind::Http, "x"), Hash::of(b"k"))
+            exec.perform(EffectId(1), &req(EffectKind::Http, "x"), Hash::of(b"k"))
                 .await,
             EffectOutcome::Ok(Some(Payload::Inline(b"second".to_vec().into())))
         );
@@ -351,7 +400,12 @@ mod tests {
         struct KeyEcho;
         #[async_trait::async_trait(?Send)]
         impl Executor for KeyEcho {
-            async fn perform(&mut self, _req: &EffectRequest, key: Hash) -> EffectOutcome {
+            async fn perform(
+                &mut self,
+                _id: EffectId,
+                _req: &EffectRequest,
+                key: Hash,
+            ) -> EffectOutcome {
                 EffectOutcome::Ok(Some(Payload::Inline(key.as_bytes().to_vec().into())))
             }
         }
@@ -359,8 +413,37 @@ mod tests {
             CompositeExecutor::new().with_effect(crate::effect::effect_ct::HTTP, Box::new(KeyEcho));
         let key = Hash::of(b"the-key");
         assert_eq!(
-            exec.perform(&req(EffectKind::Http, "x"), key).await,
+            exec.perform(EffectId(1), &req(EffectKind::Http, "x"), key)
+                .await,
             EffectOutcome::Ok(Some(Payload::Inline(key.as_bytes().to_vec().into())))
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn composite_threads_the_effect_id_to_the_inner_executor() {
+        // userspace-effects I3: the delegating executor binds its reply-token to the dispatch's EffectId, so
+        // the router MUST forward the SAME id (the one keying the open Dispatched frame) to the inner leaf
+        // executor unchanged — else a Deferred executor would mint a token against the wrong id and its
+        // later `effect/reply` would settle the wrong open effect. Prove the id round-trips through the route.
+        struct IdEcho;
+        #[async_trait::async_trait(?Send)]
+        impl Executor for IdEcho {
+            async fn perform(
+                &mut self,
+                id: EffectId,
+                _req: &EffectRequest,
+                _key: Hash,
+            ) -> EffectOutcome {
+                EffectOutcome::Ok(Some(Payload::Inline(id.0.to_le_bytes().to_vec().into())))
+            }
+        }
+        let mut exec =
+            CompositeExecutor::new().with_effect(crate::effect::effect_ct::HTTP, Box::new(IdEcho));
+        assert_eq!(
+            exec.perform(EffectId(4242), &req(EffectKind::Http, "x"), Hash::of(b"k"))
+                .await,
+            EffectOutcome::Ok(Some(Payload::Inline(4242u64.to_le_bytes().to_vec().into()))),
+            "the composite router forwards the dispatch EffectId to the inner executor unchanged"
         );
     }
 
@@ -399,14 +482,14 @@ mod tests {
         r.content_type.family = EffectKind::Model.family().into();
         // Routed by family ("model") to the MODEL executor, despite kind == Http.
         assert_eq!(
-            exec.perform(&r, Hash::of(b"k")).await,
+            exec.perform(EffectId(1), &r, Hash::of(b"k")).await,
             EffectOutcome::Ok(Some(Payload::Inline(b"model-executor".to_vec().into())))
         );
         // And a family with NO registered executor (and no EffectKind variant) is an observable Err naming
         // that family — the fail-closed seam the register-by-string slice hardens to retry::permanent.
         let mut ext = req(EffectKind::Http, "x");
         ext.content_type.family = "embedding".into();
-        match exec.perform(&ext, Hash::of(b"k")).await {
+        match exec.perform(EffectId(1), &ext, Hash::of(b"k")).await {
             EffectOutcome::Err { message: msg, .. } => assert!(
                 msg.contains("embedding"),
                 "unroutable extension family named in the err: {msg}"

--- a/implementation/seed/crates/cdz-kernel/src/kernel.rs
+++ b/implementation/seed/crates/cdz-kernel/src/kernel.rs
@@ -1215,7 +1215,7 @@ impl Session {
                 target_len = req.target.len(),
                 "dispatching effect to executor"
             );
-            let outcome = executor.perform(&req, idempotency_key).await;
+            let outcome = executor.perform(id, &req, idempotency_key).await;
 
             // DEFERRED (userspace-effects I2): the executor forwarded this effect for asynchronous
             // fulfillment (e.g. a UserspaceEffectExecutor delegated to a registered handler session) and will
@@ -2835,7 +2835,12 @@ mod monotonic_now_tests {
     struct StuckClock(u64);
     #[async_trait::async_trait(?Send)]
     impl Executor for StuckClock {
-        async fn perform(&mut self, req: &EffectRequest, _key: Hash) -> EffectOutcome {
+        async fn perform(
+            &mut self,
+            _id: EffectId,
+            req: &EffectRequest,
+            _key: Hash,
+        ) -> EffectOutcome {
             assert_eq!(req.kind, EffectKind::Now);
             EffectOutcome::Ok(Some(Payload::Inline(self.0.to_le_bytes().to_vec().into())))
         }
@@ -4113,7 +4118,12 @@ mod monotonic_now_tests {
     struct FailingHttpExecutor;
     #[async_trait::async_trait(?Send)]
     impl Executor for FailingHttpExecutor {
-        async fn perform(&mut self, req: &EffectRequest, _key: Hash) -> EffectOutcome {
+        async fn perform(
+            &mut self,
+            _id: EffectId,
+            req: &EffectRequest,
+            _key: Hash,
+        ) -> EffectOutcome {
             assert_eq!(req.kind, EffectKind::Http);
             EffectOutcome::err("PERMANENT: 400 bad request".to_string())
         }
@@ -4211,7 +4221,12 @@ mod monotonic_now_tests {
     struct DeferringExecutor;
     #[async_trait::async_trait(?Send)]
     impl Executor for DeferringExecutor {
-        async fn perform(&mut self, _req: &EffectRequest, _key: Hash) -> EffectOutcome {
+        async fn perform(
+            &mut self,
+            _id: EffectId,
+            _req: &EffectRequest,
+            _key: Hash,
+        ) -> EffectOutcome {
             EffectOutcome::Deferred
         }
     }
@@ -5303,7 +5318,12 @@ mod store_effect_tests {
     }
     #[async_trait::async_trait(?Send)]
     impl crate::executor::Executor for ScriptedAgentExecutor {
-        async fn perform(&mut self, req: &EffectRequest, _key: Hash) -> EffectOutcome {
+        async fn perform(
+            &mut self,
+            _id: EffectId,
+            req: &EffectRequest,
+            _key: Hash,
+        ) -> EffectOutcome {
             let family = req.content_type.family.as_ref();
             if family == effect_ct::MODEL {
                 self.model_calls += 1;
@@ -6242,7 +6262,12 @@ mod store_effect_tests {
     }
     #[async_trait::async_trait(?Send)]
     impl Executor for StubBlobExecutor {
-        async fn perform(&mut self, req: &EffectRequest, _key: Hash) -> EffectOutcome {
+        async fn perform(
+            &mut self,
+            _id: EffectId,
+            req: &EffectRequest,
+            _key: Hash,
+        ) -> EffectOutcome {
             let family = req.content_type.family.as_ref();
             match family {
                 effect_ct::BLOB_PUT => {

--- a/implementation/seed/crates/cdz-kernel/tests/loop_and_recovery.rs
+++ b/implementation/seed/crates/cdz-kernel/tests/loop_and_recovery.rs
@@ -291,7 +291,12 @@ async fn timeout_cancels_so_a_late_result_is_dropped() {
     struct TimeoutExecutor;
     #[async_trait::async_trait(?Send)]
     impl Executor for TimeoutExecutor {
-        async fn perform(&mut self, _req: &EffectRequest, _key: Hash) -> EffectOutcome {
+        async fn perform(
+            &mut self,
+            _id: cdz_kernel::effect::EffectId,
+            _req: &EffectRequest,
+            _key: Hash,
+        ) -> EffectOutcome {
             EffectOutcome::TimedOut
         }
     }


### PR DESCRIPTION
Candidate PR for v-agent-harness-host's merge-request (ref 81e18d06c, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.