### PR TITLE
feat(cdz-platform): async content-addressed blob store — trait + in-memory impl (§8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arr_macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c49336e062fa2ae8aca17a2f99c34d9c1a5d30827e8aff1cb4c294f253afe992"
+dependencies = [
+ "arr_macro_impl",
+ "proc-macro-hack",
+ "proc-macro-nested",
+]
+
+[[package]]
+name = "arr_macro_impl"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6368f9ae5c6ec403ca910327ae0c9437b0a85255b6950c90d497e6177f6e5e"
+dependencies = [
+ "proc-macro-hack",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,10 +167,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bach"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eca5d361ec40efb17b1ceead40e656a9598241eb12923d828ff9caf0d015eeb"
+dependencies = [
+ "arr_macro",
+ "atomic-waker",
+ "bolero-generator",
+ "bytes",
+ "event-listener-strategy",
+ "futures-core",
+ "intrusive-collections",
+ "pin-project-lite",
+ "rand",
+ "rand_core 0.9.5",
+ "rand_xoshiro 0.8.1",
+ "s2n-quic-core",
+ "siphasher",
+ "slotmap",
+ "tokio",
+]
 
 [[package]]
 name = "base64"
@@ -215,8 +266,8 @@ dependencies = [
  "bolero-generator-derive",
  "either",
  "getrandom",
- "rand_core",
- "rand_xoshiro",
+ "rand_core 0.9.5",
+ "rand_xoshiro 0.7.0",
 ]
 
 [[package]]
@@ -258,6 +309,12 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 dependencies = [
  "allocator-api2",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -312,8 +369,8 @@ dependencies = [
  "lsp-server",
  "lsp-types",
  "notify",
- "rand_core",
- "rand_xoshiro",
+ "rand_core 0.9.5",
+ "rand_xoshiro 0.7.0",
  "rcdzc",
  "serde",
  "serde_json",
@@ -352,8 +409,11 @@ dependencies = [
 name = "cdz-platform"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
+ "bach",
  "blake3",
  "bytes",
+ "tokio",
 ]
 
 [[package]]
@@ -874,6 +934,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1185,12 @@ checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "intrusive-collections"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4275b20e6057cd7733fd8df8a5a31701e4fe44497dad0f3fa0e1c4fb971506be"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1461,12 +1552,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1611,6 +1713,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,10 +1793,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xoshiro"
@@ -1690,7 +1819,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662effc7698e08ea324d3acccf8d9d7f7bf79b9785e270a174ea36e56900c91d"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1811,6 +1949,33 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "s2n-codec"
+version = "0.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22bacdd8e47b929c10802a93070890d26b8c0e510857113b8f098fca002aecf4"
+dependencies = [
+ "byteorder",
+ "zerocopy",
+]
+
+[[package]]
+name = "s2n-quic-core"
+version = "0.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0d2cd0e789568ac5c374ea7fbf599e1a9d63362bd37baf2d45d386f5f3d25f"
+dependencies = [
+ "byteorder",
+ "cfg-if",
+ "hex-literal",
+ "num-rational",
+ "num-traits",
+ "pin-project-lite",
+ "s2n-codec",
+ "subtle",
+ "zerocopy",
+]
 
 [[package]]
 name = "same-file"
@@ -1997,6 +2162,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,6 +2225,23 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2171,6 +2362,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "toml_datetime"
@@ -3038,6 +3250,26 @@ dependencies = [
  "wasmparser 0.239.0",
  "wit-parser",
  "xshell",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/implementation/seed/crates/cdz-platform/Cargo.toml
+++ b/implementation/seed/crates/cdz-platform/Cargo.toml
@@ -22,4 +22,14 @@ publish = false
 [dependencies]
 blake3 = "1" # the ONE content-address digest (fleet-unified on blake3, operator 2026-08-08)
 bytes = "1"  # every byte buffer is bytes::Bytes, never Vec<u8> (spec §12) — O(1) clone as it threads through
+async-trait = "0.1" # dyn-safe async traits, so a store/kv backend is a swappable trait object (spec §8)
+# tokio is the platform's async runtime (spec §9 shared async runtime). A main dep per operator directive
+# 2026-08-20; the trait layers stay runtime-AGNOSTIC (await-only, no tokio primitives) so they also run
+# under the Bach simulator in tests. Minimal features for now; the scheduler layer widens them later.
+tokio = { version = "1", features = ["rt", "macros"] }
+
+[dev-dependencies]
+# Bach (Cameron's crate) — a discrete-event simulation runtime for DETERMINISTIC async testing. Drives the
+# runtime-agnostic trait futures in simulated time so store/kv behavior is deterministic + snapshotable.
+bach = "0.1"
 

--- a/implementation/seed/crates/cdz-platform/Cargo.toml
+++ b/implementation/seed/crates/cdz-platform/Cargo.toml
@@ -20,16 +20,16 @@ edition = "2024"
 publish = false
 
 [dependencies]
-blake3 = "1" # the ONE content-address digest (fleet-unified on blake3, operator 2026-08-08)
+blake3 = "1" # the one content-address digest (fleet-unified on blake3, operator 2026-08-08)
 bytes = "1"  # every byte buffer is bytes::Bytes, never Vec<u8> (spec §12) — O(1) clone as it threads through
 async-trait = "0.1" # dyn-safe async traits, so a store/kv backend is a swappable trait object (spec §8)
 # tokio is the platform's async runtime (spec §9 shared async runtime). A main dep per operator directive
-# 2026-08-20; the trait layers stay runtime-AGNOSTIC (await-only, no tokio primitives) so they also run
+# 2026-08-20; the trait layers stay runtime-agnostic (await-only, no tokio primitives) so they also run
 # under the Bach simulator in tests. Minimal features for now; the scheduler layer widens them later.
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [dev-dependencies]
-# Bach (Cameron's crate) — a discrete-event simulation runtime for DETERMINISTIC async testing. Drives the
+# Bach (Cameron's crate) — a discrete-event simulation runtime for deterministic async testing. Drives the
 # runtime-agnostic trait futures in simulated time so store/kv behavior is deterministic + snapshotable.
 bach = "0.1"
 

--- a/implementation/seed/crates/cdz-platform/src/blob_store.rs
+++ b/implementation/seed/crates/cdz-platform/src/blob_store.rs
@@ -1,0 +1,187 @@
+//! The content-addressed blob store (`design/cadenza-platform.md` §8).
+//!
+//! There is exactly ONE store: a mapping from a [`Hash`] to its bytes. Its whole interface is: put bytes
+//! (getting back their hash), get bytes by hash, and ask whether a hash is present. Everything the system
+//! keeps by hash lives here — log blobs, large state values, contract declarations, wasm components — a
+//! component is not special, it is bytes addressed by its hash like any other value.
+//!
+//! **The store is unpermissioned: the hash is the capability.** You cannot forge bytes for a hash, so
+//! possessing a hash both names and authorizes reading its bytes — there is nothing to gate on a read.
+//! Confidentiality lives one layer up, at name resolution (which hashes a reducer ever comes to hold).
+//!
+//! The operations are **async** so a disk/network-backed store (a local cache, S3) can fetch without
+//! blocking the runtime — but they stay deterministic: `get(hash)` is a pure function of the hash
+//! (content-addressed, the same bytes every time) and `put(bytes)` a pure function of the bytes, so
+//! awaiting a fetch changes only timing, never the result. The trait is [`async_trait`] so a backend is a
+//! dyn-safe swappable trait object, and the methods are runtime-AGNOSTIC (they only await), so they run
+//! under tokio in production and under the Bach simulator in deterministic tests alike.
+
+use crate::{Bytes, Hash};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// A content-addressed blob store: hash <-> bytes. The one store of §8; backends (in-memory, disk, S3)
+/// implement this and are swapped by reference. `Send + Sync` so it can be shared across the runtime's
+/// concurrent tasks behind an `Arc`.
+#[async_trait]
+pub trait BlobStore: Send + Sync {
+    /// Store `bytes` and return their content hash. Idempotent by construction: the hash is derived from
+    /// the bytes, so putting the same bytes twice yields the same hash and simply re-stores identical
+    /// content. (No `Result`: a well-formed backend's put is a pure function of its input; a fallible
+    /// backend absorbs transient I/O internally, e.g. by retry — this layer stays deterministic per §8/§9.)
+    async fn put(&self, bytes: Bytes) -> Hash;
+
+    /// Fetch the bytes stored under `hash`, or `None` if the store does not hold it. `None` is genuine
+    /// absence, not a transient failure.
+    async fn get(&self, hash: Hash) -> Option<Bytes>;
+
+    /// Whether `hash` is present in the store.
+    async fn has(&self, hash: Hash) -> bool;
+}
+
+/// An in-memory [`BlobStore`] — a plain hash-map behind a `Mutex`. For tests and single-process use; the
+/// smallest honest backend. Runtime-agnostic: the lock is a `std::sync::Mutex` held only across the map
+/// operation (never across an `.await`), so this drives identically under tokio and under Bach.
+#[derive(Default)]
+pub struct InMemoryBlobStore {
+    blobs: Mutex<HashMap<Hash, Bytes>>,
+}
+
+impl InMemoryBlobStore {
+    /// An empty in-memory store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of distinct blobs held (by content hash). Handy for tests/introspection.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.blobs.lock().expect("blob-store mutex poisoned").len()
+    }
+
+    /// Whether the store holds no blobs.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.blobs
+            .lock()
+            .expect("blob-store mutex poisoned")
+            .is_empty()
+    }
+}
+
+#[async_trait]
+impl BlobStore for InMemoryBlobStore {
+    async fn put(&self, bytes: Bytes) -> Hash {
+        let hash = Hash::of(&bytes);
+        // O(1) Bytes clone into the map; the guard is dropped before returning (no await held across it).
+        self.blobs
+            .lock()
+            .expect("blob-store mutex poisoned")
+            .insert(hash, bytes);
+        hash
+    }
+
+    async fn get(&self, hash: Hash) -> Option<Bytes> {
+        // `cloned()` on a Bytes is an O(1) refcount bump, not a copy.
+        self.blobs
+            .lock()
+            .expect("blob-store mutex poisoned")
+            .get(&hash)
+            .cloned()
+    }
+
+    async fn has(&self, hash: Hash) -> bool {
+        self.blobs
+            .lock()
+            .expect("blob-store mutex poisoned")
+            .contains_key(&hash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BlobStore, InMemoryBlobStore};
+    use crate::{Bytes, Hash};
+
+    #[tokio::test]
+    async fn put_returns_the_content_hash_and_get_round_trips() {
+        let store = InMemoryBlobStore::new();
+        let bytes = Bytes::from_static(b"the hash is the capability");
+        let h = store.put(bytes.clone()).await;
+        // put returns the content hash of exactly those bytes.
+        assert_eq!(h, Hash::of(&bytes));
+        // get by that hash returns the same bytes.
+        assert_eq!(store.get(h).await, Some(bytes));
+        assert!(store.has(h).await);
+    }
+
+    #[tokio::test]
+    async fn get_and_has_report_absence() {
+        let store = InMemoryBlobStore::new();
+        let absent = Hash::of(b"never stored");
+        assert_eq!(store.get(absent).await, None);
+        assert!(!store.has(absent).await);
+    }
+
+    #[tokio::test]
+    async fn put_is_idempotent_by_content() {
+        let store = InMemoryBlobStore::new();
+        let h1 = store.put(Bytes::from_static(b"same")).await;
+        let h2 = store.put(Bytes::from_static(b"same")).await;
+        // same bytes -> same hash, and only one blob is held.
+        assert_eq!(h1, h2);
+        assert_eq!(store.len(), 1);
+        // distinct bytes -> a distinct hash + a second blob.
+        let h3 = store.put(Bytes::from_static(b"different")).await;
+        assert_ne!(h1, h3);
+        assert_eq!(store.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn stores_and_distinguishes_many_blobs() {
+        let store = InMemoryBlobStore::new();
+        let mut hashes = Vec::new();
+        for i in 0..64u16 {
+            hashes.push(
+                store
+                    .put(Bytes::from(format!("blob-{i}").into_bytes()))
+                    .await,
+            );
+        }
+        assert_eq!(store.len(), 64);
+        // every stored blob is retrievable and the hashes are all distinct.
+        for (i, h) in hashes.iter().enumerate() {
+            let got = store.get(*h).await.expect("stored blob must be present");
+            assert_eq!(got, Bytes::from(format!("blob-{i}").into_bytes()));
+        }
+    }
+
+    /// The store drives correctly under Cameron's Bach simulator — the same put/get/has round-trip run
+    /// on the deterministic discrete-event runtime rather than tokio. This is the seam for Bach's
+    /// determinism/snapshot testing: because the trait + in-memory impl are runtime-agnostic (await-only,
+    /// no tokio primitives), Bach can drive them with no changes. `.primary()` ends the sim when the task
+    /// finishes; asserts inside the spawned task fail the test.
+    #[test]
+    fn blob_store_round_trips_under_the_bach_simulator() {
+        use bach::ext::*;
+        bach::sim(|| {
+            async {
+                let store = InMemoryBlobStore::new();
+                let h = store.put(Bytes::from_static(b"deterministic")).await;
+                assert_eq!(h, Hash::of(b"deterministic"));
+                assert_eq!(
+                    store.get(h).await,
+                    Some(Bytes::from_static(b"deterministic"))
+                );
+                assert!(store.has(h).await);
+                // genuine absence under the simulator too.
+                assert_eq!(store.get(Hash::of(b"absent")).await, None);
+            }
+            .group("blob-store")
+            .primary()
+            .spawn();
+        });
+    }
+}

--- a/implementation/seed/crates/cdz-platform/src/blob_store.rs
+++ b/implementation/seed/crates/cdz-platform/src/blob_store.rs
@@ -1,6 +1,6 @@
 //! The content-addressed blob store (`design/cadenza-platform.md` §8).
 //!
-//! There is exactly ONE store: a mapping from a [`Hash`] to its bytes. Its whole interface is: put bytes
+//! There is exactly one store: a mapping from a [`Hash`] to its bytes. Its whole interface is: put bytes
 //! (getting back their hash), get bytes by hash, and ask whether a hash is present. Everything the system
 //! keeps by hash lives here — log blobs, large state values, contract declarations, wasm components — a
 //! component is not special, it is bytes addressed by its hash like any other value.
@@ -13,7 +13,7 @@
 //! blocking the runtime — but they stay deterministic: `get(hash)` is a pure function of the hash
 //! (content-addressed, the same bytes every time) and `put(bytes)` a pure function of the bytes, so
 //! awaiting a fetch changes only timing, never the result. The trait is [`async_trait`] so a backend is a
-//! dyn-safe swappable trait object, and the methods are runtime-AGNOSTIC (they only await), so they run
+//! dyn-safe swappable trait object, and the methods are runtime-agnostic (they only await), so they run
 //! under tokio in production and under the Bach simulator in deterministic tests alike.
 
 use crate::{Bytes, Hash};

--- a/implementation/seed/crates/cdz-platform/src/lib.rs
+++ b/implementation/seed/crates/cdz-platform/src/lib.rs
@@ -6,9 +6,11 @@
 //! is unpermissioned because the hash *is* the capability. Everything downstream — routing, the
 //! registry, the store — addresses by it, so it is the correct first primitive to settle.
 
+mod blob_store;
 mod hash;
 mod str;
 
+pub use blob_store::{BlobStore, InMemoryBlobStore};
 pub use hash::{Hash, base64url};
 pub use str::Str;
 


### PR DESCRIPTION
## What this is

**PR #4 of the platform rebuild** — the next low-level layer per your roadmap: the one content-addressed **blob store** (spec §8), async, with an in-memory impl so it's easy to test. Builds on the `Hash` (#2908) and `Bytes`/`Str` (#2909) foundations.

## `BlobStore` trait

`#[async_trait]` (so a backend is a **dyn-safe swappable trait object** per §8). The whole interface:
```rust
async fn put(&self, bytes: Bytes) -> Hash;      // store, return content hash (idempotent by content)
async fn get(&self, hash: Hash) -> Option<Bytes>; // fetch by hash, None = genuine absence
async fn has(&self, hash: Hash) -> bool;
```
Async so a disk/network backend can fetch without blocking (§8/§9), but **deterministic**: `get` is a pure function of the hash, `put` of the bytes.

**One design choice to flag:** the methods are **infallible** (no `Result`). Rationale: §8/§9 frame the CAS as a *deterministic* pure lookup (hash → the same bytes every time); a fallible backend (S3) absorbs transient I/O internally (retry) rather than surfacing it here, keeping this layer deterministic. If you'd rather it be `Result`-returning for real disk/S3 backends, say so and I'll change it before this becomes load-bearing.

## `InMemoryBlobStore`

A `HashMap` behind a `std::sync::Mutex`. **Runtime-agnostic** — the lock is held only across the map op (never across an `.await`), and there are no tokio primitives — so it drives identically under **tokio** (production) and under **Bach** (deterministic tests). `put` is idempotent by content; `get`/`has` clone `Bytes` in O(1).

## Deps

- `tokio` as a **main** dep (the platform's async runtime, §9 — per your directive), `async-trait` main.
- `bach` (github.com/camshaft/bach) as a **dev-dep**.

## Tests (5)

4 `#[tokio::test]` (round-trip, absence, idempotent-by-content, many-blobs) **plus one that drives the same round-trip under `bach::sim`** — proving the layer is Bach-drivable, which is the seam for your determinism/snapshot testing.

## Verification

`cargo xtask dev-gate` green (pinned clippy + **23** crate tests; the nix vendor builds the new crates.io deps — no git sources). Root `Cargo.lock` grows by the async closure (tokio/async-trait/bach/s2n-*); no version conflicts, and `cdz-runtime`'s frozen-hash lock is a separate workspace so `REQUIRED_RUNTIME_HASH` is unaffected.

## Next

The **KV trait** (async, same shape) + in-memory impl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)