### PR TITLE
compiler-ml: land the demand type_of spine as a live module (lazy-Db-via-effects)

### DIFF
--- a/implementation/compiler-ml/src/db-query-perfield.cdz
+++ b/implementation/compiler-ml/src/db-query-perfield.cdz
@@ -1,0 +1,105 @@
+/// db-query-perfield.cdz — THE demand type_of spine on the per-field single-family DbState contract, the
+/// operator-mandated lazy-memoized-database-via-effects architecture (mirror rcdzc's demand+memoize type_of
+/// SEMANTICS, but carry the Db in an effect handler rather than threading &mut Db — the intended divergence
+/// from the rust version).
+///
+/// DbState is ONE effect FAMILY with FINER-GRAINED PER-FIELD ops — get-ty/set-ty (types column),
+/// get-resolved (resolved column), node-of (read-only ast) — NOT one whole-Db getter/setter. The single
+/// handler installed for the family carries ALL columns as its shared state and serves every op, reading or
+/// writing ONLY that op's slice (so a middleware/log layer can intercept one field at a time — the operator's
+/// rationale). The performer threads a scalar NodeId per op; the whole Db is never threaded through an op.
+///
+/// type-of / compute-type / cache-type are a mutually-recursive GROUP, each performing per-field ops — the
+/// idiomatic salsa/demand shape (a memoized query pulls sub-queries recursively over one state). This LOWERS
+/// as of the effect group-aware recursive-perform fold (floor #2866 + group-fold #2877 + slot-fix #2889): the
+/// mutual 3-performer cycle specializes and runs end-to-end.
+///
+/// STATUS: this is the demand-type_of spine, live as a tested module. It currently uses SIMPLIFIED
+/// combine-bin/combine-if stand-ins (the effect axis is what this module proves); the FAITHFUL upgrade — call
+/// the real infer-db bin-type/if-type/let-type/var-type via get-tcol/get-tree projection — is a follow-on
+/// (blocked on an emit bug for the wide-Tree effect-return, filed to v-effects as non-blocking). The
+/// live-pipeline flip (route run-of-db / ty-of-db through this) is a later differential-guarded slice.
+import { Node, Tree, node-at } from "parse-db"
+import { Db, db-of, db-tree, require-ty, fill-ty, require-resolved, fill-resolved } from "db"
+import { Ty } from "ty"
+import { Resolved } from "resolve-db"
+import { bin-type, if-type, let-type, var-type, t-int-deferred, mk-int } from "infer-db"
+
+/// The DbState effect FAMILY — ONE group, per-field ops over the shared column state (operator-confirmed).
+/// Reads return Option (Absent/Filled = the Slot semantics); writes take the scalar payload and resume Unit.
+/// node-at/child-of are read-only ast ops. The handler (below) carries the whole Db and serves every op.
+  effect DbState =
+  | get-ty : Int64 -> Option(Ty)
+  | set-ty : Tuple(Int64, Ty) -> Unit
+  | get-resolved : Int64 -> Option(Resolved)
+  | node-of : Int64 -> Option(Node)
+
+/// DEMAND the type at `id` (rcdzc type_of@43): per-field memo check via get-ty; HIT returns, MISS computes +
+/// caches. Performs get-ty (scalar NodeId in, Option(Ty) out). Member of the mutual performer group.
+def type-of(id: Int64) = match DbState.get-ty(id) with
+  | Option.Some(t) => t
+  | Option.None(_) => cache-type(id, compute-type(id))
+
+/// MISS cache path — performs set-ty (per-field write, scalar payload). Mutual-group member.
+def cache-type(id: Int64, t: Ty) = match DbState.set-ty((id, t)) with
+  | _ => t
+
+/// COMPUTE a node's type, DEMANDING children via type-of (recursion) + combining via infer-db's rules.
+/// Reads the node via node-of + resolution via get-resolved (per-field read ops). Mutual-group member.
+/// NB: the infer-db combiners (bin-type/if-type/let-type/var-type) still take an explicit tcol Map today;
+/// under the effect spine that column lives in the handler state, so the combiners read it via a rebuilt
+/// tcol projection. For the acceptance test we thread a small tcol snapshot via type-of's demanded facts —
+/// the combiners are PURE over the child types they are handed, so the effect axis is isolated to get/set.
+def compute-type(id: Int64) = match DbState.node-of(id) with
+  | Option.Some(Node.NLit(_)) => t-int-deferred()
+  | Option.Some(Node.NBoolLit(_)) => Ty.TyBool
+  | Option.Some(Node.NAnnLit(_, sflag, w)) => mk-int((if sflag == 1 then true else false), w)
+  | Option.Some(Node.NVar(_)) =>
+      (match DbState.get-resolved(id) with
+        | Option.Some(Resolved.RBound(binder)) => (let _bt = type-of(binder) in _bt)
+        | _ => Ty.TyErr)
+  | Option.Some(Node.NBin(op, l, r)) =>
+      (let lt = type-of(l) in (let rt = type-of(r) in combine-bin(op, lt, rt)))
+  | Option.Some(Node.NLet(_, valId, bodyId)) =>
+      (let _v = type-of(valId) in type-of(bodyId))
+  | Option.Some(Node.NIf(c, t, e)) =>
+      (let _c = type-of(c) in (let tt = type-of(t) in (let et = type-of(e) in combine-if(_c, tt, et))))
+  | Option.Some(_) => Ty.TyErr
+  | Option.None(_) => Ty.TyErr
+
+/// PURE arith combine over the two operand types — the effect-free half (isolates the effect axis to get/set).
+/// A faithful spine would call bin-type over the shared tcol; here the operand types are handed in directly.
+def combine-bin(op: Int64, lt: Ty, rt: Ty) =
+  (if op == 60 then Ty.TyBool
+   else (if op == 61 then Ty.TyBool
+     else (if op == 62 then Ty.TyBool
+       else (match lt with | Ty.TyErr => Ty.TyErr | _ => (match rt with | Ty.TyErr => Ty.TyErr | _ => lt)))))
+
+/// PURE if-join over cond/then/else types.
+def combine-if(ct: Ty, tt: Ty, et: Ty) =
+  (match ct with
+    | Ty.TyBool => (match tt with | Ty.TyErr => Ty.TyErr | _ => (match et with | Ty.TyErr => Ty.TyErr | _ => tt))
+    | _ => Ty.TyErr)
+
+/// Driver: install ONE handler for the DbState family carrying the whole Db as shared state. Each per-field op
+/// reads/writes ONLY its column slice via the existing db.cdz accessors, then resumes threading the (updated)
+/// Db. The performer never destructures the Db — only these handler arms do — the finer-grained-ops-over-one-
+/// shared-state shape the operator confirmed + v-effects' fold targets.
+def run-type-of(db0: Db, root: Int64) =
+  handle DbState(db0) with
+    | get-ty(id, db) => resume(require-ty(db, id), db)
+    | set-ty(pair, db) => (match pair with | (id, t) => resume(unit, fill-ty(db, id, t)))
+    | get-resolved(id, db) => resume(require-resolved(db, id), db)
+    | node-of(id, db) => resume(node-at(db-tree(db), id), db)
+  in
+  type-of(root)
+
+export { run-type-of }
+
+// ---- acceptance test exercising the mutual-performer group over the per-field family (triggers the fold) ----
+import { Tok, parse-tokens } from "parse-db"
+import { is-int-ty } from "ty"
+import { resolve-into-db } from "db-resolve"
+@test
+def pfq-arith() = match parse-tokens([Tok.TNum(1), Tok.TOp(43), Tok.TNum(2)]) with
+  | (root, tree) => (let db = resolve-into-db(db-of(tree), root) in (if is-int-ty(run-type-of(db, root)) then unit else trap("int")))


### PR DESCRIPTION
Candidate PR for v-compiler-ml's merge-request (ref f3613c88758a4fa685541e30bb422f9bd08b1508, lane compiler-ml). Auto-merge armed; pr-sync's schedule-pass reaps on green.