### PR TITLE
syntax: cadenza-lint cdz lint --fix — apply each firing lint's Verified fix as a validated codemod

### DIFF
--- a/implementation/seed/crates/cadenza-syntax/src/cli.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/cli.rs
@@ -183,6 +183,22 @@ pub struct LintArgs {
     /// Promote a named lint (or group) to an error (fails the run). Repeatable. See `--allow`.
     #[arg(long = "deny", value_name = "NAME")]
     deny: Vec<String>,
+
+    /// Apply each lint's `Verified` fix in place (an equivalence-preserving codemod), rewriting each
+    /// input FILE. Only `Verified` fixes apply (add `--heuristic` to opt in Heuristic ones); a lint
+    /// set to `--allow` (or an in-source `@allow`) applies no fix. Requires FILE inputs (never stdin);
+    /// the edit is formatting-preserving. Mutually exclusive with `--json`.
+    #[arg(long)]
+    fix: bool,
+
+    /// With `--fix`, also apply `Heuristic` fixes (offered-not-auto by default). Ignored without `--fix`.
+    #[arg(long)]
+    heuristic: bool,
+
+    /// Target line width for a reprinted `--fix` result (used only when the formatting-preserving
+    /// splice must fall back to a whole-tree reprint).
+    #[arg(short, long, default_value_t = Options::default().width)]
+    width: usize,
 }
 
 #[derive(Args)]
@@ -1227,6 +1243,11 @@ fn run_clones(args: &ClonesArgs) -> Result<(), String> {
 /// Lint the targets against a rule set, printing diagnostics (or JSON). Returns whether any
 /// `error`-severity diagnostic fired (the caller maps `true` → non-zero exit, the CI gate).
 fn run_lint(args: &LintArgs) -> Result<bool, String> {
+    if args.fix && args.json {
+        return Err(
+            "--fix is mutually exclusive with --json (a fix rewrites files, not JSON)".into(),
+        );
+    }
     // Assemble the rule set from --rules FILE and/or inline --rule forms.
     let mut set = LintSet::default();
     if let Some(path) = &args.rules {
@@ -1262,6 +1283,9 @@ fn run_lint(args: &LintArgs) -> Result<bool, String> {
     }
 
     let targets = collect_targets(&args.files, args.from)?;
+    if args.fix && targets.iter().any(|t| t.path.is_none()) {
+        return Err("--fix needs FILE input(s), not stdin".into());
+    }
     let multi = targets.len() > 1;
     let mut any_error = false;
     let mut json_objs: Vec<String> = Vec::new();
@@ -1277,6 +1301,32 @@ fn run_lint(args: &LintArgs) -> Result<bool, String> {
         // each file honors its OWN in-source attributes.
         let mut levels = crate::query::lint::LintLevels::from_attributes(&target.tree);
         levels.overlay(&cli_levels);
+
+        if args.fix {
+            // Apply each firing lint's Verified fix (Heuristic too under --heuristic) as a validated,
+            // formatting-preserving codemod, then write the file back only when it changed. Reporting
+            // is a separate action from fixing (DESIGN-cadenza-lint §5): --fix rewrites, it does not
+            // also print the warnings it resolved.
+            let outcome = query::driver::lint_fix_with_levels(
+                &set,
+                &target,
+                &src,
+                spec.format,
+                &levels,
+                args.heuristic,
+                args.width,
+            )
+            .map_err(|e| with_path(&spec.path, &e))?;
+            let path = spec.path.as_deref().expect("--fix requires a path");
+            if outcome.count == 0 {
+                eprintln!("cdz: {path}: no fixable lints");
+            } else {
+                let content = ensure_trailing_newline(&outcome.output);
+                std::fs::write(path, content).map_err(|e| format!("writing {path}: {e}"))?;
+                eprintln!("cdz: {path}: fixed {} lint(s)", outcome.count);
+            }
+            continue;
+        }
 
         if args.json {
             let (j, had_error) = query::driver::lint_json_with_levels(

--- a/implementation/seed/crates/cadenza-syntax/src/query.rs
+++ b/implementation/seed/crates/cadenza-syntax/src/query.rs
@@ -2018,6 +2018,72 @@ pub mod driver {
         (arr.finish(), lint::has_error(&diags))
     }
 
+    /// Build the `Verified`-fix rewrite set for `lints` under `levels`: each NAMED lint that (a) is
+    /// not suppressed (`Allow`) and (b) carries a fix of an eligible applicability contributes a
+    /// `pattern → fix-template` rewrite rule, in catalog order (so a fix pass is deterministic).
+    /// `include_heuristic` opts `Heuristic` fixes in; by default only `Verified` fixes apply
+    /// (DESIGN-cadenza-lint §2 — a Heuristic fix is offered, not auto-applied).
+    fn fix_ruleset(
+        lints: &lint::LintSet,
+        levels: &lint::LintLevels,
+        include_heuristic: bool,
+    ) -> RuleSet {
+        let mut rules = Vec::new();
+        for rule in &lints.rules {
+            // A lint suppressed to `Allow` fires no diagnostic, so it applies no fix either.
+            if rule.name.as_deref().and_then(|n| levels.effective(n))
+                == Some(lint::LintLevel::Allow)
+            {
+                continue;
+            }
+            if let Some((template, app)) = &rule.fix {
+                let eligible = matches!(app, lint::Applicability::Verified) || include_heuristic;
+                if eligible {
+                    rules.push(Rule::new(rule.pattern.clone(), template.clone()));
+                }
+            }
+        }
+        RuleSet::new(rules)
+    }
+
+    /// Apply the `Verified` (and, when `include_heuristic`, `Heuristic`) fixes of `lints` to `target`
+    /// as a validated, formatting-preserving codemod: reuse [`apply_rewrite_preserving`] (splice only
+    /// changed subtrees at their spans, leaving layout/comments verbatim), falling back to a whole-tree
+    /// reprint when a span-splice can't be validated. `levels` gates which named lints fire (a lint set
+    /// to `Allow` — by `--allow` or an `@allow` attribute — applies no fix). Fixes run to a fixed point,
+    /// so a fix that exposes a nested idiom collapses in the same pass. Returns the fixed program text
+    /// plus the number of sites rewritten; when nothing is fixable the source is returned with count 0.
+    ///
+    /// The `Verified` bar means every applied fix is semantically equivalent (licensed by the
+    /// apply-and-recheck witness gate, DESIGN-cadenza-lint §6); the validated transaction here rejects
+    /// any fix whose result does not re-parse to the intended tree, so a broken template never writes.
+    pub fn lint_fix_with_levels(
+        lints: &lint::LintSet,
+        target: &Target,
+        src: &str,
+        surface: Format,
+        levels: &lint::LintLevels,
+        include_heuristic: bool,
+        width: usize,
+    ) -> Result<RewriteOutcome, String> {
+        let rules = fix_ruleset(lints, levels, include_heuristic);
+        if rules.rules.is_empty() {
+            return Ok(RewriteOutcome {
+                output: src.to_string(),
+                count: 0,
+            });
+        }
+        // Prefer the formatting-preserving splice (the DEFAULT for a codemod over hand-formatted
+        // source): it needs spans and errors without them, so a spanless target (or a splice that
+        // can't be validated) falls straight through to the whole-tree reprint below.
+        if let Ok(o) =
+            apply_rewrite_preserving(&rules, Strategy::BottomUp, target, src, surface, true)
+        {
+            return Ok(o);
+        }
+        apply_rewrite(&rules, Strategy::BottomUp, target, surface, width, true)
+    }
+
     /// A per-source-label cache of [`LineIndex`], so resolving MANY clone sites in one source builds that
     /// source's index ONCE (O(len)) and binary-searches per site — turning the report's O(sites × len)
     /// newline re-scan into O(len + sites·log). Keyed by the file label a `CloneSite` carries.
@@ -5564,6 +5630,100 @@ mod tests {
                 !had_error && report.is_empty(),
                 "allow suppresses: {report:?}"
             );
+        }
+
+        #[test]
+        fn lint_fix_applies_verified_fixes_and_round_trips() {
+            // The apply-and-recheck witness DESIGN-cadenza-lint §6 licenses `Verified`: fixing the
+            // built-in `idiomatic/if-bool` rewrites `(if b true false)` → `b`, the result re-parses,
+            // and re-linting the fixed program is clean (the idiom is gone).
+            let src = "(module m (def (f (: b Bool)) (if b true false)) (export f))";
+            let (target, _) = driver::load(src.as_bytes(), Format::Sexpr).unwrap();
+            let set = crate::query::lint::LintSet::builtin();
+            let levels = crate::query::lint::LintLevels::default();
+            let out = driver::lint_fix_with_levels(
+                &set,
+                &target,
+                src,
+                Format::Sexpr,
+                &levels,
+                false,
+                100,
+            )
+            .unwrap();
+            assert_eq!(
+                out.count, 1,
+                "the one if-bool site was fixed: {}",
+                out.output
+            );
+            assert!(
+                out.output.contains("(def (f (: b Bool)) b)"),
+                "if-bool collapsed to the condition: {}",
+                out.output
+            );
+            // Re-lint the fixed program — the idiom is gone (apply-and-recheck).
+            let (fixed, _) = driver::load(out.output.as_bytes(), Format::Sexpr).unwrap();
+            let diags = crate::query::lint::run(&set, &fixed.tree, fixed.spans.as_ref());
+            assert!(diags.is_empty(), "fixed program is idiom-clean: {diags:?}");
+        }
+
+        #[test]
+        fn lint_fix_respects_allow_and_applies_no_fix() {
+            // A lint suppressed to `Allow` (via a level, mirroring `--allow` / an `@allow` attribute)
+            // fires no diagnostic AND applies no fix — the source is returned unchanged, count 0.
+            use crate::query::lint::{LintLevel, LintLevels};
+            let src = "(module m (def (f (: b Bool)) (if b true false)) (export f))";
+            let (target, _) = driver::load(src.as_bytes(), Format::Sexpr).unwrap();
+            let set = crate::query::lint::LintSet::builtin();
+            let mut levels = LintLevels::new();
+            levels.set("idiomatic/if-bool", LintLevel::Allow);
+            let out = driver::lint_fix_with_levels(
+                &set,
+                &target,
+                src,
+                Format::Sexpr,
+                &levels,
+                false,
+                100,
+            )
+            .unwrap();
+            assert_eq!(out.count, 0, "an allowed lint applies no fix");
+            assert_eq!(out.output, src, "source returned verbatim: {}", out.output);
+        }
+
+        #[test]
+        fn lint_fix_leaves_verified_only_by_default_and_takes_heuristic_on_opt_in() {
+            // A `Heuristic` fix is NOT applied by default (offered, not auto-applied); `include_heuristic`
+            // opts it in. Uses a user rule so the applicability is under the test's control.
+            let src = "(do (risky a))";
+            let (target, _) = driver::load(src.as_bytes(), Format::Sexpr).unwrap();
+            let set = crate::query::lint::LintSet::compile(
+                "(lint style/risky (risky ,x) \"prefer safe\" => (safe ,x) heuristic)",
+            )
+            .unwrap();
+            let levels = crate::query::lint::LintLevels::default();
+            // Default: heuristic excluded → no change.
+            let off = driver::lint_fix_with_levels(
+                &set,
+                &target,
+                src,
+                Format::Sexpr,
+                &levels,
+                false,
+                100,
+            )
+            .unwrap();
+            assert_eq!(
+                off.count, 0,
+                "heuristic fix withheld by default: {}",
+                off.output
+            );
+            // Opt-in: heuristic applied.
+            let on =
+                driver::lint_fix_with_levels(&set, &target, src, Format::Sexpr, &levels, true, 100)
+                    .unwrap();
+            assert_eq!(on.count, 1, "heuristic fix applied under opt-in");
+            assert!(on.output.contains("safe"), "the fix ran: {}", on.output);
         }
     }
 

--- a/implementation/seed/crates/cdz/tests/lint_cli.rs
+++ b/implementation/seed/crates/cdz/tests/lint_cli.rs
@@ -152,6 +152,58 @@ fn lint_with_no_rule_runs_the_builtin_idiomatic_catalog() {
 }
 
 #[test]
+fn lint_fix_rewrites_the_file_in_place_and_re_lints_clean() {
+    // `cdz lint --fix FILE` applies each firing lint's Verified fix as an equivalence-preserving
+    // codemod, writing the file back. A built-in `idiomatic/if-bool` site (`if b true false`) is
+    // rewritten to the condition; the fixed file re-lints clean (apply-and-recheck).
+    let file = temp_src(
+        "fix",
+        "(module m (def (f (: b Bool)) (if b true false)) (export f))",
+    );
+    let (code, _out, err) = run(&["lint", &file, "--fix"]);
+    assert_eq!(code, 0, "a successful --fix exits 0: {err}");
+    assert!(err.contains("fixed 1 lint"), "reports the fix count: {err}");
+    let fixed = std::fs::read_to_string(&file).unwrap();
+    assert!(
+        fixed.contains("(def (f (: b Bool)) b)"),
+        "the if-bool idiom collapsed to the condition: {fixed}"
+    );
+    // Re-lint: the idiom is gone.
+    let (rcode, rout, _rerr) = run(&["lint", &file]);
+    assert_eq!(rcode, 0, "fixed file re-lints clean");
+    assert!(!rout.contains("idiomatic"), "no idiom remains: {rout}");
+}
+
+#[test]
+fn lint_fix_honors_allow_and_makes_no_change() {
+    // `--allow` on the target lint suppresses BOTH the diagnostic and the fix — the file is untouched.
+    let before = "(module m (def (f (: b Bool)) (if b true false)) (export f))";
+    let file = temp_src("fix-allow", before);
+    let (code, _out, err) = run(&["lint", &file, "--fix", "--allow", "idiomatic/if-bool"]);
+    assert_eq!(code, 0, "no fixable lints still exits 0: {err}");
+    assert!(
+        err.contains("no fixable lints"),
+        "reports nothing to fix: {err}"
+    );
+    let after = std::fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        after, before,
+        "an allowed lint leaves the file unchanged: {after}"
+    );
+}
+
+#[test]
+fn lint_fix_on_stdin_is_rejected() {
+    // A fix rewrites files, so stdin (no path to write back) is a usage error.
+    let (code, _out, err) = run(&["lint", "-", "--from", "sexpr", "--fix"]);
+    assert_ne!(code, 0, "--fix on stdin errors");
+    assert!(
+        err.contains("FILE"),
+        "the error explains --fix needs a file: {err}"
+    );
+}
+
+#[test]
 fn lint_on_a_missing_file_errors() {
     let (code, _out, err) = run(&["lint", "/no/such/file.sexp", "--rule", RULE_ERR]);
     assert_ne!(code, 0, "a missing file is an error");


### PR DESCRIPTION
Candidate for v-syntax's lint --fix (ref d86239285), re-cut single-commit: the trunk..ref range false-conflicted because it stacked on 97b03fe9c (Tier-A pack, landed as #2888). The tip cherry-picks clean alone onto origin/main (3 files, +262). Auto-merge armed; reaps on green.