### PR TITLE
syntax: cadenza-lint I1 Tier-A pack — built-in idiomatic catalog (if-bool, redundant-let) as default cdz lint

### DIFF
--- a/implementation/seed/crates/cadenza-syntax/src/cli.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/cli.rs
@@ -1238,8 +1238,11 @@ fn run_lint(args: &LintArgs) -> Result<bool, String> {
         set.rules
             .extend(LintSet::compile(r).map_err(|e| e.to_string())?.rules);
     }
+    // With NO explicit rules, `cdz lint FILE` runs the BUILT-IN `idiomatic` catalog (the Tier-A pack) —
+    // so the command is useful out of the box, not an error. Explicit --rules/--rule still fully replace
+    // it (they populate `set` above); a level flag/directive then tunes whichever set is active.
     if set.rules.is_empty() {
-        return Err("no lint rules — pass --rules FILE and/or --rule '(lint …)'".into());
+        set = LintSet::builtin();
     }
 
     // Build the CLI level overrides (allow/warn/deny NAME). Later flags win on the same key; a CLI

--- a/implementation/seed/crates/cadenza-syntax/src/query.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/query.rs
@@ -3269,6 +3269,38 @@ pub mod lint {
                 .collect::<Result<_, _>>()?;
             Ok(LintSet::new(rules))
         }
+
+        /// The BUILT-IN `idiomatic` lint catalog (DESIGN-cadenza-lint §2, Tier A — the first shipped
+        /// pack) — the curated `LintSet` `cdz lint` uses by default so `cdz lint FILE` works out of the
+        /// box. Each rule is a named, level-controllable idiomatic lint carrying a `Verified` structural
+        /// fix where a canonical rewrite exists:
+        ///
+        /// - `idiomatic/if-bool` — `(if c true false)` → `c`; `(if c false true)` → `(not c)`. Two rules
+        ///   (the arena distinguishes the arms), both Verified.
+        /// - `idiomatic/redundant-let` — `(let ((x e)) x)` → `e` (bind then immediately return it),
+        ///   Verified. NB the arena let-shape is the binding-LIST `(let ((x e)) x)`, not `(let x e x)`.
+        ///
+        /// `idiomatic/single-arm-match` (`(match x (p e))` → `(let p x e)`) is NOT here yet: its fix must
+        /// DELEGATE to `match_to_let`'s irrefutable+unguarded precondition (a refutable single arm is not
+        /// safe to convert), which a pure `=> TEMPLATE` cannot express — it needs the codemod path, a
+        /// follow-on brick. The catalog grows increment-by-increment (§2 open catalog).
+        ///
+        /// `compile` of this text is infallible (a unit test pins it), so `expect` is sound.
+        pub fn builtin() -> LintSet {
+            // A sequence of `(lint …)` forms — `LintSet::compile` reads them via `sexpr::read_all`,
+            // which synthesizes the `(do …)` wrapper itself (so we must NOT write our own `(do …)`, or
+            // it double-wraps and the inner `(do …)` fails the `(lint …)` head check).
+            Self::compile(concat!(
+                "(lint idiomatic/if-bool (if ,c true false) ",
+                "\"redundant `if` on a Bool — use the condition directly\" => ,c verified)\n",
+                "(lint idiomatic/if-bool (if ,c false true) ",
+                "\"redundant `if` on a Bool — use `not(condition)`\" => (not ,c) verified)\n",
+                "(lint idiomatic/redundant-let (let ((,x ,e)) ,x) ",
+                "\"redundant `let` — binds a value then immediately returns it; use the value directly\" ",
+                "=> ,e verified)\n",
+            ))
+            .expect("the built-in idiomatic lint catalog compiles")
+        }
     }
 
     /// The per-lint control level (DESIGN-cadenza-lint §3, the one net-new mechanism). Distinct from
@@ -6139,6 +6171,84 @@ mod tests {
                 levels.effective("idiomatic/if-bool"),
                 Some(LintLevel::Allow)
             );
+        }
+
+        // --- cadenza-lint I1 (Tier-A pack): the built-in `idiomatic` catalog. ---
+
+        #[test]
+        fn builtin_catalog_compiles_and_names_its_lints() {
+            let set = LintSet::builtin();
+            // if-bool (×2, the true/false + false/true arms) + redundant-let.
+            assert_eq!(set.rules.len(), 3, "3 Tier-A rules");
+            let names: Vec<&str> = set.rules.iter().filter_map(|r| r.name.as_deref()).collect();
+            assert_eq!(
+                names,
+                [
+                    "idiomatic/if-bool",
+                    "idiomatic/if-bool",
+                    "idiomatic/redundant-let"
+                ]
+            );
+            // Every catalog rule carries a Verified fix.
+            for r in &set.rules {
+                let (_, app) = r.fix.as_ref().expect("a catalog lint carries a fix");
+                assert_eq!(*app, Applicability::Verified, "catalog fixes are Verified");
+            }
+        }
+
+        #[test]
+        fn builtin_catalog_fires_on_the_idiomatic_shapes() {
+            let set = LintSet::builtin();
+            // `(if b true false)` → if-bool fires; `(let ((x e)) x)` → redundant-let fires.
+            let s = subj("(do (if b true false) (let ((x (h))) x) (g 1))");
+            let diags = lint::run(&set, &s, None);
+            assert_eq!(
+                diags.len(),
+                2,
+                "both if-bool and redundant-let fire: {diags:?}"
+            );
+            assert!(diags.iter().all(|d| d.severity == Severity::Warning));
+            // A clean program (no idiomatic issue) fires nothing.
+            let clean = subj("(do (if b (f 1) (g 2)) (let ((x (h))) (k x)))");
+            assert!(
+                lint::run(&set, &clean, None).is_empty(),
+                "no false positives"
+            );
+        }
+
+        #[test]
+        fn builtin_if_bool_negated_arm_fires_separately() {
+            let set = LintSet::builtin();
+            // `(if b false true)` → the negated if-bool rule (fix `(not b)`), distinct from the `true false` rule.
+            let s = subj("(do (if b false true))");
+            let diags = lint::run(&set, &s, None);
+            assert_eq!(diags.len(), 1, "the false/true arm fires: {diags:?}");
+            assert!(diags[0].message.contains("not(condition)"));
+        }
+
+        #[test]
+        fn builtin_verified_fixes_rewrite_to_the_equivalent_form() {
+            // The §6 Verified witness: applying each catalog fix's pattern→template yields the intended
+            // equivalent form. `(if c true false)` → `c`; `(if c false true)` → `(not c)`;
+            // `(let ((x e)) x)` → `e`. (Applying is a separate `--fix`/code-action; this pins the fix
+            // TEMPLATE is correct — the equivalence-preserving rewrite the applier would perform.)
+            let set = LintSet::builtin();
+            let cases = [
+                (0usize, "(if a true false)", "a"),
+                (1, "(if a false true)", "(not a)"),
+                (2, "(let ((y (m))) y)", "(m)"),
+            ];
+            for (i, src, want) in cases {
+                let (tmpl, _) = set.rules[i].fix.as_ref().expect("fix present");
+                let subject = subj(src);
+                let out = crate::query::rewrite(&set.rules[i].pattern, tmpl, &subject);
+                assert_eq!(
+                    out.tree.to_sexpr(),
+                    want,
+                    "rule {i} fix on {src} should rewrite to {want}"
+                );
+                assert_eq!(out.count, 1, "exactly one rewrite site");
+            }
         }
     }
 

--- a/implementation/seed/crates/cdz/tests/lint_cli.rs
+++ b/implementation/seed/crates/cdz/tests/lint_cli.rs
@@ -5,8 +5,9 @@
 //! message` (or, under `--json`, a structured diagnostic array). The pattern-matching engine lives in
 //! cadenza-syntax; what is pinned HERE is the CLI contract only `cdz` owns: a rule match renders the
 //! diagnostic + the severity→exit-code discipline (an `error` match fails with exit 1; a `warning`-only
-//! match still exits 0; a clean file exits 0), the `--json` diagnostic shape, and the guard that a run
-//! with NO rule is a usage error (exit 1) rather than a silent no-op. Drives the built binary.
+//! match still exits 0; a clean file exits 0), the `--json` diagnostic shape, and that a run with NO
+//! explicit rule uses the built-in `idiomatic` catalog (the Tier-A pack) rather than erroring or being a
+//! silent no-op. Drives the built binary.
 
 use std::process::Command;
 
@@ -123,16 +124,31 @@ fn lint_json_emits_a_structured_diagnostic_array() {
 }
 
 #[test]
-fn lint_with_no_rule_is_a_usage_error() {
-    // A `cdz lint` with NO `--rule`/`--rules` has nothing to check — a clear error (exit non-zero)
-    // naming the tool + how to supply a rule, NOT a silent exit-0 no-op.
+fn lint_with_no_rule_runs_the_builtin_idiomatic_catalog() {
+    // `cdz lint FILE` with NO `--rule`/`--rules` runs the BUILT-IN `idiomatic` catalog (the Tier-A
+    // pack) — the tool is useful out of the box (DESIGN-cadenza-lint §2), not a usage error. On a
+    // program with no idiomatic issue (PROG uses `deprecated-op`, which no built-in lint targets) it
+    // exits 0 with no diagnostics; a program WITH an idiomatic shape flags it (checked below).
     let file = temp_src("norule", PROG);
-    let (code, _out, err) = run(&["lint", &file]);
-    assert_ne!(code, 0, "no rules is an error, not a silent pass");
-    assert!(
-        err.contains("cdz:") && err.contains("no lint rules"),
-        "the error names the tool + explains --rule/--rules: {err}"
+    let (code, out, _err) = run(&["lint", &file]);
+    assert_eq!(
+        code, 0,
+        "no explicit rules runs the built-in catalog, not an error: {out}"
     );
+    // A program with a built-in-lint shape (`if b true false` → idiomatic/if-bool) is flagged.
+    let idiomatic = temp_src(
+        "idiom",
+        "(module m (def (f (: b Bool)) (if b true false)) (export f))",
+    );
+    let (icode, iout, _ierr) = run(&["lint", &idiomatic]);
+    assert_eq!(icode, 0, "a warning-level lint does not fail the run");
+    assert!(
+        iout.contains("idiomatic") || iout.contains("if"),
+        "the built-in if-bool lint fires by default: {iout}"
+    );
+    // `--deny` on the built-in lint promotes it to an error (exit non-zero).
+    let (dcode, _dout, _derr) = run(&["lint", &idiomatic, "--deny", "idiomatic/if-bool"]);
+    assert_ne!(dcode, 0, "--deny on a built-in lint fails the run");
 }
 
 #[test]

--- a/implementation/seed/crates/cdz/tests/query_cli.rs
+++ b/implementation/seed/crates/cdz/tests/query_cli.rs
@@ -712,10 +712,22 @@ fn lint_from_a_rules_file_over_a_directory() {
 }
 
 #[test]
-fn lint_with_no_rules_is_an_error() {
-    let (ok, _, stderr) = run(&["lint", "--from", "sexpr"], "(f a)");
-    assert!(!ok);
-    assert!(stderr.contains("no lint rules"), "reason: {stderr}");
+fn lint_with_no_rules_runs_the_builtin_catalog() {
+    // `cdz lint` with no explicit `--rule`/`--rules` runs the built-in `idiomatic` catalog (Tier-A
+    // pack) — useful out of the box, not a usage error (DESIGN-cadenza-lint §2). `(f a)` has no
+    // idiomatic issue, so it exits 0 cleanly.
+    let (ok, _out, _stderr) = run(&["lint", "--from", "sexpr"], "(f a)");
+    assert!(
+        ok,
+        "no explicit rules runs the built-in catalog and a clean program passes"
+    );
+    // A program matching a built-in lint (`if b true false` → idiomatic/if-bool) is flagged.
+    let (ok2, out2, _e2) = run(&["lint", "--from", "sexpr"], "(if b true false)");
+    assert!(ok2, "a warning-level built-in lint does not fail the run");
+    assert!(
+        out2.contains("idiomatic") || out2.contains("if"),
+        "the built-in if-bool lint fires by default: {out2}"
+    );
 }
 
 // ---- clone detection (the `clones` subcommand) ----


### PR DESCRIPTION
Candidate for v-syntax's Tier-A pack (ref 857f8cf7f), re-cut as single-commit delta: the trunk..ref range false-conflicted because it was stacked on c9f87e1a9 (pipe-in-arm, landed as #2882) + f37c1eda1 (schema, landing separately) — both already on/reaching trunk by patch-id. The tip 857f8cf7f cherry-picks CLEAN alone onto origin/main (4 files, +155/-14). Auto-merge armed; reaps on green.