### PR TITLE
feat(cdz-platform): handler registry — set-handler + dispatch lookup (§3/§4)

### DIFF
--- a/implementation/seed/crates/cdz-platform/src/lib.rs
+++ b/implementation/seed/crates/cdz-platform/src/lib.rs
@@ -11,6 +11,7 @@ mod contract;
 mod hash;
 mod kv;
 mod reducer;
+mod registry;
 mod str;
 
 pub use blob_store::{BlobStore, InMemoryBlobStore};
@@ -18,6 +19,7 @@ pub use contract::Contract;
 pub use hash::{Hash, base64url};
 pub use kv::{InMemoryKvStore, KeyRange, KvKeyScan, KvScan, KvStore, prefix_range};
 pub use reducer::{Error, Message, Outcome, Reducer, Request, Response};
+pub use registry::HandlerRegistry;
 pub use str::Str;
 
 // Re-export the byte-buffer type the platform marshals through, so downstream code depends on the

--- a/implementation/seed/crates/cdz-platform/src/registry.rs
+++ b/implementation/seed/crates/cdz-platform/src/registry.rs
@@ -1,0 +1,208 @@
+//! The handler registry (`design/cadenza-platform.md` §3/§4).
+//!
+//! The kernel keeps one registry and does one thing with it: given a message's contract-id, find the
+//! reducer(s) that should receive it. That is the whole of dispatch — no enumerated effect kinds, no family
+//! strings, no per-effect branches; the runtime never recognizes a request by a name in its own code, only
+//! by the handler a contract-id resolves to (§4). This module is that registry as a plain data structure,
+//! separate from the router that will drive reducers with it.
+//!
+//! A contract's handler is not a single reducer but a **chain** — an ordered list of reducer identifiers
+//! (§3, "handlers chain"). A chain is a stack of interceptors: a rate limiter wrapping an HTTP handler, an
+//! authorizer wrapping a credential mint, a logger wrapping anything. A reducer identifier is a [`Hash`]
+//! (the reducer's id); the registry stores identifiers, not reducer instances — resolving an id to a live
+//! reducer is the router's job. The registry keeps the chain in the order it was given and interprets
+//! nothing about it: which end a request enters and how it bubbles is the router's semantics, not the
+//! registry's.
+//!
+//! Two operations back the built-in lifecycle effects (§7):
+//! - [`set_handler`](HandlerRegistry::set_handler) installs or **replaces** the whole chain for a contract
+//!   — how a session is upgraded over time (a handler added, a chain extended or reordered) without
+//!   respawning it. Setting an empty chain removes the registration, so the two states a contract can be in
+//!   are "has a non-empty chain" or "unregistered"; there is no registered-but-empty limbo.
+//! - [`contracts_for`](HandlerRegistry::contracts_for) is the reverse lookup behind `list-handlers`: the
+//!   contracts a given reducer appears in a chain for. It returns only contract-ids (the surface); the
+//!   chains themselves — the concrete reducer identifiers, the middleware behind a contract — are never
+//!   exposed by it, matching the spec's rule that a peer sees the interface a reducer has, not how it is
+//!   implemented.
+//!
+//! Dispatch is [`resolve`](HandlerRegistry::resolve): a contract-id maps to its chain, or to `None`, which
+//! the router turns into `Err(MissingHandler)` (§4). This is pure in-memory kernel state reached by direct
+//! call — not a swappable async backend like the key-value or content store — so the operations are plain
+//! synchronous methods.
+
+use crate::Hash;
+use std::collections::HashMap;
+
+/// The kernel's handler registry: contract-id -> the ordered chain of reducer identifiers that answers it
+/// (§3/§4). Internal kernel state with a single owner (the event loop), so its mutator takes `&mut self`.
+#[derive(Debug, Default, Clone)]
+pub struct HandlerRegistry {
+    /// contract-id -> chain of reducer ids. An entry is always a non-empty chain: `set_handler` removes the
+    /// key when handed an empty chain, so a present key means "this contract has a handler" with no empty
+    /// special case for `resolve` to consider.
+    chains: HashMap<Hash, Vec<Hash>>,
+}
+
+impl HandlerRegistry {
+    /// An empty registry — nothing is registered, so every contract resolves to `None`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Install or replace the handler `chain` for `contract`, returning the chain previously registered (if
+    /// any). This is the one registration primitive (§3/§4) and the `set-handler` lifecycle effect (§7): the
+    /// caller passes the whole chain and it replaces what was there — a handler added, a chain extended or
+    /// reordered — never a merge. Takes the chain by value because it is stored, not borrowed.
+    ///
+    /// An **empty** chain removes the registration (equivalent to "no handler"): after it, `contract`
+    /// resolves to `None` and no longer appears in any reducer's [`contracts_for`](Self::contracts_for). So
+    /// there is no registered-but-empty state — a contract either has a non-empty chain or is unregistered.
+    pub fn set_handler(&mut self, contract: Hash, chain: Vec<Hash>) -> Option<Vec<Hash>> {
+        if chain.is_empty() {
+            self.chains.remove(&contract)
+        } else {
+            self.chains.insert(contract, chain)
+        }
+    }
+
+    /// Resolve `contract` to its handler chain — the one dispatch lookup (§4). `Some(chain)` is the ordered
+    /// reducer identifiers to route through (always non-empty); `None` means no handler is registered, which
+    /// the router reports as `Err(MissingHandler)`. Borrows the stored chain; the router reads it to drive
+    /// the reducers it names.
+    #[must_use]
+    pub fn resolve(&self, contract: Hash) -> Option<&[Hash]> {
+        self.chains.get(&contract).map(Vec::as_slice)
+    }
+
+    /// The contracts `reducer` is part of a handler chain for — the reverse lookup behind the `list-handlers`
+    /// effect (§7). Returns just the contract-ids (the surface a peer is allowed to see), never the chains
+    /// they front. The result is sorted ascending so it is deterministic regardless of the registry's
+    /// internal (hash-map) order — replay and equality checks depend on that.
+    ///
+    /// A reducer that appears more than once across chains (or twice in one chain) yields each contract-id
+    /// once; the caller learns which contracts it handles, not how many times it is wired in.
+    #[must_use]
+    pub fn contracts_for(&self, reducer: Hash) -> Vec<Hash> {
+        let mut contracts: Vec<Hash> = self
+            .chains
+            .iter()
+            .filter(|(_, chain)| chain.contains(&reducer))
+            .map(|(contract, _)| *contract)
+            .collect();
+        contracts.sort_unstable();
+        contracts
+    }
+
+    /// The number of contracts with a registered handler.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.chains.len()
+    }
+
+    /// Whether no contract has a registered handler.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.chains.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HandlerRegistry;
+    use crate::Hash;
+
+    // Distinct hashes to stand in for contract-ids and reducer-ids; the registry only cares that they are
+    // distinct Hashes, not what they hash.
+    fn h(tag: &str) -> Hash {
+        Hash::of(tag.as_bytes())
+    }
+
+    #[test]
+    fn resolve_returns_the_chain_in_the_order_it_was_registered() {
+        let mut reg = HandlerRegistry::new();
+        let contract = h("http.get");
+        // a chain of three: authz wraps rate-limit wraps the edge handler, say.
+        let chain = vec![h("authz"), h("rate-limit"), h("http-edge")];
+        assert!(reg.set_handler(contract, chain.clone()).is_none());
+        // the registry preserves order exactly and interprets nothing about it.
+        assert_eq!(reg.resolve(contract), Some(chain.as_slice()));
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn an_unregistered_contract_resolves_to_none() {
+        let reg = HandlerRegistry::new();
+        assert_eq!(reg.resolve(h("nobody-answers")), None);
+        assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn set_handler_replaces_the_whole_chain_and_returns_the_old_one() {
+        let mut reg = HandlerRegistry::new();
+        let contract = h("mint-credential");
+        let first = vec![h("broker")];
+        let replacement = vec![h("authz"), h("broker")]; // upgraded: authz middleware prepended.
+        reg.set_handler(contract, first.clone());
+        // replacing returns exactly the prior chain, and the new one wins entirely (no merge).
+        assert_eq!(reg.set_handler(contract, replacement.clone()), Some(first));
+        assert_eq!(reg.resolve(contract), Some(replacement.as_slice()));
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn setting_an_empty_chain_removes_the_registration() {
+        let mut reg = HandlerRegistry::new();
+        let contract = h("timer.arm");
+        let chain = vec![h("timer-edge")];
+        reg.set_handler(contract, chain.clone());
+        // removing returns the prior chain and leaves the contract unregistered — no empty-chain limbo.
+        assert_eq!(reg.set_handler(contract, Vec::new()), Some(chain));
+        assert_eq!(reg.resolve(contract), None);
+        assert!(reg.is_empty());
+        // removing an already-absent contract is a no-op returning None.
+        assert_eq!(reg.set_handler(contract, Vec::new()), None);
+    }
+
+    #[test]
+    fn contracts_for_is_the_reverse_lookup_sorted_and_deduplicated() {
+        let mut reg = HandlerRegistry::new();
+        let authz = h("authz");
+        // authz is middleware in two different contracts' chains; the edge handlers differ.
+        reg.set_handler(h("http.get"), vec![authz, h("http-edge")]);
+        reg.set_handler(h("http.post"), vec![authz, h("http-edge")]);
+        reg.set_handler(h("clock.now"), vec![h("clock-edge")]); // authz not in this one.
+
+        let mut expected = vec![h("http.get"), h("http.post")];
+        expected.sort_unstable();
+        assert_eq!(reg.contracts_for(authz), expected);
+
+        // a reducer that appears twice in one chain still yields its contract once.
+        reg.set_handler(h("loop.contract"), vec![authz, h("mid"), authz]);
+        assert!(reg.contracts_for(authz).contains(&h("loop.contract")));
+        let n = reg
+            .contracts_for(authz)
+            .iter()
+            .filter(|c| **c == h("loop.contract"))
+            .count();
+        assert_eq!(
+            n, 1,
+            "each contract appears once regardless of wiring count"
+        );
+
+        // a reducer wired nowhere handles nothing.
+        assert_eq!(reg.contracts_for(h("orphan")), Vec::<Hash>::new());
+    }
+
+    #[test]
+    fn contracts_for_reflects_removal() {
+        let mut reg = HandlerRegistry::new();
+        let edge = h("edge");
+        reg.set_handler(h("a"), vec![edge]);
+        reg.set_handler(h("b"), vec![edge]);
+        assert_eq!(reg.contracts_for(edge).len(), 2);
+        // removing one contract's chain drops it from the reverse lookup.
+        reg.set_handler(h("a"), Vec::new());
+        assert_eq!(reg.contracts_for(edge), vec![h("b")]);
+    }
+}


### PR DESCRIPTION
## What

Adds `HandlerRegistry`, the kernel's one registration primitive and one dispatch lookup (§3/§4). Now unblocked by the merged reducer interface (#2913). Touches `registry.rs` (new) + a two-line `lib.rs` wire-up.

The kernel keeps one registry and does exactly one thing with it: resolve a message's contract-id to the reducer(s) that answer it — no enumerated effect kinds, no family strings, no name matching anywhere in the runtime (§4). A contract-id maps to an ordered **chain** of reducer identifiers (§3, "handlers chain") — a stack of interceptors (authz wrapping a handler, a rate limiter wrapping an edge, ...).

## API

- `set_handler(contract, chain) -> Option<Vec<Hash>>` — installs or **replaces** the whole chain (the `set-handler` lifecycle effect, §7): the caller passes the entire chain and it wins, never a merge; returns the prior chain. An **empty** chain removes the registration, so a contract is either handled by a non-empty chain or unregistered — no registered-but-empty limbo.
- `resolve(contract) -> Option<&[Hash]>` — the dispatch lookup: `Some(non-empty chain)` or `None`, which the router turns into `Err(MissingHandler)`.
- `contracts_for(reducer) -> Vec<Hash>` — the reverse lookup behind `list-handlers` (§7): returns only the contract surface (never the chains behind it), sorted ascending for determinism, each contract once regardless of wiring count.

## Scope / boundaries

The registry stores reducer identifiers (`Hash`), **not** reducer instances, and interprets **nothing** about chain order — which end a request enters and how it bubbles is the router's job (the next slice). It is internal kernel state reached by direct call (not a swappable async backend like the kv/content store), so the methods are plain synchronous `&self` / `&mut self`.

## Tests (behavioral)

Order preservation; unregistered → `None`; whole-chain replace returning the old chain; empty-chain removal (and no-op when absent); reverse lookup sorted + deduplicated; reverse lookup reflecting a removal.

## Gate

`cargo xtask dev-gate` green (test + clippy `--all-targets -D warnings` + fmt on `cdz-platform`); 44 lib tests pass.

## Roadmap position

hashing ✓ → Str ✓ → blob ✓ → KV ✓ → contracts v1 ✓ → contract-types v2 ✓ (#2914) → reducer interface ✓ (#2913) → **handler registry (this)** → router: resolve a message to live reducers and drive the chain / correlation (next).

Note: #2915 (kv root_hash) was closed per operator direction — punted until a snapshot consumer and the structurally-shared backend exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)