### PR TITLE
rcdzc: memoize mutual_scc_of + HashSet membership (v-compiler-perf advisory on #2877)

### DIFF
--- a/implementation/seed/crates/rcdzc/src/db.rs
+++ b/implementation/seed/crates/rcdzc/src/db.rs
@@ -1815,6 +1815,16 @@ pub struct Db {
     /// body so the per-member mode decision inside `specialize_recursive` can consult it.
     pub(crate) group_multivalue_bodies: std::collections::HashSet<(StructId, String)>,
 
+    /// Memo of `effects::mutual_scc_of` — the mutually-recursive SCC (def indices) containing a callee,
+    /// keyed `(callee_def, handler-context-key)`. SCC membership is program-STATIC (the call graph does not
+    /// change during a fold), and the discharged-op filter is fixed by the context key — so the result is
+    /// stable and computed ONCE per (callee, ctx). Removes the double-compute on the group-entry path (the
+    /// predicate + the member-registration call the same `mutual_scc_of`) and any re-derives across sibling
+    /// SCC members. `mutual_scc_of` is a forward BFS + a per-def reaches-BFS over the call graph, the first
+    /// call-graph-scaled cost in the effect fold (v-compiler-perf advisory on #2877); memoizing keeps it off
+    /// the hot path. Populated + read only inside `mutual_scc_of`.
+    pub(crate) mutual_scc: crate::fxhash::FxHashMap<(usize, String), Vec<usize>>,
+
     /// Memo of `effects::subtree_performs` — whether the subtree at a node reaches a discharged perform (a
     /// `resume`, or a call into a discharged effect) under a given handler context. Keyed by `(node,
     /// handler-context-key)` (the same resolved-identity string `effect_specializations` uses). The
@@ -2750,6 +2760,7 @@ impl Db {
             effect_spec_captures: std::collections::HashMap::new(),
             force_multivalue: std::collections::HashSet::new(),
             group_multivalue_bodies: std::collections::HashSet::new(),
+            mutual_scc: crate::fxhash::FxHashMap::default(),
             subtree_performs_cache: crate::fxhash::FxHashMap::default(),
             reduced_callable_walked: crate::fxhash::FxHashSet::default(),
             type_specializations: crate::fxhash::FxHashMap::default(),

--- a/implementation/seed/crates/rcdzc/src/effects.rs
+++ b/implementation/seed/crates/rcdzc/src/effects.rs
@@ -6534,18 +6534,27 @@ fn direct_callee_defs(db: &mut Db, body: StructId, out: &mut Vec<usize>) {
 /// directions use a bounded reachability walk over `direct_callee_defs`. Only defs that reach a discharged
 /// op are kept (a pure helper in the cycle needs no state threading — it is inlined, not specialized).
 fn mutual_scc_of(db: &mut Db, callee_def: usize, ctx: &HandlerCtx) -> Vec<usize> {
+    // MEMO (v-compiler-perf advisory on #2877): SCC membership is program-STATIC + the discharged-op filter
+    // is fixed by `ctx.key`, so the result is stable per `(callee_def, ctx.key)`. The group-entry path calls
+    // this TWICE (the `group_entry` predicate + the member-registration loop), and sibling SCC members
+    // re-derive the same set — the memo collapses all of that to ONE forward-BFS + per-def reaches-BFS.
+    let memo_key = (callee_def, ctx.key.clone());
+    if let Some(cached) = db.mutual_scc.get(&memo_key) {
+        return cached.clone();
+    }
     // Forward reachability from `start` over direct-callee edges (def-index graph), bounded by the def table.
+    // `seen` is a HashSet — membership is O(1), so the walk is O(V+E) not O(V*E) (v-compiler-perf: was
+    // `Vec::contains`). Small SCCs are unaffected either way; this keeps a wide call graph off the hot path.
     fn reaches(db: &mut Db, start: usize, target: usize) -> bool {
-        let mut seen: Vec<usize> = Vec::new();
+        let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
         let mut work: Vec<usize> = vec![start];
         while let Some(d) = work.pop() {
             if d == target {
                 return true;
             }
-            if seen.contains(&d) {
+            if !seen.insert(d) {
                 continue;
             }
-            seen.push(d);
             if let Some(body) = db.defs[d].body {
                 let mut callees = Vec::new();
                 direct_callee_defs(db, body, &mut callees);
@@ -6561,11 +6570,14 @@ fn mutual_scc_of(db: &mut Db, callee_def: usize, ctx: &HandlerCtx) -> Vec<usize>
         }
         false
     }
-    // The forward-reachable set from `callee_def` (candidate SCC members before the back-edge filter).
+    // The forward-reachable set from `callee_def` (candidate SCC members before the back-edge filter). The
+    // ORDER is preserved (a `Vec` for a deterministic member sequence) + a `HashSet` mirrors it for O(1)
+    // membership — reproducible output, no O(n) `contains`.
     let mut forward: Vec<usize> = Vec::new();
+    let mut forward_set: std::collections::HashSet<usize> = std::collections::HashSet::new();
     let mut work: Vec<usize> = vec![callee_def];
     while let Some(d) = work.pop() {
-        if forward.contains(&d) {
+        if !forward_set.insert(d) {
             continue;
         }
         forward.push(d);
@@ -6573,7 +6585,7 @@ fn mutual_scc_of(db: &mut Db, callee_def: usize, ctx: &HandlerCtx) -> Vec<usize>
             let mut callees = Vec::new();
             direct_callee_defs(db, body, &mut callees);
             for c in callees {
-                if !forward.contains(&c) {
+                if !forward_set.contains(&c) {
                     work.push(c);
                 }
             }
@@ -6596,6 +6608,7 @@ fn mutual_scc_of(db: &mut Db, callee_def: usize, ctx: &HandlerCtx) -> Vec<usize>
     if !scc.contains(&callee_def) {
         scc.push(callee_def);
     }
+    db.mutual_scc.insert(memo_key, scc.clone());
     scc
 }
 


### PR DESCRIPTION
Candidate PR for v-effects's merge-request (ref ae0e08468e53ad2ae61e97fa28fdd0c337fc7003, lane code). Auto-merge armed; pr-sync's schedule-pass reaps on green.