### PR TITLE
feat(cdz-platform): the reducer interface — two entry points + message ABI (§3)

### DIFF
--- a/implementation/seed/crates/cdz-platform/src/blob_store.rs
+++ b/implementation/seed/crates/cdz-platform/src/blob_store.rs
@@ -19,7 +19,6 @@
 use crate::{Bytes, Hash};
 use async_trait::async_trait;
 use std::collections::HashMap;
-use std::sync::Mutex;
 
 /// A content-addressed blob store: hash <-> bytes. The one store of §8; backends (in-memory, disk, S3)
 /// implement this and are swapped by reference. `Send + Sync` so it can be shared across the runtime's
@@ -30,7 +29,7 @@ pub trait BlobStore: Send + Sync {
     /// the bytes, so putting the same bytes twice yields the same hash and simply re-stores identical
     /// content. (No `Result`: a well-formed backend's put is a pure function of its input; a fallible
     /// backend absorbs transient I/O internally, e.g. by retry — this layer stays deterministic per §8/§9.)
-    async fn put(&self, bytes: Bytes) -> Hash;
+    async fn put(&mut self, bytes: Bytes) -> Hash;
 
     /// Fetch the bytes stored under `hash`, or `None` if the store does not hold it. `None` is genuine
     /// absence, not a transient failure.
@@ -40,12 +39,12 @@ pub trait BlobStore: Send + Sync {
     async fn has(&self, hash: Hash) -> bool;
 }
 
-/// An in-memory [`BlobStore`] — a plain hash-map behind a `Mutex`. For tests and single-process use; the
-/// smallest honest backend. Runtime-agnostic: the lock is a `std::sync::Mutex` held only across the map
-/// operation (never across an `.await`), so this drives identically under tokio and under Bach.
+/// An in-memory [`BlobStore`] — a plain hash-map. For tests and single-process use; the smallest honest
+/// backend. `put` takes `&mut self`, so no interior mutability (a lock) is needed — the runtime owns the
+/// store exclusively in its event loop.
 #[derive(Default)]
 pub struct InMemoryBlobStore {
-    blobs: Mutex<HashMap<Hash, Bytes>>,
+    blobs: HashMap<Hash, Bytes>,
 }
 
 impl InMemoryBlobStore {
@@ -58,45 +57,31 @@ impl InMemoryBlobStore {
     /// The number of distinct blobs held (by content hash). Handy for tests/introspection.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.blobs.lock().expect("blob-store mutex poisoned").len()
+        self.blobs.len()
     }
 
     /// Whether the store holds no blobs.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.blobs
-            .lock()
-            .expect("blob-store mutex poisoned")
-            .is_empty()
+        self.blobs.is_empty()
     }
 }
 
 #[async_trait]
 impl BlobStore for InMemoryBlobStore {
-    async fn put(&self, bytes: Bytes) -> Hash {
+    async fn put(&mut self, bytes: Bytes) -> Hash {
         let hash = Hash::of(&bytes);
-        // O(1) Bytes clone into the map; the guard is dropped before returning (no await held across it).
-        self.blobs
-            .lock()
-            .expect("blob-store mutex poisoned")
-            .insert(hash, bytes);
+        self.blobs.insert(hash, bytes); // O(1) Bytes clone into the map.
         hash
     }
 
     async fn get(&self, hash: Hash) -> Option<Bytes> {
         // `cloned()` on a Bytes is an O(1) refcount bump, not a copy.
-        self.blobs
-            .lock()
-            .expect("blob-store mutex poisoned")
-            .get(&hash)
-            .cloned()
+        self.blobs.get(&hash).cloned()
     }
 
     async fn has(&self, hash: Hash) -> bool {
-        self.blobs
-            .lock()
-            .expect("blob-store mutex poisoned")
-            .contains_key(&hash)
+        self.blobs.contains_key(&hash)
     }
 }
 
@@ -107,7 +92,7 @@ mod tests {
 
     #[tokio::test]
     async fn put_returns_the_content_hash_and_get_round_trips() {
-        let store = InMemoryBlobStore::new();
+        let mut store = InMemoryBlobStore::new();
         let bytes = Bytes::from_static(b"the hash is the capability");
         let h = store.put(bytes.clone()).await;
         // put returns the content hash of exactly those bytes.
@@ -127,7 +112,7 @@ mod tests {
 
     #[tokio::test]
     async fn put_is_idempotent_by_content() {
-        let store = InMemoryBlobStore::new();
+        let mut store = InMemoryBlobStore::new();
         let h1 = store.put(Bytes::from_static(b"same")).await;
         let h2 = store.put(Bytes::from_static(b"same")).await;
         // same bytes -> same hash, and only one blob is held.
@@ -141,7 +126,7 @@ mod tests {
 
     #[tokio::test]
     async fn stores_and_distinguishes_many_blobs() {
-        let store = InMemoryBlobStore::new();
+        let mut store = InMemoryBlobStore::new();
         let mut hashes = Vec::new();
         for i in 0..64u16 {
             hashes.push(
@@ -168,7 +153,7 @@ mod tests {
         use bach::ext::*;
         bach::sim(|| {
             async {
-                let store = InMemoryBlobStore::new();
+                let mut store = InMemoryBlobStore::new();
                 let h = store.put(Bytes::from_static(b"deterministic")).await;
                 assert_eq!(h, Hash::of(b"deterministic"));
                 assert_eq!(

--- a/implementation/seed/crates/cdz-platform/src/kv.rs
+++ b/implementation/seed/crates/cdz-platform/src/kv.rs
@@ -28,7 +28,6 @@ use futures_core::Stream;
 use std::collections::BTreeMap;
 use std::ops::Bound;
 use std::pin::Pin;
-use std::sync::Mutex;
 
 /// A key range over the canonical (lexicographic) key order — the same shape `BTreeMap::range` takes, but
 /// a concrete owned type (not a generic `RangeBounds`) because the [`KvStore`] scan methods are on a
@@ -84,11 +83,11 @@ pub trait KvStore: Send + Sync {
     async fn get(&self, key: &[u8]) -> Option<Bytes>;
 
     /// Insert or overwrite the value under `key`. Last write wins, as a map does.
-    async fn put(&self, key: Bytes, value: Bytes);
+    async fn put(&mut self, key: Bytes, value: Bytes);
 
     /// Remove the entry under `key`, returning `true` if one was present (and is now gone), `false` if
     /// there was nothing to remove.
-    async fn delete(&self, key: &[u8]) -> bool;
+    async fn delete(&mut self, key: &[u8]) -> bool;
 
     /// Stream every `(key, value)` whose key falls in `range`, in ascending key order. A lazy [`Stream`],
     /// not a materialized collection, so a scan that matches a great many keys does not load them all at
@@ -101,13 +100,13 @@ pub trait KvStore: Send + Sync {
     fn scan_keys(&self, range: KeyRange) -> KvKeyScan<'_>;
 }
 
-/// An in-memory [`KvStore`] — a `BTreeMap` behind a `Mutex`. For tests and single-process use; the smallest
-/// honest backend. A `BTreeMap` (not a hash map) keeps keys in the canonical ascending order the scans
-/// need. Runtime-agnostic: the lock is a `std::sync::Mutex` held only across the map operation (never
-/// across an `.await`), so this drives identically under tokio and under Bach.
+/// An in-memory [`KvStore`] — a plain `BTreeMap`. For tests and single-process use; the smallest honest
+/// backend. A `BTreeMap` (not a hash map) keeps keys in the canonical ascending order the scans need. The
+/// mutating methods take `&mut self`, so no interior mutability (a lock) is needed — the runtime owns the
+/// store exclusively in its event loop.
 #[derive(Default)]
 pub struct InMemoryKvStore {
-    entries: Mutex<BTreeMap<Bytes, Bytes>>,
+    entries: BTreeMap<Bytes, Bytes>,
 }
 
 impl InMemoryKvStore {
@@ -120,16 +119,13 @@ impl InMemoryKvStore {
     /// The number of entries held. Handy for tests and introspection.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.entries.lock().expect("kv-store mutex poisoned").len()
+        self.entries.len()
     }
 
     /// Whether the store holds no entries.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.entries
-            .lock()
-            .expect("kv-store mutex poisoned")
-            .is_empty()
+        self.entries.is_empty()
     }
 }
 
@@ -138,48 +134,32 @@ impl KvStore for InMemoryKvStore {
     async fn get(&self, key: &[u8]) -> Option<Bytes> {
         // `cloned()` on a Bytes is an O(1) refcount bump, not a copy. `Bytes: Borrow<[u8]>` lets a byte
         // slice look up a Bytes-keyed map without allocating a key.
-        self.entries
-            .lock()
-            .expect("kv-store mutex poisoned")
-            .get(key)
-            .cloned()
+        self.entries.get(key).cloned()
     }
 
-    async fn put(&self, key: Bytes, value: Bytes) {
-        self.entries
-            .lock()
-            .expect("kv-store mutex poisoned")
-            .insert(key, value);
+    async fn put(&mut self, key: Bytes, value: Bytes) {
+        self.entries.insert(key, value);
     }
 
-    async fn delete(&self, key: &[u8]) -> bool {
-        self.entries
-            .lock()
-            .expect("kv-store mutex poisoned")
-            .remove(key)
-            .is_some()
+    async fn delete(&mut self, key: &[u8]) -> bool {
+        self.entries.remove(key).is_some()
     }
 
     fn scan(&self, range: KeyRange) -> KvScan<'_> {
         // The trait promises a lazy stream so a disk/network backend can page a huge scan. An in-memory
-        // backend already holds its data resident, so it snapshots the requested range under the lock —
-        // the pairs are O(1) Bytes-refcount clones, and BTreeMap::range visits only the keys in range —
-        // then streams that snapshot, so the lock is never held across the consumer's awaits.
-        let pairs: Vec<(Bytes, Bytes)> = {
-            let guard = self.entries.lock().expect("kv-store mutex poisoned");
-            guard
-                .range(range)
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect()
-        };
+        // backend already holds its data resident, so it snapshots the requested range — the pairs are
+        // O(1) Bytes-refcount clones, and BTreeMap::range visits only the keys in range — then streams
+        // that snapshot.
+        let pairs: Vec<(Bytes, Bytes)> = self
+            .entries
+            .range(range)
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
         Box::pin(futures_util::stream::iter(pairs))
     }
 
     fn scan_keys(&self, range: KeyRange) -> KvKeyScan<'_> {
-        let keys: Vec<Bytes> = {
-            let guard = self.entries.lock().expect("kv-store mutex poisoned");
-            guard.range(range).map(|(k, _)| k.clone()).collect()
-        };
+        let keys: Vec<Bytes> = self.entries.range(range).map(|(k, _)| k.clone()).collect();
         Box::pin(futures_util::stream::iter(keys))
     }
 }
@@ -198,7 +178,7 @@ mod tests {
 
     #[tokio::test]
     async fn put_then_get_round_trips() {
-        let kv = InMemoryKvStore::new();
+        let mut kv = InMemoryKvStore::new();
         kv.put(
             Bytes::from_static(b"tick/interval-ms"),
             Bytes::from_static(b"900000"),
@@ -218,7 +198,7 @@ mod tests {
 
     #[tokio::test]
     async fn put_overwrites_last_write_wins() {
-        let kv = InMemoryKvStore::new();
+        let mut kv = InMemoryKvStore::new();
         kv.put(Bytes::from_static(b"k"), Bytes::from_static(b"first"))
             .await;
         kv.put(Bytes::from_static(b"k"), Bytes::from_static(b"second"))
@@ -229,7 +209,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_removes_and_reports_presence() {
-        let kv = InMemoryKvStore::new();
+        let mut kv = InMemoryKvStore::new();
         kv.put(Bytes::from_static(b"k"), Bytes::from_static(b"v"))
             .await;
         assert!(kv.delete(b"k").await, "deleting a present key returns true");
@@ -240,7 +220,7 @@ mod tests {
 
     #[tokio::test]
     async fn scan_streams_a_range_of_pairs_ascending() {
-        let kv = InMemoryKvStore::new();
+        let mut kv = InMemoryKvStore::new();
         for (k, v) in [("c", "3"), ("a", "1"), ("e", "5"), ("b", "2"), ("d", "4")] {
             kv.put(
                 Bytes::from(k.as_bytes().to_vec()),
@@ -273,7 +253,7 @@ mod tests {
 
     #[tokio::test]
     async fn scan_keys_yields_only_keys() {
-        let kv = InMemoryKvStore::new();
+        let mut kv = InMemoryKvStore::new();
         kv.put(Bytes::from_static(b"a"), Bytes::from_static(b"1"))
             .await;
         kv.put(Bytes::from_static(b"b"), Bytes::from_static(b"2"))
@@ -287,7 +267,7 @@ mod tests {
 
     #[tokio::test]
     async fn prefix_range_scans_exactly_the_prefix() {
-        let kv = InMemoryKvStore::new();
+        let mut kv = InMemoryKvStore::new();
         for k in ["seen/a", "seen/b", "seen0", "seem", "tick/x"] {
             kv.put(Bytes::from(k.as_bytes().to_vec()), Bytes::from_static(b"1"))
                 .await;
@@ -331,7 +311,7 @@ mod tests {
         use futures_util::StreamExt;
         bach::sim(|| {
             async {
-                let kv = InMemoryKvStore::new();
+                let mut kv = InMemoryKvStore::new();
                 kv.put(Bytes::from_static(b"seen/msg-1"), Bytes::from_static(b"1"))
                     .await;
                 kv.put(Bytes::from_static(b"seen/msg-2"), Bytes::from_static(b"2"))

--- a/implementation/seed/crates/cdz-platform/src/lib.rs
+++ b/implementation/seed/crates/cdz-platform/src/lib.rs
@@ -10,12 +10,14 @@ mod blob_store;
 mod contract;
 mod hash;
 mod kv;
+mod reducer;
 mod str;
 
 pub use blob_store::{BlobStore, InMemoryBlobStore};
 pub use contract::Contract;
 pub use hash::{Hash, base64url};
 pub use kv::{InMemoryKvStore, KeyRange, KvKeyScan, KvScan, KvStore, prefix_range};
+pub use reducer::{Error, Message, Outcome, Reducer, Request, Response};
 pub use str::Str;
 
 // Re-export the byte-buffer type the platform marshals through, so downstream code depends on the

--- a/implementation/seed/crates/cdz-platform/src/reducer.rs
+++ b/implementation/seed/crates/cdz-platform/src/reducer.rs
@@ -108,128 +108,104 @@ pub struct Message {
 /// `Send + Sync` so the runtime can share and schedule it. The two entry points return the same product —
 /// the requests to perform and the [`Outcome`]. Async because a reduce call may await the reducer's direct
 /// accesses (its key-value store, the content store); it never blocks the runtime.
+///
+/// The methods take `&mut self`: a reducer folds an event into its own state, so it mutates. Each reducer
+/// lives in the runtime's registry with a single owner (the event loop drives one reducer at a time), so
+/// exclusive access is the natural fit and the trait does not force interior mutability on implementations.
+/// An implementation is still free to use interior mutability if it wants.
 #[async_trait]
 pub trait Reducer: Send + Sync {
     /// React to a [`Response`] — a reply to a request this reducer performed.
-    async fn on_response(&self, response: Response) -> (Vec<Request>, Outcome);
+    async fn on_response(&mut self, response: Response) -> (Vec<Request>, Outcome);
 
     /// React to a [`Message`] — an effect performed on this reducer by another, carrying its source.
-    async fn on_message(&self, message: Message) -> (Vec<Request>, Outcome);
+    async fn on_message(&mut self, message: Message) -> (Vec<Request>, Outcome);
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Error, Message, Outcome, Reducer, Request, Response};
+    use super::{Message, Outcome, Reducer, Request, Response};
     use crate::{Bytes, Hash};
 
-    /// A tiny reducer exercising the interface: on a message it performs one downstream request (echoing
-    /// the payload to a fixed contract) and keeps running; on a response it closes, carrying the answer as
-    /// the break reason. Enough to pin the ABI shapes and both entry points.
-    struct EchoThenClose {
+    /// A reducer that actually folds state: it counts the messages it has seen (in `&mut self`), forwards
+    /// each to a downstream contract carrying the running count, and closes once it has seen `close_at`.
+    /// The behavior on any given event depends on the accumulated state, so it exercises real folding
+    /// across calls rather than a fixed shape.
+    struct Counter {
+        seen: u32,
+        close_at: u32,
         downstream: Hash,
     }
 
     #[async_trait::async_trait]
-    impl Reducer for EchoThenClose {
-        async fn on_message(&self, message: Message) -> (Vec<Request>, Outcome) {
-            let req = Request {
+    impl Reducer for Counter {
+        async fn on_message(&mut self, message: Message) -> (Vec<Request>, Outcome) {
+            self.seen += 1;
+            let request = Request {
                 id: self.downstream,
-                payload: message.payload,
+                payload: Bytes::copy_from_slice(&self.seen.to_le_bytes()),
                 continuation_token: message.continuation_token,
                 deadline: None,
             };
-            (vec![req], Outcome::Continue)
-        }
-
-        async fn on_response(&self, response: Response) -> (Vec<Request>, Outcome) {
-            // close, carrying whatever we got back as the reason (its schema is the answered contract-id).
-            let reason = response
-                .payload
-                .unwrap_or_else(|_| Bytes::from_static(b"failed"));
-            (
-                Vec::new(),
+            let outcome = if self.seen >= self.close_at {
                 Outcome::Break {
-                    schema: response.id,
-                    reason,
-                },
-            )
+                    schema: message.id,
+                    reason: Bytes::from_static(b"reached limit"),
+                }
+            } else {
+                Outcome::Continue
+            };
+            (vec![request], outcome)
+        }
+
+        async fn on_response(&mut self, _response: Response) -> (Vec<Request>, Outcome) {
+            (Vec::new(), Outcome::Continue)
+        }
+    }
+
+    fn msg(token: &'static [u8]) -> Message {
+        Message {
+            id: Hash::of(b"inbound"),
+            payload: Bytes::from_static(b"x"),
+            from: Hash::of(b"peer"),
+            continuation_token: Bytes::from_static(token),
         }
     }
 
     #[tokio::test]
-    async fn on_message_emits_a_correlated_request_and_continues() {
-        let r = EchoThenClose {
-            downstream: Hash::of(b"downstream.contract"),
+    async fn folds_state_across_calls_and_breaks_at_the_limit() {
+        let mut r = Counter {
+            seen: 0,
+            close_at: 3,
+            downstream: Hash::of(b"downstream"),
         };
-        let msg = Message {
-            id: Hash::of(b"inbound.contract"),
-            payload: Bytes::from_static(b"hello"),
-            from: Hash::of(b"peer-reducer"),
-            continuation_token: Bytes::from_static(b"tok-1"),
-        };
-        let (requests, outcome) = r.on_message(msg).await;
-        assert_eq!(outcome, Outcome::Continue);
-        assert_eq!(requests.len(), 1);
-        assert_eq!(requests[0].id, Hash::of(b"downstream.contract"));
-        assert_eq!(requests[0].payload, Bytes::from_static(b"hello"));
-        // the caller's token is threaded onto the emitted request for correlation.
-        assert_eq!(requests[0].continuation_token, Bytes::from_static(b"tok-1"));
-        assert_eq!(requests[0].deadline, None);
+        // The running count carried on each forwarded request reflects accumulated state: 1, then 2.
+        let (out1, o1) = r.on_message(msg(b"t1")).await;
+        assert_eq!(out1[0].payload, Bytes::copy_from_slice(&1u32.to_le_bytes()));
+        assert_eq!(o1, Outcome::Continue);
+        let (out2, o2) = r.on_message(msg(b"t2")).await;
+        assert_eq!(out2[0].payload, Bytes::copy_from_slice(&2u32.to_le_bytes()));
+        assert_eq!(o2, Outcome::Continue);
+        // The third message hits the limit, so the reducer closes — an outcome that depends on state.
+        let (out3, o3) = r.on_message(msg(b"t3")).await;
+        assert_eq!(out3[0].payload, Bytes::copy_from_slice(&3u32.to_le_bytes()));
+        assert!(matches!(o3, Outcome::Break { .. }));
     }
 
     #[tokio::test]
-    async fn on_response_breaks_with_the_answer_as_reason() {
-        let contract = Hash::of(b"downstream.contract");
-        let r = EchoThenClose {
-            downstream: contract,
+    async fn a_forwarded_request_carries_the_callers_token_for_correlation() {
+        let mut r = Counter {
+            seen: 0,
+            close_at: 100,
+            downstream: Hash::of(b"downstream"),
         };
-        let resp = Response {
-            id: contract,
-            continuation_token: Bytes::from_static(b"tok-1"),
-            payload: Ok(Bytes::from_static(b"world")),
-        };
-        let (requests, outcome) = r.on_response(resp).await;
-        assert!(requests.is_empty());
+        // The reducer routes to its downstream contract and threads the caller's token through, so the
+        // eventual answer correlates back — the routing behavior, not the struct shape.
+        let (requests, _) = r.on_message(msg(b"correlate-me")).await;
+        assert_eq!(requests[0].id, Hash::of(b"downstream"));
         assert_eq!(
-            outcome,
-            Outcome::Break {
-                schema: contract,
-                reason: Bytes::from_static(b"world"),
-            }
+            requests[0].continuation_token,
+            Bytes::from_static(b"correlate-me")
         );
-    }
-
-    #[tokio::test]
-    async fn a_runtime_failure_is_matched_to_its_request_by_token() {
-        // Err carries the correlation (id + token) the same as Ok, so a timeout is matched to its request.
-        let contract = Hash::of(b"c");
-        let r = EchoThenClose {
-            downstream: contract,
-        };
-        let resp = Response {
-            id: contract,
-            continuation_token: Bytes::from_static(b"tok-9"),
-            payload: Err(Error::Timeout),
-        };
-        // the response still correlates (token present on the error path).
-        assert_eq!(resp.continuation_token, Bytes::from_static(b"tok-9"));
-        let (_, outcome) = r.on_response(resp).await;
-        assert!(matches!(outcome, Outcome::Break { .. }));
-    }
-
-    /// The reducer is usable as a trait object (dyn Reducer) — the registry will hold backends this way.
-    #[tokio::test]
-    async fn reducer_is_dyn_safe() {
-        let r: Box<dyn Reducer> = Box::new(EchoThenClose {
-            downstream: Hash::of(b"c"),
-        });
-        let msg = Message {
-            id: Hash::of(b"c"),
-            payload: Bytes::from_static(b"x"),
-            from: Hash::of(b"p"),
-            continuation_token: Bytes::from_static(b"t"),
-        };
-        let (requests, _) = r.on_message(msg).await;
-        assert_eq!(requests.len(), 1);
     }
 }

--- a/implementation/seed/crates/cdz-platform/src/reducer.rs
+++ b/implementation/seed/crates/cdz-platform/src/reducer.rs
@@ -1,0 +1,235 @@
+//! The reducer interface (`design/cadenza-platform.md` §3).
+//!
+//! There is one kind of participant: a reducer. Anything that takes part — a session running an agent's
+//! task, a handler that answers a single contract, the boundary that performs input and output — is a
+//! reducer with the same interface: it receives an event, updates its own state, and emits effect
+//! requests. There is no separate executor.
+//!
+//! Everything a reducer receives is an event carrying a contract-id, and it is one of two kinds, so a
+//! reducer has two entry points and the runtime calls the one that fits:
+//! - [`on_response`](Reducer::on_response) — the output side: a reply to a request this reducer performed.
+//! - [`on_message`](Reducer::on_message) — the input side: an effect another reducer performed on this
+//!   one (or a message sent to it), carrying its source so the reducer can authenticate and route on who
+//!   sent it.
+//!
+//! Both return the same product: the [`Request`]s to perform next, and an [`Outcome`] (`Continue` to keep
+//! running, or `Break` to terminate the reducer carrying a typed reason). Each call is a pure function of
+//! its input and the reducer's current state; a fresh instance runs each call and holds no memory between
+//! calls. Correlation is by the `continuation_token` a reducer chooses on a request and gets back on the
+//! response — not the `id` (the contract-id is shared by every request of that contract).
+//!
+//! Identity by hash, payload by value in bytes: every event carries an `id` (the contract-id, which is the
+//! hash of the schema) plus a `payload`. The payload is the value in its canonical encoding — carried as
+//! [`Bytes`] because the runtime routes on the `id` and never decodes a payload; a reducer that needs the
+//! structured value decodes it (and derefs the schema from the store by `id`) itself, lazily.
+
+use crate::{Bytes, Hash};
+use async_trait::async_trait;
+use std::time::Duration;
+
+/// A runtime-level failure of a request — distinct from a handler's own domain error, which is a normal
+/// answer that rides in `Ok(output)` (§3). These are the only two ways a dispatch fails without an answer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// The request carried a deadline that elapsed with no answer. The dispatch is cancelled — no late
+    /// answer will ever fold — so a reducer never has to handle a response arriving after it gave up.
+    Timeout,
+    /// No handler is registered for the contract; nothing could answer it.
+    MissingHandler,
+}
+
+/// What a reduce call decides about the reducer's own life (§3). A reducer ends *itself* only by returning
+/// `Break`; it never ends itself via an effect. Because the return is a product of `(requests, outcome)`,
+/// a reducer can emit final requests and `Break` in one call (send a result, notify a peer, then close);
+/// those final requests dispatch but their responses never fold.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Outcome {
+    /// Keep the reducer running.
+    Continue,
+    /// Terminate the reducer, carrying the reason for closure as a typed value: the schema hash of the
+    /// reason plus the reason value's canonical bytes. The runtime imposes no normal-vs-error taxonomy —
+    /// a clean completion and a failure are both `Break`s, distinguished only by the reason a subscribing
+    /// supervisor decodes.
+    Break {
+        /// The contract-id (schema hash) of the reason value.
+        schema: Hash,
+        /// The reason value in its canonical encoding.
+        reason: Bytes,
+    },
+}
+
+/// A request a reducer emits: perform the contract `id` with `payload`, and correlate the eventual answer
+/// by `continuation_token` (§3/§4).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Request {
+    /// The contract-id: the hash of the schema being requested.
+    pub id: Hash,
+    /// The input value, in its canonical encoding.
+    pub payload: Bytes,
+    /// The token the reducer chooses to correlate the eventual response back to this request. Unique per
+    /// outstanding request in a session; returned verbatim on the response.
+    pub continuation_token: Bytes,
+    /// An optional per-request deadline. With `Some(d)`, no answer within `d` delivers `Err(Timeout)` and
+    /// cancels the dispatch; `None` means no timeout. This is the reducer's own opt-in anti-stuck control.
+    pub deadline: Option<Duration>,
+}
+
+/// The answer to a request this reducer performed, delivered to [`on_response`](Reducer::on_response). The
+/// correlation (`id`, `continuation_token`) is on the `Response` itself — not inside the `Result` — so a
+/// failure is matched back to its originating request the same way a success is (§4).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Response {
+    /// The contract-id this answers (schema hash).
+    pub id: Hash,
+    /// The token from the originating request — present on both `Ok` and `Err`.
+    pub continuation_token: Bytes,
+    /// The result: `Ok` the contract's output value (canonical bytes; a handler's *domain* failure rides
+    /// here too, since answering with an error is still answering), or `Err` a runtime-level failure.
+    pub payload: Result<Bytes, Error>,
+}
+
+/// An effect another reducer performed on this one, delivered to [`on_message`](Reducer::on_message). It
+/// carries its source (`from`) as envelope metadata so the reducer can authenticate and route on who sent
+/// it — the reason `on_message` is distinct from `on_response`. The reducer answers by emitting its reply,
+/// correlated by this `continuation_token`, which the runtime routes back to the caller's `on_response`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Message {
+    /// The contract-id of the effect being performed on this reducer.
+    pub id: Hash,
+    /// The input value of that effect, in its canonical encoding.
+    pub payload: Bytes,
+    /// The source reducer's id — envelope metadata to authenticate or route on.
+    pub from: Hash,
+    /// The caller's token; the reducer's reply is correlated back to the caller by it.
+    pub continuation_token: Bytes,
+}
+
+/// The one interface every participant implements (§3): receive an event, update state, emit requests.
+/// `Send + Sync` so the runtime can share and schedule it. The two entry points return the same product —
+/// the requests to perform and the [`Outcome`]. Async because a reduce call may await the reducer's direct
+/// accesses (its key-value store, the content store); it never blocks the runtime.
+#[async_trait]
+pub trait Reducer: Send + Sync {
+    /// React to a [`Response`] — a reply to a request this reducer performed.
+    async fn on_response(&self, response: Response) -> (Vec<Request>, Outcome);
+
+    /// React to a [`Message`] — an effect performed on this reducer by another, carrying its source.
+    async fn on_message(&self, message: Message) -> (Vec<Request>, Outcome);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, Message, Outcome, Reducer, Request, Response};
+    use crate::{Bytes, Hash};
+
+    /// A tiny reducer exercising the interface: on a message it performs one downstream request (echoing
+    /// the payload to a fixed contract) and keeps running; on a response it closes, carrying the answer as
+    /// the break reason. Enough to pin the ABI shapes and both entry points.
+    struct EchoThenClose {
+        downstream: Hash,
+    }
+
+    #[async_trait::async_trait]
+    impl Reducer for EchoThenClose {
+        async fn on_message(&self, message: Message) -> (Vec<Request>, Outcome) {
+            let req = Request {
+                id: self.downstream,
+                payload: message.payload,
+                continuation_token: message.continuation_token,
+                deadline: None,
+            };
+            (vec![req], Outcome::Continue)
+        }
+
+        async fn on_response(&self, response: Response) -> (Vec<Request>, Outcome) {
+            // close, carrying whatever we got back as the reason (its schema is the answered contract-id).
+            let reason = response
+                .payload
+                .unwrap_or_else(|_| Bytes::from_static(b"failed"));
+            (
+                Vec::new(),
+                Outcome::Break {
+                    schema: response.id,
+                    reason,
+                },
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn on_message_emits_a_correlated_request_and_continues() {
+        let r = EchoThenClose {
+            downstream: Hash::of(b"downstream.contract"),
+        };
+        let msg = Message {
+            id: Hash::of(b"inbound.contract"),
+            payload: Bytes::from_static(b"hello"),
+            from: Hash::of(b"peer-reducer"),
+            continuation_token: Bytes::from_static(b"tok-1"),
+        };
+        let (requests, outcome) = r.on_message(msg).await;
+        assert_eq!(outcome, Outcome::Continue);
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].id, Hash::of(b"downstream.contract"));
+        assert_eq!(requests[0].payload, Bytes::from_static(b"hello"));
+        // the caller's token is threaded onto the emitted request for correlation.
+        assert_eq!(requests[0].continuation_token, Bytes::from_static(b"tok-1"));
+        assert_eq!(requests[0].deadline, None);
+    }
+
+    #[tokio::test]
+    async fn on_response_breaks_with_the_answer_as_reason() {
+        let contract = Hash::of(b"downstream.contract");
+        let r = EchoThenClose {
+            downstream: contract,
+        };
+        let resp = Response {
+            id: contract,
+            continuation_token: Bytes::from_static(b"tok-1"),
+            payload: Ok(Bytes::from_static(b"world")),
+        };
+        let (requests, outcome) = r.on_response(resp).await;
+        assert!(requests.is_empty());
+        assert_eq!(
+            outcome,
+            Outcome::Break {
+                schema: contract,
+                reason: Bytes::from_static(b"world"),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn a_runtime_failure_is_matched_to_its_request_by_token() {
+        // Err carries the correlation (id + token) the same as Ok, so a timeout is matched to its request.
+        let contract = Hash::of(b"c");
+        let r = EchoThenClose {
+            downstream: contract,
+        };
+        let resp = Response {
+            id: contract,
+            continuation_token: Bytes::from_static(b"tok-9"),
+            payload: Err(Error::Timeout),
+        };
+        // the response still correlates (token present on the error path).
+        assert_eq!(resp.continuation_token, Bytes::from_static(b"tok-9"));
+        let (_, outcome) = r.on_response(resp).await;
+        assert!(matches!(outcome, Outcome::Break { .. }));
+    }
+
+    /// The reducer is usable as a trait object (dyn Reducer) — the registry will hold backends this way.
+    #[tokio::test]
+    async fn reducer_is_dyn_safe() {
+        let r: Box<dyn Reducer> = Box::new(EchoThenClose {
+            downstream: Hash::of(b"c"),
+        });
+        let msg = Message {
+            id: Hash::of(b"c"),
+            payload: Bytes::from_static(b"x"),
+            from: Hash::of(b"p"),
+            continuation_token: Bytes::from_static(b"t"),
+        };
+        let (requests, _) = r.on_message(msg).await;
+        assert_eq!(requests.len(), 1);
+    }
+}


### PR DESCRIPTION
## What this is

**PR #7 of the platform rebuild** — the reducer interface (spec §3), the one interface every participant implements. A reducer receives an event, updates its state, and emits requests. This slice is the ABI: the message types + the two-entry-point trait. The registry and router that dispatch by contract-id come next.

## Two entry points

An event is one of two kinds, so the runtime calls the one that fits:
```rust
async fn on_response(&self, response: Response) -> (Vec<Request>, Outcome); // a reply to a request we made
async fn on_message(&self, message: Message) -> (Vec<Request>, Outcome);   // an effect performed on us
```
Both return the same product — the requests to perform and an `Outcome`. `on_message` carries `from` (the source reducer) so the reducer can authenticate/route on who sent it, which is why it's distinct from `on_response`.

## The ABI types (spec field names)

- `Request { id, payload, continuation_token, deadline: Option<Duration> }`
- `Response { id, continuation_token, payload: Result<Bytes, Error> }` — the correlation is on the `Response`, not inside the `Result`, so a **failure is matched to its request the same way a success is** (§4).
- `Message { id, payload, from, continuation_token }`
- `Error = Timeout | MissingHandler` (runtime failures; a handler's own *domain* error rides in `Ok(output)`)
- `Outcome = Continue | Break { schema: Hash, reason: Bytes }` — a reducer ends *itself* only via `Break`.

**Payloads/reasons are `Bytes`** (the value in canonical encoding), because the runtime routes on the `id` and never decodes a payload — a reducer decodes the structured value (and derefs the schema from the store by `id`) itself, lazily (§3 "identity by hash, schema by reference"). `id` is the contract-id throughout; `from` is the source reducer id.

The trait is `async_trait` + dyn-safe (the registry will hold reducers as trait objects); async because a reduce call may await its direct accesses (KV, the content store).

## Tests (4)

A small `EchoThenClose` reducer: `on_message` emits a token-correlated request and `Continue`s; `on_response` `Break`s with the answer as reason; a runtime failure still correlates by token; and it's usable as `Box<dyn Reducer>`.

## Verification

`cargo xtask dev-gate` green (pinned clippy + **40** crate tests). No new deps.

## Notes / next

- The reducer's **direct accesses** (KV/CAS/self-id during a call, §3) aren't threaded in yet — that context comes with the registry/router slice (the runtime provides it). This slice is the pure input → `(requests, outcome)` ABI.
- Next: the **registry** (`set-handler` by contract-id) + the **router** that delivers a message to its handler (§3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)