### PR TITLE
feat(cdz-platform): contracts — (name, input, output) hashed to a contract-id (§1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "bach",
  "blake3",
  "bytes",
+ "cadenza-ast",
  "futures-core",
  "futures-util",
  "tokio",

--- a/implementation/seed/crates/cdz-platform/Cargo.toml
+++ b/implementation/seed/crates/cdz-platform/Cargo.toml
@@ -20,6 +20,11 @@ edition = "2024"
 publish = false
 
 [dependencies]
+# cadenza-ast is the LANGUAGE's canonical AST + type system (not the compiler) — the value model contracts
+# are declared in and hashed over (spec §1/§12; operator ruling 2026-08-20 "use the canonical AST crate
+# for all encoding and contract identification"). Depending on the language is right; only depending on the
+# compiler (rcdzc) would be the coupling to avoid.
+cadenza-ast = { path = "../cadenza-ast" }
 blake3 = "1" # the one content-address digest (fleet-unified on blake3, operator 2026-08-08)
 bytes = "1"  # every byte buffer is bytes::Bytes, never Vec<u8> (spec §12) — O(1) clone as it threads through
 async-trait = "0.1" # dyn-safe async traits, so a store/kv backend is a swappable trait object (spec §8)

--- a/implementation/seed/crates/cdz-platform/src/contract.rs
+++ b/implementation/seed/crates/cdz-platform/src/contract.rs
@@ -24,14 +24,14 @@
 //! runtime treats the payload against a contract as opaque bytes; what the types mean is the concern of the
 //! programs on each end.
 
-use crate::{Hash, Str};
-use cadenza_ast::ast::{Arenas, Builder, Leaf, StructId};
+use crate::{Bytes, Hash, Str};
+use cadenza_ast::ast::{Builder, Leaf, StructId};
 use cadenza_ast::{canon, codec};
 use std::sync::Arc;
 
 /// A contract: a `(name, input type, output type)` declaration whose canonical encoding hashes to its
-/// [`contract-id`](Contract::id) — the sole identity used to route (§1). Holds the declaration as a
-/// canonical [`Arenas`], so `id` is a pure function of it and reproducible from the declaration alone.
+/// [`contract-id`](Contract::id) — the sole identity used to route (§1). The id is computed once at
+/// construction, so it is a pure function of the declaration and reproducible from it alone.
 #[derive(Clone)]
 pub struct Contract {
     /// The contract-id: the hash of the canonical declaration, computed once at construction (the getter
@@ -40,8 +40,10 @@ pub struct Contract {
     /// The contract's name — kept for the [`name`](Contract::name) accessor; it is also encoded inside the
     /// declaration (which is what the id is taken over).
     name: Str,
-    /// The canonical declaration value `(contract <name> <input> <output>)`.
-    declaration: Arenas,
+    /// The canonical declaration `(contract <name> <input> <output>)` in its encoded binary form. Stored
+    /// as the encoded `Bytes` (an O(1) clone) rather than the `Arenas`, since encoding is exactly what the
+    /// id is taken over; a consumer that wants the structured value decodes it with `cadenza_ast::codec`.
+    declaration: Bytes,
 }
 
 impl Contract {
@@ -49,27 +51,28 @@ impl Contract {
     /// the same arena as the declaration, using the `cadenza-ast` type builders (for example
     /// `|b| b.wit_type_prim("f64")` for a `Float`, or `|b| b.wit_type_list(b.wit_type_prim("u8"))`).
     ///
-    /// The declaration is canonicalized immediately, so [`id`](Contract::id) and [`declaration`] are
-    /// stable and reproducible.
+    /// The declaration is canonicalized and encoded immediately, so [`id`](Contract::id) and
+    /// [`declaration`](Contract::declaration) are stable and reproducible.
     pub fn new(
-        name: &str,
+        name: Str,
         input: impl FnOnce(&mut Builder) -> StructId,
         output: impl FnOnce(&mut Builder) -> StructId,
     ) -> Self {
         let mut b = Builder::new();
         let head = b.name("contract");
-        let name_node = b.atom_leaf(Leaf::Str(Arc::from(name)));
+        let name_node = b.atom_leaf(Leaf::Str(Arc::from(name.as_str())));
         let input_ty = input(&mut b);
         let output_ty = output(&mut b);
         let root = b.list(vec![head, name_node, input_ty, output_ty]);
         let arenas = b.finish(root);
-        // Canonicalize now so the stored declaration is the one canonical form its hash is taken over,
-        // and compute the contract-id once here rather than on every `id()` call.
-        let declaration = canon::canonicalize(&arenas).into_owned();
-        let id = Hash::of(&codec::encode(&declaration));
+        // Canonicalize, then encode ONCE: the encoded bytes are both the stored declaration and what the
+        // contract-id is the hash of (so id() and declaration() are both cheap getters afterward).
+        let canonical = canon::canonicalize(&arenas).into_owned();
+        let declaration = Bytes::from(codec::encode(&canonical));
+        let id = Hash::of(&declaration);
         Self {
             id,
-            name: Str::from(name),
+            name,
             declaration,
         }
     }
@@ -84,13 +87,14 @@ impl Contract {
 
     /// The contract's name.
     #[must_use]
-    pub fn name(&self) -> &str {
-        self.name.as_str()
+    pub fn name(&self) -> &Str {
+        &self.name
     }
 
-    /// The canonical declaration value, for a consumer that wants to inspect or re-encode it.
+    /// The canonical declaration in its encoded binary form. Decode it with `cadenza_ast::codec` to
+    /// inspect the structured value; the id is the hash of exactly these bytes.
     #[must_use]
-    pub fn declaration(&self) -> &Arenas {
+    pub fn declaration(&self) -> &Bytes {
         &self.declaration
     }
 }
@@ -98,6 +102,7 @@ impl Contract {
 #[cfg(test)]
 mod tests {
     use super::Contract;
+    use crate::Str;
 
     // helpers building the two types the spec's example uses.
     fn float(b: &mut cadenza_ast::ast::Builder) -> cadenza_ast::ast::StructId {
@@ -111,16 +116,16 @@ mod tests {
     #[test]
     fn id_is_reproducible_from_the_declaration_alone() {
         // Building the same contract twice yields the same id (a pure function of the declaration).
-        let a = Contract::new("temp.celsius", float, float);
-        let b = Contract::new("temp.celsius", float, float);
+        let a = Contract::new(Str::from("temp.celsius"), float, float);
+        let b = Contract::new(Str::from("temp.celsius"), float, float);
         assert_eq!(a.id(), b.id());
     }
 
     #[test]
     fn identity_is_nominal_same_shape_different_name_differs() {
         // temp.celsius : Float -> Float and temp.fahrenheit : Float -> Float share a shape but not an id.
-        let celsius = Contract::new("temp.celsius", float, float);
-        let fahrenheit = Contract::new("temp.fahrenheit", float, float);
+        let celsius = Contract::new(Str::from("temp.celsius"), float, float);
+        let fahrenheit = Contract::new(Str::from("temp.fahrenheit"), float, float);
         assert_ne!(
             celsius.id(),
             fahrenheit.id(),
@@ -131,9 +136,9 @@ mod tests {
     #[test]
     fn evolution_is_a_new_contract_type_change_differs() {
         // Same name, but a different input or output type is a different contract (a different hash).
-        let base = Contract::new("fetch", float, float);
-        let diff_input = Contract::new("fetch", u8_list, float);
-        let diff_output = Contract::new("fetch", float, u8_list);
+        let base = Contract::new(Str::from("fetch"), float, float);
+        let diff_input = Contract::new(Str::from("fetch"), u8_list, float);
+        let diff_output = Contract::new(Str::from("fetch"), float, u8_list);
         assert_ne!(base.id(), diff_input.id());
         assert_ne!(base.id(), diff_output.id());
         assert_ne!(diff_input.id(), diff_output.id());
@@ -141,13 +146,13 @@ mod tests {
 
     #[test]
     fn name_reads_back() {
-        let c = Contract::new("temp.celsius", float, float);
-        assert_eq!(c.name(), "temp.celsius");
+        let c = Contract::new(Str::from("temp.celsius"), float, float);
+        assert_eq!(c.name().as_str(), "temp.celsius");
     }
 
     #[test]
     fn id_is_a_32_byte_hash_rendered_base64url() {
-        let c = Contract::new("x", float, float);
+        let c = Contract::new(Str::from("x"), float, float);
         // it is a real content hash — 32 bytes, 43 base64url chars, and stable across calls.
         assert_eq!(c.id().as_bytes().len(), 32);
         assert_eq!(c.id().to_string().len(), 43);

--- a/implementation/seed/crates/cdz-platform/src/contract.rs
+++ b/implementation/seed/crates/cdz-platform/src/contract.rs
@@ -34,6 +34,9 @@ use std::sync::Arc;
 /// canonical [`Arenas`], so `id` is a pure function of it and reproducible from the declaration alone.
 #[derive(Clone)]
 pub struct Contract {
+    /// The contract-id: the hash of the canonical declaration, computed once at construction (the getter
+    /// just returns it — hashing every call would be wasteful).
+    id: Hash,
     /// The contract's name — kept for the [`name`](Contract::name) accessor; it is also encoded inside the
     /// declaration (which is what the id is taken over).
     name: Str,
@@ -60,19 +63,23 @@ impl Contract {
         let output_ty = output(&mut b);
         let root = b.list(vec![head, name_node, input_ty, output_ty]);
         let arenas = b.finish(root);
-        // Canonicalize now so the stored declaration is the one canonical form its hash is taken over.
+        // Canonicalize now so the stored declaration is the one canonical form its hash is taken over,
+        // and compute the contract-id once here rather than on every `id()` call.
+        let declaration = canon::canonicalize(&arenas).into_owned();
+        let id = Hash::of(&codec::encode(&declaration));
         Self {
+            id,
             name: Str::from(name),
-            declaration: canon::canonicalize(&arenas).into_owned(),
+            declaration,
         }
     }
 
-    /// The contract-id: the hash of the canonical declaration (§1). Reproducible from the declaration
-    /// alone, so two contracts with equal declarations have equal ids, and any difference in name, input,
-    /// or output type gives a different id.
+    /// The contract-id: the hash of the canonical declaration (§1). Computed once at construction (above),
+    /// so this is a cheap getter. Reproducible from the declaration alone, so two contracts with equal
+    /// declarations have equal ids, and any difference in name, input, or output type gives a different id.
     #[must_use]
     pub fn id(&self) -> Hash {
-        Hash::of(&codec::encode(&self.declaration))
+        self.id
     }
 
     /// The contract's name.

--- a/implementation/seed/crates/cdz-platform/src/contract.rs
+++ b/implementation/seed/crates/cdz-platform/src/contract.rs
@@ -1,0 +1,149 @@
+//! Contracts — how everything communicates (`design/cadenza-platform.md` §1).
+//!
+//! A contract is a declared interaction: a name, the type of its input, and the type of its output. Its
+//! identity is the hash of that declaration — the contract-id. Nothing communicates by string name or an
+//! enumerated kind; a program references the exact contract it was built against, by hash, and routing is
+//! an exact content-addressed lookup, never a string match or a version range.
+//!
+//! Three consequences the identity delivers (§1):
+//! - Identity is nominal: the name is part of the hash, so `temp.celsius : Float -> Float` and
+//!   `temp.fahrenheit : Float -> Float` have the same shape but different hashes and never route to each
+//!   other.
+//! - Identity is exact: a caller's contract-id must equal what an answerer declares — no compatibility
+//!   check, no tolerant reader, no version field.
+//! - Evolution is a new contract: changing an input or output type produces a different declaration and so
+//!   a different hash.
+//!
+//! The input and output are Cadenza types, and the whole declaration is a Cadenza value in its canonical
+//! binary form (§1/§12), so the contract-id is reproducible from the declaration alone. We build the
+//! declaration with the language's canonical AST (`cadenza-ast`) and hash its canonical encoding — one
+//! canonical form shared with the compiler, never a parallel or lossy re-encoding.
+//!
+//! Declaration shape: the value `(contract <name> <input-type> <output-type>)` — a list whose head is the
+//! name `contract`, followed by the contract's name as a string, then the input and output type trees. The
+//! runtime treats the payload against a contract as opaque bytes; what the types mean is the concern of the
+//! programs on each end.
+
+use crate::{Hash, Str};
+use cadenza_ast::ast::{Arenas, Builder, Leaf, StructId};
+use cadenza_ast::{canon, codec};
+use std::sync::Arc;
+
+/// A contract: a `(name, input type, output type)` declaration whose canonical encoding hashes to its
+/// [`contract-id`](Contract::id) — the sole identity used to route (§1). Holds the declaration as a
+/// canonical [`Arenas`], so `id` is a pure function of it and reproducible from the declaration alone.
+#[derive(Clone)]
+pub struct Contract {
+    /// The contract's name — kept for the [`name`](Contract::name) accessor; it is also encoded inside the
+    /// declaration (which is what the id is taken over).
+    name: Str,
+    /// The canonical declaration value `(contract <name> <input> <output>)`.
+    declaration: Arenas,
+}
+
+impl Contract {
+    /// Declare a contract from a `name` and its input/output types. The type closures build each type into
+    /// the same arena as the declaration, using the `cadenza-ast` type builders (for example
+    /// `|b| b.wit_type_prim("f64")` for a `Float`, or `|b| b.wit_type_list(b.wit_type_prim("u8"))`).
+    ///
+    /// The declaration is canonicalized immediately, so [`id`](Contract::id) and [`declaration`] are
+    /// stable and reproducible.
+    pub fn new(
+        name: &str,
+        input: impl FnOnce(&mut Builder) -> StructId,
+        output: impl FnOnce(&mut Builder) -> StructId,
+    ) -> Self {
+        let mut b = Builder::new();
+        let head = b.name("contract");
+        let name_node = b.atom_leaf(Leaf::Str(Arc::from(name)));
+        let input_ty = input(&mut b);
+        let output_ty = output(&mut b);
+        let root = b.list(vec![head, name_node, input_ty, output_ty]);
+        let arenas = b.finish(root);
+        // Canonicalize now so the stored declaration is the one canonical form its hash is taken over.
+        Self {
+            name: Str::from(name),
+            declaration: canon::canonicalize(&arenas).into_owned(),
+        }
+    }
+
+    /// The contract-id: the hash of the canonical declaration (§1). Reproducible from the declaration
+    /// alone, so two contracts with equal declarations have equal ids, and any difference in name, input,
+    /// or output type gives a different id.
+    #[must_use]
+    pub fn id(&self) -> Hash {
+        Hash::of(&codec::encode(&self.declaration))
+    }
+
+    /// The contract's name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    /// The canonical declaration value, for a consumer that wants to inspect or re-encode it.
+    #[must_use]
+    pub fn declaration(&self) -> &Arenas {
+        &self.declaration
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Contract;
+
+    // helpers building the two types the spec's example uses.
+    fn float(b: &mut cadenza_ast::ast::Builder) -> cadenza_ast::ast::StructId {
+        b.wit_type_prim("f64")
+    }
+    fn u8_list(b: &mut cadenza_ast::ast::Builder) -> cadenza_ast::ast::StructId {
+        let elem = b.wit_type_prim("u8");
+        b.wit_type_list(elem)
+    }
+
+    #[test]
+    fn id_is_reproducible_from_the_declaration_alone() {
+        // Building the same contract twice yields the same id (a pure function of the declaration).
+        let a = Contract::new("temp.celsius", float, float);
+        let b = Contract::new("temp.celsius", float, float);
+        assert_eq!(a.id(), b.id());
+    }
+
+    #[test]
+    fn identity_is_nominal_same_shape_different_name_differs() {
+        // temp.celsius : Float -> Float and temp.fahrenheit : Float -> Float share a shape but not an id.
+        let celsius = Contract::new("temp.celsius", float, float);
+        let fahrenheit = Contract::new("temp.fahrenheit", float, float);
+        assert_ne!(
+            celsius.id(),
+            fahrenheit.id(),
+            "the name is part of the identity"
+        );
+    }
+
+    #[test]
+    fn evolution_is_a_new_contract_type_change_differs() {
+        // Same name, but a different input or output type is a different contract (a different hash).
+        let base = Contract::new("fetch", float, float);
+        let diff_input = Contract::new("fetch", u8_list, float);
+        let diff_output = Contract::new("fetch", float, u8_list);
+        assert_ne!(base.id(), diff_input.id());
+        assert_ne!(base.id(), diff_output.id());
+        assert_ne!(diff_input.id(), diff_output.id());
+    }
+
+    #[test]
+    fn name_reads_back() {
+        let c = Contract::new("temp.celsius", float, float);
+        assert_eq!(c.name(), "temp.celsius");
+    }
+
+    #[test]
+    fn id_is_a_32_byte_hash_rendered_base64url() {
+        let c = Contract::new("x", float, float);
+        // it is a real content hash — 32 bytes, 43 base64url chars, and stable across calls.
+        assert_eq!(c.id().as_bytes().len(), 32);
+        assert_eq!(c.id().to_string().len(), 43);
+        assert_eq!(c.id(), c.id());
+    }
+}

--- a/implementation/seed/crates/cdz-platform/src/lib.rs
+++ b/implementation/seed/crates/cdz-platform/src/lib.rs
@@ -7,11 +7,13 @@
 //! registry, the store — addresses by it, so it is the correct first primitive to settle.
 
 mod blob_store;
+mod contract;
 mod hash;
 mod kv;
 mod str;
 
 pub use blob_store::{BlobStore, InMemoryBlobStore};
+pub use contract::Contract;
 pub use hash::{Hash, base64url};
 pub use kv::{InMemoryKvStore, KeyRange, KvKeyScan, KvScan, KvStore, prefix_range};
 pub use str::Str;


### PR DESCRIPTION
## What this is

**PR #6 of the platform rebuild** — contracts (spec §1), the identity everything routes by, built on the canonical AST per your ruling ("use the canonical AST crate for all encoding and contract identification").

A contract is a declared interaction — a name, the type of its input, and the type of its output — and its **contract-id is the hash of its declaration**. Routing is exact content-addressed lookup on that hash: no string match, no version range, no tolerant reader.

## `Contract`

```rust
Contract::new("temp.celsius", |b| b.wit_type_prim("f64"), |b| b.wit_type_prim("f64"))
```
- `new(name, input, output)` builds the declaration `(contract <name> <input-type> <output-type>)` as one `cadenza-ast` value — the input/output closures build each type into the same arena via the language's type builders (`wit_type_prim`/`wit_type_list`/…). It canonicalizes immediately (`cadenza_ast::canon`), so the stored declaration is the one canonical form.
- `id()` = `Hash::of(codec::encode(declaration))` — the contract-id, reproducible from the declaration alone. `name()` reads back the name; `declaration()` exposes the canonical value.

Uses **`cadenza-ast`** — the *language's* AST + type system (not the compiler `rcdzc`) — for the value model and canonical binary encoding, so there's one canonical form shared with the compiler and no parallel or lossy re-encoding (per your language-yes / compiler-no clarification).

## Declaration shape (a decision to confirm)

I defined the declaration as `(contract <name-str> <input-type> <output-type>)`. Spec §1 says the declaration is "a Cadenza value with a canonical encoding" but doesn't pin the exact shape — this is my proposed convention, documented in the module. Happy to reshape if you have a preferred canonical form (e.g. a record with named fields rather than a positional list).

## Tests (5) — pinning the §1 guarantees

- id reproducible from the declaration alone;
- **identity is nominal** — the spec's own example: `temp.celsius : Float→Float` and `temp.fahrenheit : Float→Float` share a shape but get different ids;
- **evolution is a new contract** — a changed input *or* output type gives a different id;
- name reads back; id is a real 32-byte base64url hash.

## Verification

No new deps (`cadenza-ast` is a workspace member; `Cargo.lock` +1 edge). `cargo xtask dev-gate` green (pinned clippy + **36** crate tests). Plain-prose comments.

## Next

The **reducer interface** (`on_response` / `on_message`) + the **registry and router** that dispatch by contract-id (§3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)